### PR TITLE
Configure signed release artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ jobs:
   build:
     name: Build MAUI Packages
     runs-on: windows-latest
+    env:
+      ANDROID_KEYSTORE_PATH: ${{ runner.temp }}/android_signing.keystore
+      WINDOWS_CERTIFICATE_PATH: ${{ runner.temp }}/windows_signing_certificate.pfx
 
     steps:
       - name: Checkout repository
@@ -24,13 +27,52 @@ jobs:
         run: dotnet workload install maui --ignore-failed-sources
         shell: pwsh
 
+      - name: Compute version numbers
+        shell: pwsh
+        run: |
+          $majorMinor = "1.0"
+          $build = "${{ github.run_number }}"
+          $appVersion = "$majorMinor.$build"
+          $windowsVersion = "$majorMinor.$build.0"
+
+          "APP_MAJOR_MINOR=$majorMinor" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "APP_BUILD=$build" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "APP_VERSION=$appVersion" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "APP_VERSION_WINDOWS=$windowsVersion" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Restore dependencies
         run: dotnet restore "./Password Phrase Producer/Password Phrase Producer.sln"
         shell: pwsh
 
-      - name: Publish Android APK
-        run: dotnet publish "./Password Phrase Producer/Password Phrase Producer.sln" -c Release -f net8.0-android
+      - name: Restore Android signing keystore
+        if: ${{ secrets.ANDROID_KEYSTORE_BASE64 != '' }}
         shell: pwsh
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          [IO.File]::WriteAllBytes($env:ANDROID_KEYSTORE_PATH, [Convert]::FromBase64String($env:ANDROID_KEYSTORE_BASE64))
+
+      - name: Publish Android APK
+        shell: pwsh
+        env:
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          $signingArgs = ""
+          if (Test-Path $env:ANDROID_KEYSTORE_PATH) {
+            $signingArgs = "-p:AndroidSigningKeyStore=$env:ANDROID_KEYSTORE_PATH -p:AndroidSigningStorePass=$env:ANDROID_KEYSTORE_PASSWORD -p:AndroidSigningKeyAlias=$env:ANDROID_KEY_ALIAS -p:AndroidSigningKeyPass=$env:ANDROID_KEY_PASSWORD"
+          }
+          else {
+            Write-Host "::warning::Android keystore not provided. APK will be unsigned and cannot be installed or updated on devices."
+          }
+
+          dotnet publish "./Password Phrase Producer/Password Phrase Producer.sln" `
+            -c Release `
+            -f net8.0-android `
+            -p:ApplicationDisplayVersion=$env:APP_VERSION `
+            -p:ApplicationVersion=$env:APP_BUILD `
+            $signingArgs
 
       - name: Upload Android artifact
         uses: actions/upload-artifact@v4
@@ -39,13 +81,40 @@ jobs:
           path: |
             Password Phrase Producer\bin\Release\net8.0-android\publish\*.apk
 
-      - name: Publish Windows portable package
-        run: dotnet publish "./Password Phrase Producer/Password Phrase Producer.sln" -c Release -f net8.0-windows10.0.19041.0 -p:RuntimeIdentifier=win10-x64 -p:SelfContained=true -p:WindowsPackageType=None
+      - name: Restore Windows signing certificate
+        if: ${{ secrets.WINDOWS_PFX_BASE64 != '' }}
         shell: pwsh
+        env:
+          WINDOWS_PFX_BASE64: ${{ secrets.WINDOWS_PFX_BASE64 }}
+        run: |
+          [IO.File]::WriteAllBytes($env:WINDOWS_CERTIFICATE_PATH, [Convert]::FromBase64String($env:WINDOWS_PFX_BASE64))
+
+      - name: Publish Windows MSIX package
+        shell: pwsh
+        env:
+          WINDOWS_PFX_PASSWORD: ${{ secrets.WINDOWS_PFX_PASSWORD }}
+        run: |
+          $signingArgs = "-p:AppxPackageSigningEnabled=false"
+          if (Test-Path $env:WINDOWS_CERTIFICATE_PATH) {
+            $signingArgs = "-p:AppxPackageSigningEnabled=true -p:PackageCertificateFile=$env:WINDOWS_CERTIFICATE_PATH -p:PackageCertificatePassword=$env:WINDOWS_PFX_PASSWORD"
+          }
+          else {
+            Write-Host "::warning::Windows certificate not provided. MSIX package will be unsigned and require manual trust before installation or updates."
+          }
+
+          dotnet publish "./Password Phrase Producer/Password Phrase Producer.sln" `
+            -c Release `
+            -f net8.0-windows10.0.19041.0 `
+            -p:RuntimeIdentifier=win10-x64 `
+            -p:WindowsPackageType=msix `
+            -p:ApplicationDisplayVersion=$env:APP_VERSION `
+            -p:ApplicationVersion=$env:APP_BUILD `
+            -p:PackageVersion=$env:APP_VERSION_WINDOWS `
+            $signingArgs
 
       - name: Upload Windows artifact
         uses: actions/upload-artifact@v4
         with:
-          name: windows-portable
+          name: windows-msix
           path: |
-            Password Phrase Producer\bin\Release\net8.0-windows10.0.19041.0\win10-x64\publish\**
+            Password Phrase Producer\bin\Release\net8.0-windows10.0.19041.0\win10-x64\AppPackages\**\*.msix

--- a/Password Phrase Producer/Platforms/Windows/Package.appxmanifest
+++ b/Password Phrase Producer/Platforms/Windows/Package.appxmanifest
@@ -6,13 +6,13 @@
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   IgnorableNamespaces="uap rescap">
 
-  <Identity Name="maui-package-name-placeholder" Publisher="CN=User Name" Version="0.0.0.0" />
+  <Identity Name="com.passwordphraseproducer.app" Publisher="CN=Password Phrase Producer" Version="0.0.0.0" />
 
   <mp:PhoneIdentity PhoneProductId="68B752A1-6AB2-4F97-9D5C-F5F8EC14EC5D" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 
   <Properties>
     <DisplayName>$placeholder$</DisplayName>
-    <PublisherDisplayName>User Name</PublisherDisplayName>
+    <PublisherDisplayName>Password Phrase Producer</PublisherDisplayName>
     <Logo>$placeholder$.png</Logo>
   </Properties>
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # Password-Phrase-Producer
+
 A versatile tool for generating secure passwords with various customizable modes, including complex patterns based on user input.
+
+## Continuous delivery packages
+
+The GitHub Actions workflow now produces installable artifacts for Android and Windows that can be updated in-place as long as the signing material stays the same.
+
+### Android (APK)
+
+To receive an installable and updatable APK you must provide a persistent Android keystore through encrypted GitHub secrets:
+
+| Secret | Description |
+| --- | --- |
+| `ANDROID_KEYSTORE_BASE64` | Base64 encoded keystore file. |
+| `ANDROID_KEYSTORE_PASSWORD` | Password used to protect the keystore. |
+| `ANDROID_KEY_ALIAS` | Alias of the key used for signing. |
+| `ANDROID_KEY_PASSWORD` | Password for the signing key. |
+
+The workflow restores the keystore, signs the APK during `dotnet publish`, and increments both the display and internal version numbers so that newer builds can be installed as updates on devices.
+
+### Windows (MSIX)
+
+Windows artifacts are now delivered as a single MSIX package that supports updating without manual uninstalling. Provide a code-signing certificate by configuring the following secrets:
+
+| Secret | Description |
+| --- | --- |
+| `WINDOWS_PFX_BASE64` | Base64 encoded `.pfx` certificate used to sign the MSIX. Ensure that the subject matches `CN=Password Phrase Producer` so that it aligns with the package manifest. |
+| `WINDOWS_PFX_PASSWORD` | Password that protects the certificate. |
+
+If the certificate is absent the workflow still produces an unsigned MSIX, which Windows will require you to trust manually before installing.
+
+### Versioning
+
+Both Android and Windows builds derive their version numbers from the GitHub Actions run number (`1.0.<run_number>`), allowing each build to install as an update without removing the previous version.


### PR DESCRIPTION
## Summary
- add signing support and version management to the Android build so APKs can be installed as updates
- switch the Windows build to produce a single MSIX package and support certificate-based signing
- document the required secrets and versioning behaviour in the README and align the package manifest identity

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e8158c8580832a927608694fb311d8