### PR TITLE
Fix MAUI build errors and clean warnings

### DIFF
--- a/Password Phrase Producer/AppShell.xaml
+++ b/Password Phrase Producer/AppShell.xaml
@@ -5,8 +5,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:local="clr-namespace:Password_Phrase_Producer"
     Title="Password Phrase Producer"
-    FlyoutBackgroundColor="#1A1A1A"
-    FlyoutForegroundColor="White">
+    FlyoutBackgroundColor="#1A1A1A">
 
     <FlyoutItem Title="Startseite"
                 Route="home"

--- a/Password Phrase Producer/PasswordGenerationTechniques/TbvTechniques/TBV1.cs
+++ b/Password Phrase Producer/PasswordGenerationTechniques/TbvTechniques/TBV1.cs
@@ -154,7 +154,7 @@ namespace PasswordPhraseProducer.PasswordGenerationTechniques.TbvTechniques
         };
 
         private TBVHelper helper = new TBVHelper();
-        private string resultWithoutSpaces;
+        private string resultWithoutSpaces = string.Empty;
         public static bool IsCancelled { get; set; } = false;
 
 

--- a/Password Phrase Producer/PasswordGenerationTechniques/TbvTechniques/TBVHelper.cs
+++ b/Password Phrase Producer/PasswordGenerationTechniques/TbvTechniques/TBVHelper.cs
@@ -26,7 +26,7 @@ namespace PasswordPhraseProducer.PasswordGenerationTechniques.TbvTechniques
         {
             var result = new List<char>();
             var charactersList = inputString.ToList();
-            bool firstCode = true, secondCode = false, thirdCode = false;
+            bool firstCode = true, secondCode = false;
 
             while (charactersList.Count > 0)
             {
@@ -39,12 +39,13 @@ namespace PasswordPhraseProducer.PasswordGenerationTechniques.TbvTechniques
                 else if (secondCode)
                 {
                     index = ValidateIndex(code2, charactersList.Count);
-                    secondCode = false; thirdCode = true;
+                    secondCode = false;
                 }
                 else
                 {
                     index = ValidateIndex(code3, charactersList.Count);
-                    thirdCode = false; firstCode = true;
+                    firstCode = true;
+                    secondCode = false;
                 }
 
                 result.Add(charactersList[index]);

--- a/Password Phrase Producer/StartPage.xaml
+++ b/Password Phrase Producer/StartPage.xaml
@@ -37,7 +37,7 @@
             <CollectionView ItemsSource="{Binding ModeOptions}"
                             SelectionMode="None">
                 <CollectionView.ItemsLayout>
-                    <VerticalGridItemsLayout Span="1" ItemSpacing="18"/>
+                    <GridItemsLayout Orientation="Vertical" Span="1" ItemSpacing="18"/>
                 </CollectionView.ItemsLayout>
                 <CollectionView.ItemTemplate>
                     <DataTemplate x:DataType="local:PasswordModeOption">

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/ConcatenationTechniquesUiPage.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/ConcatenationTechniquesUiPage.xaml.cs
@@ -28,10 +28,14 @@ public partial class ConcatenationTechniquesUiPage : ContentView
 
     private async void OnCopyClicked(object sender, EventArgs e)
     {
-        if (!string.IsNullOrWhiteSpace(resultEntry.Text))
+        if (!string.IsNullOrWhiteSpace(resultEntry?.Text))
         {
-            await Clipboard.Default.SetTextAsync(resultEntry.Text);
-            await Application.Current.MainPage.DisplayAlert("Info", "Password copied to clipboard", "OK");
+            await Clipboard.Default.SetTextAsync(resultEntry!.Text);
+            var mainPage = Application.Current?.MainPage;
+            if (mainPage is not null)
+            {
+                await mainPage.DisplayAlert("Info", "Password copied to clipboard", "OK");
+            }
         }
     }
 
@@ -48,7 +52,10 @@ public partial class ConcatenationTechniquesUiPage : ContentView
         }
 
         var result = concatenationTechnique.EncryptPassword(phrases);
-        resultEntry.Text = result;
+        if (resultEntry is not null)
+        {
+            resultEntry.Text = result;
+        }
     }
 
     private View CreatePhraseEntry()

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/HachBasedTechniquesUiPage.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/HachBasedTechniquesUiPage.xaml.cs
@@ -16,25 +16,35 @@ public partial class HachBasedTechniquesUiPage : ContentView
 
     private void OnCreateClicked(object sender, EventArgs e)
     {
-        string password = passwordEntry.Text ?? string.Empty;
+        string password = passwordEntry?.Text ?? string.Empty;
 
         if (!string.IsNullOrWhiteSpace(password))
         {
             string result = hashBasedTechnique.GeneratePassword(password);
-            resultEntry.Text = result;
+            if (resultEntry is not null)
+            {
+                resultEntry.Text = result;
+            }
         }
         else
         {
-            resultEntry.Text = string.Empty;
+            if (resultEntry is not null)
+            {
+                resultEntry.Text = string.Empty;
+            }
         }
     }
 
     private async void OnCopyClicked(object sender, EventArgs e)
     {
-        if (!string.IsNullOrWhiteSpace(resultEntry.Text))
+        if (!string.IsNullOrWhiteSpace(resultEntry?.Text))
         {
-            await Clipboard.Default.SetTextAsync(resultEntry.Text);
-            await Application.Current.MainPage.DisplayAlert("Info", "Password copied to clipboard", "OK");
+            await Clipboard.Default.SetTextAsync(resultEntry!.Text);
+            var mainPage = Application.Current?.MainPage;
+            if (mainPage is not null)
+            {
+                await mainPage.DisplayAlert("Info", "Password copied to clipboard", "OK");
+            }
         }
     }
 }

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/TbvUiPage.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/TbvUiPage.xaml.cs
@@ -16,7 +16,7 @@ public partial class TbvUiPage : ContentView
 
     private void OnCreateClicked(object sender, EventArgs e)
     {
-        var password = passwordEntry.Text;
+        var password = passwordEntry?.Text;
 
         if (string.IsNullOrWhiteSpace(password))
         {
@@ -24,27 +24,37 @@ public partial class TbvUiPage : ContentView
             return;
         }
 
-        bool c1 = int.TryParse(code1Entry.Text, out var code1);
-        bool c2 = int.TryParse(code2Entry.Text, out var code2);
-        bool c3 = int.TryParse(code3Entry.Text, out var code3);
+        bool c1 = int.TryParse(code1Entry?.Text, out var code1);
+        bool c2 = int.TryParse(code2Entry?.Text, out var code2);
+        bool c3 = int.TryParse(code3Entry?.Text, out var code3);
 
         if (c1 && c2 && c3)
         {
             string result = tbv.GeneratePassword(password, code1, code2, code3);
-            resultEntry.Text = result;
+            if (resultEntry is not null)
+            {
+                resultEntry.Text = result;
+            }
         }
         else
         {
-            resultEntry.Text = string.Empty;
+            if (resultEntry is not null)
+            {
+                resultEntry.Text = string.Empty;
+            }
         }
     }
 
     private async void OnCopyClicked(object sender, EventArgs e)
     {
-        if (!string.IsNullOrWhiteSpace(resultEntry.Text))
+        if (!string.IsNullOrWhiteSpace(resultEntry?.Text))
         {
-            await Clipboard.Default.SetTextAsync(resultEntry.Text);
-            await Application.Current.MainPage.DisplayAlert("Info", "Password copied to clipboard", "OK");
+            await Clipboard.Default.SetTextAsync(resultEntry!.Text);
+            var mainPage = Application.Current?.MainPage;
+            if (mainPage is not null)
+            {
+                await mainPage.DisplayAlert("Info", "Password copied to clipboard", "OK");
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove unsupported FlyoutForegroundColor property from AppShell to fix XAML compilation
- replace deprecated VerticalGridItemsLayout usage on the start page with the supported GridItemsLayout
- address nullable reference warnings across TBV helpers and Windows UI pages by initializing fields and adding null checks

## Testing
- dotnet build Password Phrase Producer/PasswordPhraseProducer.csproj -f net8.0-android *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68eac95c1f9c832ab266749778b03a7e