### PR TITLE
Fix shell navigation routes for mode selection

### DIFF
--- a/Password Phrase Producer/AppShell.xaml.cs
+++ b/Password Phrase Producer/AppShell.xaml.cs
@@ -18,7 +18,7 @@ public partial class AppShell : Shell
             var shellContent = new ShellContent
             {
                 Title = mode.Title,
-                Route = mode.Route,
+                Route = mode.ContentRoute,
                 ContentTemplate = new DataTemplate(() => new ModeHostPage(mode))
             };
 

--- a/Password Phrase Producer/Models/PasswordModeOption.cs
+++ b/Password Phrase Producer/Models/PasswordModeOption.cs
@@ -12,6 +12,7 @@ public class PasswordModeOption
         Description = description;
         Icon = icon;
         Route = route;
+        ContentRoute = $"{route}-content";
         ContentFactory = contentFactory;
     }
 
@@ -22,6 +23,8 @@ public class PasswordModeOption
     public string Description { get; }
 
     public string Route { get; }
+
+    public string ContentRoute { get; }
 
     public string? Icon { get; }
 

--- a/Password Phrase Producer/Services/ModeCatalog.cs
+++ b/Password Phrase Producer/Services/ModeCatalog.cs
@@ -15,42 +15,42 @@ public static class ModeCatalog
             "1 Word Password",
             "Deterministisches Hash-Verfahren für ein einzelnes Wort.",
             () => new HachBasedTechniquesUiPage(new DeterministicHashPasswordGenerator()),
-            "mode/hash-one",
+            "mode-hash-one",
             "🔐"),
         new(
             "alternate",
             "Alternate Words",
             "Kombiniere abwechselnde Wörter zu einer starken Passphrase.",
             () => new ConcatenationTechniquesUiPage(new AlternatingUpDownChaining()),
-            "mode/alternate",
+            "mode-alternate",
             "🧩"),
         new(
             "tbv1-errors",
             "TBV1 With Errors",
             "Dreifache Verifizierung mit intelligenter Fehlerbehandlung.",
             () => new TbvUiPage(new TBV1WithErrors()),
-            "mode/tbv1-errors",
+            "mode-tbv1-errors",
             "🛡️"),
         new(
             "tbv1",
             "TBV1",
             "Klassische dreifache Verifizierung für Passphrasen.",
             () => new TbvUiPage(new TBV1()),
-            "mode/tbv1",
+            "mode-tbv1",
             "🧱"),
         new(
             "tbv2",
             "TBV2",
             "Erweiterte Verifizierung mit zusätzlichen Sicherheitsstufen.",
             () => new TbvUiPage(new TBV2()),
-            "mode/tbv2",
+            "mode-tbv2",
             "⚙️"),
         new(
             "tbv3",
             "TBV3",
             "Modernes Verfahren mit erweiterten Prüfungen und Komfort.",
             () => new TbvUiPage(new TBV3()),
-            "mode/tbv3",
+            "mode-tbv3",
             "🚀")
     };
 }

--- a/Password Phrase Producer/ViewModels/StartPageViewModel.cs
+++ b/Password Phrase Producer/ViewModels/StartPageViewModel.cs
@@ -25,6 +25,6 @@ public class StartPageViewModel
             return;
         }
 
-        await Shell.Current.GoToAsync($"//{option.Route}");
+        await Shell.Current.GoToAsync($"//{option.Route}/{option.ContentRoute}");
     }
 }


### PR DESCRIPTION
## Summary
- assign stable route names to each mode option without nested segments
- update shell menu construction to use separate routes for flyout items and content
- navigate using the full absolute route so tapping cards or flyout entries opens the correct page

## Testing
- Not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68eae2da3e40832aaadfe9f78dfe7448