### PR TITLE
Fix Windows publish by limiting target frameworks when RID set

### DIFF
--- a/Password Phrase Producer/PasswordPhraseProducer.csproj
+++ b/Password Phrase Producer/PasswordPhraseProducer.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
-		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
+        <PropertyGroup>
+                <TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+                <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+                <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
 
 		<!-- Note for MacCatalyst:
@@ -37,7 +37,11 @@
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
 		<DefaultLanguage>EN</DefaultLanguage>
-	</PropertyGroup>
+        </PropertyGroup>
+
+        <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'win10-x64'">
+                <TargetFrameworks>net8.0-windows10.0.19041.0</TargetFrameworks>
+        </PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-android|AnyCPU'">
 	  <AndroidPackageFormat>apk</AndroidPackageFormat>


### PR DESCRIPTION
## Summary
- override the TargetFrameworks when the win10-x64 runtime identifier is supplied so the publish focuses on the Windows target

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6b5a130d8832a9eb73a6a55b97a70