### PR TITLE
Fix MSIX package type value in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,7 +123,7 @@ jobs:
             -c Release `
             -f net8.0-windows10.0.19041.0 `
             -p:RuntimeIdentifier=win10-x64 `
-            -p:WindowsPackageType=msix `
+            -p:WindowsPackageType=MSIX `
             -p:ApplicationDisplayVersion=$env:APP_VERSION `
             -p:ApplicationVersion=$env:APP_BUILD `
             -p:PackageVersion=$env:APP_VERSION_WINDOWS `


### PR DESCRIPTION
## Summary
- correct the Windows package type argument in the workflow to use the valid `MSIX` casing for .NET publish

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68e9615374f4832ab7884233ae908d98