### PR TITLE
Refactor main page to MVVM and update styling

### DIFF
--- a/Password Phrase Producer/MainPage.xaml
+++ b/Password Phrase Producer/MainPage.xaml
@@ -2,96 +2,47 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Password_Phrase_Producer.MainPage"
-             >
+             BackgroundColor="#1E1E1E">
 
-    
-
-    <VerticalStackLayout x:Name="Content" Padding="20" BackgroundColor="#1E1E1E">
-
+    <Grid RowDefinitions="Auto,*" Padding="20" RowSpacing="20">
         <Button Text="Menu"
-                BackgroundColor="White"
-                TextColor="Black"
-                CornerRadius="25"
-                FontSize="18"
-                HeightRequest="50"
-                Margin="5"
-                HorizontalOptions="FillAndExpand"
-                Clicked="OnMenuClicked"/>
+                Style="{StaticResource PrimaryActionButtonStyle}"
+                Command="{Binding ShowMenuCommand}"/>
 
+        <VerticalStackLayout Grid.Row="1" Spacing="20">
+            <Label Text="Wähle den Modus aus:"
+                   FontSize="24"
+                   HorizontalOptions="Center"
+                   TextColor="White"
+                   IsVisible="{Binding IsMenuVisible}"/>
 
-        <!-- Auswahlmenü -->
-        <Label Text="Wähle den Modus aus:"
-               TextColor="White"
-               FontSize="24"
-               HorizontalOptions="Center"
-               Margin="10"
-               x:Name="L1"/>
+            <CollectionView x:Name="ModeCollection"
+                            ItemsSource="{Binding ModeOptions}"
+                            SelectionMode="Single"
+                            IsVisible="{Binding IsMenuVisible}"
+                            SelectedItem="{Binding SelectedMode}"
+                            SelectionChangedCommand="{Binding SelectModeCommand}"
+                            SelectionChangedCommandParameter="{Binding Source={x:Reference ModeCollection}, Path=SelectedItem}">
+                <CollectionView.ItemsLayout>
+                    <GridItemsLayout Orientation="Vertical" Span="1" />
+                </CollectionView.ItemsLayout>
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <Frame Padding="15" Margin="0,0,0,15" HasShadow="False" BackgroundColor="#2A2A2A" CornerRadius="15">
+                            <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto" ColumnSpacing="12">
+                                <Label Text="{Binding Icon}" FontSize="24" VerticalOptions="Center" IsVisible="{Binding Icon}"/>
+                                <Label Text="{Binding Title}" Grid.Column="1" FontSize="20" FontAttributes="Bold"/>
+                                <Label Text="{Binding Description}" Grid.ColumnSpan="2" Grid.Row="1" FontSize="14" Opacity="0.8"/>
+                            </Grid>
+                        </Frame>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
 
-        <Button Text="1 Word Password"
-        BackgroundColor="#4CAF50"
-        TextColor="White"
-        CornerRadius="25"
-        FontSize="18"
-        HeightRequest="50"
-        Margin="5"
-        HorizontalOptions="FillAndExpand"
-        Clicked="OneWordPasswordClicked"
-        x:Name="B6"/>
-        
-        <Button Text="Alternate Words"
-                BackgroundColor="#4CAF50"
-                TextColor="White"
-                CornerRadius="25"
-                FontSize="18"
-                HeightRequest="50"
-                Margin="5"
-                HorizontalOptions="FillAndExpand"
-                Clicked="OnAlternateWordsClicked"
-                x:Name="B1"/>
-
-        <Button Text="TBV1 With Errors"
-                BackgroundColor="#4CAF50"
-                TextColor="White"
-                CornerRadius="25"
-                FontSize="18"
-                HeightRequest="50"
-                Margin="5"
-                HorizontalOptions="FillAndExpand"
-                Clicked="OnTBV1WithErrorsClicked"
-                x:Name="B2"/>
-
-        <Button Text="TBV1"
-                BackgroundColor="#4CAF50"
-                TextColor="White"
-                CornerRadius="25"
-                FontSize="18"
-                HeightRequest="50"
-                Margin="5"
-                HorizontalOptions="FillAndExpand"
-                Clicked="OnTBV1Clicked"
-                x:Name="B3"/>
-
-        <Button Text="TBV2"
-                BackgroundColor="#4CAF50"
-                TextColor="White"
-                CornerRadius="25"
-                FontSize="18"
-                HeightRequest="50"
-                Margin="5"
-                HorizontalOptions="FillAndExpand"
-                Clicked="OnTBV2Clicked"
-                x:Name="B4"/>
-
-        <Button Text="TBV3"
-                BackgroundColor="#4CAF50"
-                TextColor="White"
-                CornerRadius="25"
-                FontSize="18"
-                HeightRequest="50"
-                Margin="5"
-                HorizontalOptions="FillAndExpand"
-                Clicked="OnTBV3Clicked"
-                x:Name="B5"/>
-    </VerticalStackLayout>
-
+            <ContentPresenter Content="{Binding CurrentContent}"
+                              IsVisible="{Binding IsContentVisible}"
+                              HorizontalOptions="FillAndExpand"
+                              VerticalOptions="FillAndExpand"/>
+        </VerticalStackLayout>
+    </Grid>
 </ContentPage>

--- a/Password Phrase Producer/MainPage.xaml.cs
+++ b/Password Phrase Producer/MainPage.xaml.cs
@@ -1,108 +1,13 @@
-﻿using Password_Phrase_Producer.PasswordGenerationTechniques.ConcatenationTechniques;
-using Password_Phrase_Producer.PasswordGenerationTechniques.HashBasedTechniques;
-using Password_Phrase_Producer.Windows.PasswordGenerationWindows;
-using PasswordPhraseProducer.PasswordGenerationTechniques.TbvTechniques;
+using Password_Phrase_Producer.ViewModels;
 
 namespace Password_Phrase_Producer
 {
     public partial class MainPage : ContentPage
     {
-        
-
-        TbvUiPage TbvUiPage;
-        ConcatenationTechniquesUiPage ConcatenationTechniquesUiPage;
-        HachBasedTechniquesUiPage HachBasedTechniquesUiPage;
         public MainPage()
         {
             InitializeComponent();
-        }
-
-        private void OnMenuClicked(object sender, EventArgs e)
-        {
-            ShowMenuButtons();
-            if (this.TbvUiPage != null)
-            {
-                Content.Remove(this.TbvUiPage);
-                this.TbvUiPage = null;
-            }
-            if(this.ConcatenationTechniquesUiPage != null)
-            {
-                Content.Remove(this.ConcatenationTechniquesUiPage);
-                this.ConcatenationTechniquesUiPage = null;
-            }
-
-            if (this.HachBasedTechniquesUiPage != null)
-            {
-                Content.Remove(this.HachBasedTechniquesUiPage);
-                this.HachBasedTechniquesUiPage = null;
-            }
-        }
-
-        private void OnAlternateWordsClicked(object sender, EventArgs e)
-        {
-            HideMenuButtons();
-            this.ConcatenationTechniquesUiPage = new ConcatenationTechniquesUiPage(new AlternatingUpDownChaining());
-            Content.Add(this.ConcatenationTechniquesUiPage);
-        }
-
-        private void OneWordPasswordClicked(object sender, EventArgs e)
-        {
-            HideMenuButtons();
-            this.HachBasedTechniquesUiPage = new HachBasedTechniquesUiPage(new DeterministicHashPasswordGenerator());
-            Content.Add(this.HachBasedTechniquesUiPage);
-        }
-
-
-
-        private void OnTBV1WithErrorsClicked(object sender, EventArgs e)
-        {
-            HideMenuButtons();
-            this.TbvUiPage = new TbvUiPage(new TBV1WithErrors());
-            Content.Add(this.TbvUiPage);          
-        }
-
-        private void OnTBV1Clicked(object sender, EventArgs e)
-        {
-            HideMenuButtons();
-            this.TbvUiPage = new TbvUiPage(new TBV1());
-            Content.Add(this.TbvUiPage);
-        }
-
-        private void OnTBV2Clicked(object sender, EventArgs e)
-        {
-            HideMenuButtons();
-            this.TbvUiPage = new TbvUiPage(new TBV2());
-            Content.Add(this.TbvUiPage);
-        }
-
-        private void OnTBV3Clicked(object sender, EventArgs e)
-        {
-            HideMenuButtons();
-            this.TbvUiPage = new TbvUiPage(new TBV3());
-            Content.Add(this.TbvUiPage);
-        }
-
-        public void HideMenuButtons()
-        {
-            L1.IsVisible = false;
-            B1.IsVisible = false;
-            B2.IsVisible = false;
-            B3.IsVisible = false;
-            B4.IsVisible = false;
-            B5.IsVisible = false;
-            B6.IsVisible = false;
-        }
-
-        public void ShowMenuButtons()
-        {
-            L1.IsVisible = true;
-            B1.IsVisible = true;
-            B2.IsVisible = true;
-            B3.IsVisible = true;
-            B4.IsVisible = true;
-            B5.IsVisible = true;
-            B6.IsVisible = true;
+            BindingContext = new MainPageViewModel();
         }
     }
-
 }

--- a/Password Phrase Producer/Resources/Styles/Styles.xaml
+++ b/Password Phrase Producer/Resources/Styles/Styles.xaml
@@ -424,4 +424,27 @@
         <Setter Property="SelectedTabColor" Value="{AppThemeBinding Light={StaticResource Gray950}, Dark={StaticResource Gray200}}" />
     </Style>
 
+    <Style TargetType="Button" x:Key="PrimaryActionButtonStyle">
+        <Setter Property="TextColor" Value="White" />
+        <Setter Property="BackgroundColor" Value="#4CAF50" />
+        <Setter Property="CornerRadius" Value="25" />
+        <Setter Property="FontSize" Value="18" />
+        <Setter Property="HeightRequest" Value="50" />
+        <Setter Property="Margin" Value="5" />
+        <Setter Property="HorizontalOptions" Value="FillAndExpand" />
+        <Setter Property="VerticalOptions" Value="Center" />
+        <Setter Property="Padding" Value="20,10" />
+    </Style>
+
+    <Style TargetType="Entry" x:Key="DarkEntryStyle">
+        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
+        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light=#F2F2F2, Dark=#333333}" />
+        <Setter Property="PlaceholderColor" Value="{AppThemeBinding Light=#666666, Dark=#AAAAAA}" />
+        <Setter Property="FontSize" Value="18" />
+        <Setter Property="Margin" Value="5" />
+        <Setter Property="HorizontalOptions" Value="FillAndExpand" />
+        <Setter Property="VerticalOptions" Value="Center" />
+        <Setter Property="HeightRequest" Value="50" />
+    </Style>
+
 </ResourceDictionary>

--- a/Password Phrase Producer/ViewModels/MainPageViewModel.cs
+++ b/Password Phrase Producer/ViewModels/MainPageViewModel.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+using Microsoft.Maui.Controls;
+using Password_Phrase_Producer.PasswordGenerationTechniques.ConcatenationTechniques;
+using Password_Phrase_Producer.PasswordGenerationTechniques.HashBasedTechniques;
+using Password_Phrase_Producer.Windows.PasswordGenerationWindows;
+using PasswordPhraseProducer.PasswordGenerationTechniques.TbvTechniques;
+
+namespace Password_Phrase_Producer.ViewModels;
+
+public class MainPageViewModel : INotifyPropertyChanged
+{
+    private PasswordModeOption? selectedMode;
+    private View? currentContent;
+    private bool isMenuVisible = true;
+
+    public ObservableCollection<PasswordModeOption> ModeOptions { get; }
+
+    public ICommand ShowMenuCommand { get; }
+    public ICommand SelectModeCommand { get; }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public MainPageViewModel()
+    {
+        ModeOptions = new ObservableCollection<PasswordModeOption>
+        {
+            new(
+                "1 Word Password",
+                "Deterministic hash-based password generation",
+                () => new HachBasedTechniquesUiPage(new DeterministicHashPasswordGenerator()),
+                "🔐"),
+            new(
+                "Alternate Words",
+                "Combine alternating phrases into a passphrase",
+                () => new ConcatenationTechniquesUiPage(new AlternatingUpDownChaining()),
+                "🧩"),
+            new(
+                "TBV1 With Errors",
+                "Three block verification with error handling",
+                () => new TbvUiPage(new TBV1WithErrors()),
+                "🛡️"),
+            new(
+                "TBV1",
+                "Classic three block verification",
+                () => new TbvUiPage(new TBV1()),
+                "🧱"),
+            new(
+                "TBV2",
+                "Enhanced verification variant",
+                () => new TbvUiPage(new TBV2()),
+                "⚙️"),
+            new(
+                "TBV3",
+                "Advanced verification with extra checks",
+                () => new TbvUiPage(new TBV3()),
+                "🚀")
+        };
+
+        ShowMenuCommand = new Command(ShowMenu);
+        SelectModeCommand = new Command<PasswordModeOption>(SelectMode);
+    }
+
+    public PasswordModeOption? SelectedMode
+    {
+        get => selectedMode;
+        set
+        {
+            if (selectedMode == value)
+            {
+                return;
+            }
+
+            selectedMode = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public View? CurrentContent
+    {
+        get => currentContent;
+        private set
+        {
+            if (currentContent == value)
+            {
+                return;
+            }
+
+            currentContent = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(IsContentVisible));
+        }
+    }
+
+    public bool IsMenuVisible
+    {
+        get => isMenuVisible;
+        private set
+        {
+            if (isMenuVisible == value)
+            {
+                return;
+            }
+
+            isMenuVisible = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(IsContentVisible));
+        }
+    }
+
+    public bool IsContentVisible => !IsMenuVisible && CurrentContent is not null;
+
+    private void ShowMenu()
+    {
+        CurrentContent = null;
+        SelectedMode = null;
+        IsMenuVisible = true;
+    }
+
+    private void SelectMode(PasswordModeOption? option)
+    {
+        if (option is null)
+        {
+            return;
+        }
+
+        SelectedMode = option;
+        CurrentContent = option.CreateView();
+        IsMenuVisible = false;
+    }
+
+    protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}
+
+public class PasswordModeOption
+{
+    public PasswordModeOption(string title, string description, Func<ContentView> contentFactory, string? icon = null)
+    {
+        Title = title;
+        Description = description;
+        ContentFactory = contentFactory;
+        Icon = icon;
+    }
+
+    public string Title { get; }
+
+    public string Description { get; }
+
+    public string? Icon { get; }
+
+    private Func<ContentView> ContentFactory { get; }
+
+    public ContentView CreateView() => ContentFactory();
+}

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/ConcatenationTechniquesUiPage.xaml
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/ConcatenationTechniquesUiPage.xaml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Password_Phrase_Producer.Windows.PasswordGenerationWindows.ConcatenationTechniquesUiPage">
+    <VerticalStackLayout Padding="20" Spacing="15">
+        <ScrollView HeightRequest="250">
+            <VerticalStackLayout x:Name="phraseContainer" Spacing="10" />
+        </ScrollView>
+
+        <Button Text="New Entry"
+                Style="{StaticResource PrimaryActionButtonStyle}"
+                Clicked="OnAddNewTextField" />
+
+        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
+            <Entry x:Name="resultEntry"
+                   Placeholder="Result"
+                   Style="{StaticResource DarkEntryStyle}"
+                   IsReadOnly="True"
+                   Margin="0,5,0,5" />
+            <Button Grid.Column="1"
+                    Text="Copy"
+                    Style="{StaticResource PrimaryActionButtonStyle}"
+                    Clicked="OnCopyClicked"
+                    HorizontalOptions="End" />
+        </Grid>
+
+        <Button Text="Create"
+                Style="{StaticResource PrimaryActionButtonStyle}"
+                Clicked="OnCreateClicked" />
+    </VerticalStackLayout>
+</ContentView>

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/ConcatenationTechniquesUiPage.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/ConcatenationTechniquesUiPage.xaml.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Maui.Controls;
+using Password_Phrase_Producer.PasswordGenerationTechniques.ConcatenationTechniques;
+
+namespace Password_Phrase_Producer.Windows.PasswordGenerationWindows;
+
+public partial class ConcatenationTechniquesUiPage : ContentView
+{
+    private readonly IConcatenationTechnique concatenationTechnique;
+    private const int InitialEntryCount = 4;
+
+    public ConcatenationTechniquesUiPage(IConcatenationTechnique concatenationTechnique)
+    {
+        InitializeComponent();
+        this.concatenationTechnique = concatenationTechnique;
+
+        for (int i = 0; i < InitialEntryCount; i++)
+        {
+            phraseContainer.Children.Add(CreatePhraseEntry());
+        }
+    }
+
+    private void OnAddNewTextField(object? sender, EventArgs e)
+    {
+        phraseContainer.Children.Add(CreatePhraseEntry());
+    }
+
+    private async void OnCopyClicked(object sender, EventArgs e)
+    {
+        if (!string.IsNullOrWhiteSpace(resultEntry.Text))
+        {
+            await Clipboard.Default.SetTextAsync(resultEntry.Text);
+            await Application.Current.MainPage.DisplayAlert("Info", "Password copied to clipboard", "OK");
+        }
+    }
+
+    private void OnCreateClicked(object sender, EventArgs e)
+    {
+        var phrases = new List<string>();
+
+        foreach (var child in phraseContainer.Children)
+        {
+            if (child is Entry entry && !string.IsNullOrWhiteSpace(entry.Text))
+            {
+                phrases.Add(entry.Text);
+            }
+        }
+
+        var result = concatenationTechnique.EncryptPassword(phrases);
+        resultEntry.Text = result;
+    }
+
+    private View CreatePhraseEntry()
+    {
+        var entry = new Entry
+        {
+            Placeholder = "Phrase"
+        };
+
+        if (Application.Current?.Resources.TryGetValue("DarkEntryStyle", out var styleObj) == true && styleObj is Style style)
+        {
+            entry.Style = style;
+        }
+
+        return entry;
+    }
+}

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/HachBasedTechniquesUiPage.xaml
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/HachBasedTechniquesUiPage.xaml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Password_Phrase_Producer.Windows.PasswordGenerationWindows.HachBasedTechniquesUiPage">
+    <VerticalStackLayout Padding="20" Spacing="15">
+        <Entry x:Name="passwordEntry"
+               Placeholder="Password phrase"
+               Style="{StaticResource DarkEntryStyle}" />
+
+        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
+            <Entry x:Name="resultEntry"
+                   Placeholder="Result"
+                   Style="{StaticResource DarkEntryStyle}"
+                   IsReadOnly="True"
+                   Margin="0,5,0,5" />
+            <Button Grid.Column="1"
+                    Text="Copy"
+                    Style="{StaticResource PrimaryActionButtonStyle}"
+                    Clicked="OnCopyClicked"
+                    HorizontalOptions="End" />
+        </Grid>
+
+        <Button Text="Create"
+                Style="{StaticResource PrimaryActionButtonStyle}"
+                Clicked="OnCreateClicked" />
+    </VerticalStackLayout>
+</ContentView>

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/HachBasedTechniquesUiPage.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/HachBasedTechniquesUiPage.xaml.cs
@@ -1,0 +1,40 @@
+using System;
+using Microsoft.Maui.Controls;
+using Password_Phrase_Producer.PasswordGenerationTechniques.HashBasedTechniques;
+
+namespace Password_Phrase_Producer.Windows.PasswordGenerationWindows;
+
+internal partial class HachBasedTechniquesUiPage : ContentView
+{
+    private readonly IHashBasedTechniques hashBasedTechnique;
+
+    public HachBasedTechniquesUiPage(IHashBasedTechniques hashBasedTechnique)
+    {
+        InitializeComponent();
+        this.hashBasedTechnique = hashBasedTechnique;
+    }
+
+    private void OnCreateClicked(object sender, EventArgs e)
+    {
+        string password = passwordEntry.Text ?? string.Empty;
+
+        if (!string.IsNullOrWhiteSpace(password))
+        {
+            string result = hashBasedTechnique.GeneratePassword(password);
+            resultEntry.Text = result;
+        }
+        else
+        {
+            resultEntry.Text = string.Empty;
+        }
+    }
+
+    private async void OnCopyClicked(object sender, EventArgs e)
+    {
+        if (!string.IsNullOrWhiteSpace(resultEntry.Text))
+        {
+            await Clipboard.Default.SetTextAsync(resultEntry.Text);
+            await Application.Current.MainPage.DisplayAlert("Info", "Password copied to clipboard", "OK");
+        }
+    }
+}

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/TbvUiPage.xaml
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/TbvUiPage.xaml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Password_Phrase_Producer.Windows.PasswordGenerationWindows.TbvUiPage">
+    <VerticalStackLayout Padding="20" Spacing="15">
+        <Entry x:Name="passwordEntry"
+               Placeholder="Password phrase"
+               Style="{StaticResource DarkEntryStyle}" />
+        <Entry x:Name="code1Entry"
+               Placeholder="Code 1"
+               Keyboard="Numeric"
+               Style="{StaticResource DarkEntryStyle}" />
+        <Entry x:Name="code2Entry"
+               Placeholder="Code 2"
+               Keyboard="Numeric"
+               Style="{StaticResource DarkEntryStyle}" />
+        <Entry x:Name="code3Entry"
+               Placeholder="Code 3"
+               Keyboard="Numeric"
+               Style="{StaticResource DarkEntryStyle}" />
+        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
+            <Entry x:Name="resultEntry"
+                   Placeholder="Result"
+                   Style="{StaticResource DarkEntryStyle}"
+                   IsReadOnly="True"
+                   Margin="0,5,0,5" />
+            <Button Grid.Column="1"
+                    Text="Copy"
+                    Style="{StaticResource PrimaryActionButtonStyle}"
+                    Clicked="OnCopyClicked"
+                    HorizontalOptions="End" />
+        </Grid>
+        <Button Text="Create"
+                Style="{StaticResource PrimaryActionButtonStyle}"
+                Clicked="OnCreateClicked" />
+    </VerticalStackLayout>
+</ContentView>

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/TbvUiPage.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/TbvUiPage.xaml.cs
@@ -1,0 +1,50 @@
+using System;
+using Microsoft.Maui.Controls;
+using Password_Phrase_Producer.PasswordGenerationTechniques.TbvTechniques;
+
+namespace Password_Phrase_Producer.Windows.PasswordGenerationWindows;
+
+public partial class TbvUiPage : ContentView
+{
+    private readonly Itbv tbv;
+
+    public TbvUiPage(Itbv itbv)
+    {
+        InitializeComponent();
+        tbv = itbv;
+    }
+
+    private void OnCreateClicked(object sender, EventArgs e)
+    {
+        var password = passwordEntry.Text;
+
+        if (string.IsNullOrWhiteSpace(password))
+        {
+            resultEntry.Text = string.Empty;
+            return;
+        }
+
+        bool c1 = int.TryParse(code1Entry.Text, out var code1);
+        bool c2 = int.TryParse(code2Entry.Text, out var code2);
+        bool c3 = int.TryParse(code3Entry.Text, out var code3);
+
+        if (c1 && c2 && c3)
+        {
+            string result = tbv.GeneratePassword(password, code1, code2, code3);
+            resultEntry.Text = result;
+        }
+        else
+        {
+            resultEntry.Text = string.Empty;
+        }
+    }
+
+    private async void OnCopyClicked(object sender, EventArgs e)
+    {
+        if (!string.IsNullOrWhiteSpace(resultEntry.Text))
+        {
+            await Clipboard.Default.SetTextAsync(resultEntry.Text);
+            await Application.Current.MainPage.DisplayAlert("Info", "Password copied to clipboard", "OK");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- bind MainPage to a new MainPageViewModel that exposes selectable password mode options and renders their views dynamically
- introduce shared styles for primary action buttons and dark entries and apply them across the pages
- convert the technique content views to XAML, make result fields read-only, and add explicit copy actions

## Testing
- dotnet build *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e99e45cc60832a9220ceddfa7f5213