### PR TITLE
Restrict Android artifact upload to signed APK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
         with:
           name: android-apk
           path: |
-            Password Phrase Producer\bin\Release\net8.0-android\publish\*.apk
+            Password Phrase Producer\bin\Release\net8.0-android\publish\*-Signed.apk
 
       - name: Restore Windows signing certificate
         if: ${{ env.HAS_WINDOWS_CERTIFICATE == 'true' }}


### PR DESCRIPTION
## Summary
- limit the Android artifact upload step to files ending with `-Signed.apk`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e9725565ec832a83ad42620d878a1e