### PR TITLE
Fix GitHub Actions contexts for signing assets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,11 +10,28 @@ jobs:
   build:
     name: Build MAUI Packages
     runs-on: windows-latest
-    env:
-      ANDROID_KEYSTORE_PATH: ${{ runner.temp }}/android_signing.keystore
-      WINDOWS_CERTIFICATE_PATH: ${{ runner.temp }}/windows_signing_certificate.pfx
-
     steps:
+      - name: Set signing file paths
+        shell: pwsh
+        run: |
+          $androidPath = [System.IO.Path]::Combine($env:RUNNER_TEMP, 'android_signing.keystore')
+          $windowsPath = [System.IO.Path]::Combine($env:RUNNER_TEMP, 'windows_signing_certificate.pfx')
+
+          "ANDROID_KEYSTORE_PATH=$androidPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "WINDOWS_CERTIFICATE_PATH=$windowsPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Detect available signing assets
+        shell: pwsh
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          WINDOWS_PFX_BASE64: ${{ secrets.WINDOWS_PFX_BASE64 }}
+        run: |
+          $hasAndroidKeystore = -not [string]::IsNullOrEmpty($env:ANDROID_KEYSTORE_BASE64)
+          $hasWindowsCertificate = -not [string]::IsNullOrEmpty($env:WINDOWS_PFX_BASE64)
+
+          "HAS_ANDROID_KEYSTORE=$($hasAndroidKeystore.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "HAS_WINDOWS_CERTIFICATE=$($hasWindowsCertificate.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -45,7 +62,7 @@ jobs:
         shell: pwsh
 
       - name: Restore Android signing keystore
-        if: ${{ secrets.ANDROID_KEYSTORE_BASE64 != '' }}
+        if: ${{ env.HAS_ANDROID_KEYSTORE == 'true' }}
         shell: pwsh
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
@@ -82,7 +99,7 @@ jobs:
             Password Phrase Producer\bin\Release\net8.0-android\publish\*.apk
 
       - name: Restore Windows signing certificate
-        if: ${{ secrets.WINDOWS_PFX_BASE64 != '' }}
+        if: ${{ env.HAS_WINDOWS_CERTIFICATE == 'true' }}
         shell: pwsh
         env:
           WINDOWS_PFX_BASE64: ${{ secrets.WINDOWS_PFX_BASE64 }}


### PR DESCRIPTION
## Summary
- initialize signing file paths on the runner using PowerShell instead of the runner context
- gate signing steps using environment flags derived from the available secrets so the workflow parses correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e8200e7290832aa3c5e8a349786d8e