### PR TITLE
Fix accessibility of hash technique page partial class

### DIFF
--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/HachBasedTechniquesUiPage.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/HachBasedTechniquesUiPage.xaml.cs
@@ -4,7 +4,7 @@ using Password_Phrase_Producer.PasswordGenerationTechniques.HashBasedTechniques;
 
 namespace Password_Phrase_Producer.Windows.PasswordGenerationWindows;
 
-internal partial class HachBasedTechniquesUiPage : ContentView
+public partial class HachBasedTechniquesUiPage : ContentView
 {
     private readonly IHashBasedTechniques hashBasedTechnique;
 


### PR DESCRIPTION
## Summary
- update the code-behind for the hash-based techniques UI page to be public so it matches the generated XAML partial class

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ea986233b0832aaf0bad36bcf942e0