### PR TITLE
Fix Android workflow build failures

### DIFF
--- a/Password Phrase Producer/PasswordGenerationTechniques/TbvTechniques/TBVHelper.cs
+++ b/Password Phrase Producer/PasswordGenerationTechniques/TbvTechniques/TBVHelper.cs
@@ -161,7 +161,7 @@ namespace PasswordPhraseProducer.PasswordGenerationTechniques.TbvTechniques
                 _ => 0
             };
 
-            if (limit == 0) return null;
+            if (limit == 0) return Array.Empty<int[]>();
 
             var codeList = new int[(int)Math.Pow(limit, 3)][];
             int index = 0;

--- a/Password Phrase Producer/StartPage.xaml
+++ b/Password Phrase Producer/StartPage.xaml
@@ -37,7 +37,7 @@
             <CollectionView ItemsSource="{Binding ModeOptions}"
                             SelectionMode="None">
                 <CollectionView.ItemsLayout>
-                    <GridItemsLayout Orientation="Vertical" Span="1" ItemSpacing="18"/>
+                    <GridItemsLayout Orientation="Vertical" Span="1" VerticalItemSpacing="18"/>
                 </CollectionView.ItemsLayout>
                 <CollectionView.ItemTemplate>
                     <DataTemplate x:DataType="local:PasswordModeOption">


### PR DESCRIPTION
## Summary
- replace the unsupported ItemSpacing attribute with VerticalItemSpacing on the start page CollectionView to satisfy MAUI XAML compilation
- return an empty array when TBV code combinations are unavailable to eliminate nullable warnings during Android builds

## Testing
- `dotnet build 'Password Phrase Producer.sln' -c Release -f net8.0-android` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eacd1dfc7c832a885692a325f52326