### PR TITLE
Modernize UI layout and add back navigation

### DIFF
--- a/Password Phrase Producer/Resources/Styles/Styles.xaml
+++ b/Password Phrase Producer/Resources/Styles/Styles.xaml
@@ -426,25 +426,31 @@
 
     <Style TargetType="Button" x:Key="PrimaryActionButtonStyle">
         <Setter Property="TextColor" Value="White" />
-        <Setter Property="BackgroundColor" Value="#4CAF50" />
-        <Setter Property="CornerRadius" Value="25" />
-        <Setter Property="FontSize" Value="18" />
-        <Setter Property="HeightRequest" Value="50" />
-        <Setter Property="Margin" Value="5" />
+        <Setter Property="BackgroundColor" Value="#6366F1" />
+        <Setter Property="CornerRadius" Value="22" />
+        <Setter Property="FontSize" Value="16" />
+        <Setter Property="FontAttributes" Value="Bold" />
+        <Setter Property="HeightRequest" Value="52" />
+        <Setter Property="Margin" Value="0" />
         <Setter Property="HorizontalOptions" Value="FillAndExpand" />
         <Setter Property="VerticalOptions" Value="Center" />
-        <Setter Property="Padding" Value="20,10" />
+        <Setter Property="Padding" Value="22,14" />
+        <Setter Property="Shadow">
+            <Setter.Value>
+                <Shadow Brush="#33000000" Radius="12" Offset="0,6" />
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style TargetType="Entry" x:Key="DarkEntryStyle">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light=#F2F2F2, Dark=#333333}" />
-        <Setter Property="PlaceholderColor" Value="{AppThemeBinding Light=#666666, Dark=#AAAAAA}" />
-        <Setter Property="FontSize" Value="18" />
-        <Setter Property="Margin" Value="5" />
+        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light=#EEF1FF, Dark=#22263A}" />
+        <Setter Property="PlaceholderColor" Value="{AppThemeBinding Light=#7A7FA6, Dark=#9EA3CC}" />
+        <Setter Property="FontSize" Value="16" />
+        <Setter Property="Margin" Value="0" />
         <Setter Property="HorizontalOptions" Value="FillAndExpand" />
         <Setter Property="VerticalOptions" Value="Center" />
-        <Setter Property="HeightRequest" Value="50" />
+        <Setter Property="HeightRequest" Value="52" />
     </Style>
 
 </ResourceDictionary>

--- a/Password Phrase Producer/StartPage.xaml
+++ b/Password Phrase Producer/StartPage.xaml
@@ -3,79 +3,208 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:Password_Phrase_Producer"
              x:Class="Password_Phrase_Producer.StartPage"
-             BackgroundColor="#121212"
              Padding="0">
-    <ScrollView>
-        <VerticalStackLayout Spacing="24"
-                             Padding="24,48,24,36">
-            <VerticalStackLayout Spacing="8">
-                <Label Text="Password Phrase Producer"
-                       FontSize="32"
-                       TextColor="White"
-                       FontAttributes="Bold"/>
-                <Label Text="Wähle einen sicheren Generator aus oder entdecke neue Möglichkeiten deine Passphrasen zu erstellen."
-                       TextColor="#D0D0D0"
-                       FontSize="16"/>
-            </VerticalStackLayout>
+    <ContentPage.Background>
+        <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
+            <GradientStop Color="#121212" Offset="0" />
+            <GradientStop Color="#1C1C24" Offset="0.5" />
+            <GradientStop Color="#101018" Offset="1" />
+        </LinearGradientBrush>
+    </ContentPage.Background>
 
+    <ScrollView>
+        <VerticalStackLayout Spacing="32"
+                             Padding="24,48,24,40">
             <Border StrokeThickness="0"
-                    BackgroundColor="#1E1E1E"
-                    Padding="18">
+                    Padding="24"
+                    Margin="0,0,0,8">
                 <Border.StrokeShape>
-                    <RoundRectangle CornerRadius="20" />
+                    <RoundRectangle CornerRadius="28" />
                 </Border.StrokeShape>
-                <VerticalStackLayout Spacing="12">
-                    <Label Text="Schnellstart"
-                           FontSize="20"
-                           TextColor="White"
-                           FontAttributes="Bold"/>
-                    <Label Text="Tippe auf eine Karte um den Modus zu öffnen."
-                           TextColor="#B0B0B0"/>
-                </VerticalStackLayout>
+                <Border.Background>
+                    <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
+                        <GradientStop Color="#2D3BFF" Offset="0" />
+                        <GradientStop Color="#7C4DFF" Offset="1" />
+                    </LinearGradientBrush>
+                </Border.Background>
+                <Border.Shadow>
+                    <Shadow Brush="#40000000" Radius="18" Offset="0,8" />
+                </Border.Shadow>
+                <Grid ColumnDefinitions="*,Auto"
+                      RowSpacing="12">
+                    <VerticalStackLayout Spacing="10">
+                        <Label Text="Password Phrase Producer"
+                               FontSize="34"
+                               FontAttributes="Bold"
+                               TextColor="White"/>
+                        <Label Text="Erstelle in Sekunden starke Passphrasen und finde den passenden Generator für deinen Anwendungsfall."
+                               TextColor="#F2F5FF"
+                               FontSize="16"
+                               LineBreakMode="WordWrap"/>
+                        <Button Text="Schnellstart"
+                                FontAttributes="Bold"
+                                Padding="22,12"
+                                HorizontalOptions="Start"
+                                Command="{Binding NavigateToModeCommand}"
+                                CommandParameter="{Binding FeaturedMode}"
+                                BackgroundColor="#FFFFFF22"
+                                TextColor="White"
+                                CornerRadius="22"/>
+                    </VerticalStackLayout>
+                    <Border Grid.Column="1"
+                            BackgroundColor="#FFFFFF18"
+                            Padding="16"
+                            StrokeThickness="0"
+                            HeightRequest="120"
+                            WidthRequest="120"
+                            HorizontalOptions="End"
+                            VerticalOptions="Center">
+                        <Border.StrokeShape>
+                            <RoundRectangle CornerRadius="28" />
+                        </Border.StrokeShape>
+                        <VerticalStackLayout Spacing="4"
+                                             HorizontalOptions="Center"
+                                             VerticalOptions="Center">
+                            <Label Text="{Binding ModeOptions.Count}"
+                                   FontSize="32"
+                                   FontAttributes="Bold"
+                                   TextColor="White"
+                                   HorizontalOptions="Center"/>
+                            <Label Text="Generatoren"
+                                   FontSize="14"
+                                   TextColor="#D7DBFF"
+                                   HorizontalOptions="Center"/>
+                        </VerticalStackLayout>
+                    </Border>
+                </Grid>
             </Border>
 
+            <Grid ColumnDefinitions="*,*" ColumnSpacing="18">
+                <Border StrokeThickness="0"
+                        Padding="18"
+                        BackgroundColor="#1E1E29"
+                        HeightRequest="120">
+                    <Border.StrokeShape>
+                        <RoundRectangle CornerRadius="24" />
+                    </Border.StrokeShape>
+                    <Border.Shadow>
+                        <Shadow Brush="#25000000" Radius="12" Offset="0,6" />
+                    </Border.Shadow>
+                    <VerticalStackLayout Spacing="6">
+                        <Label Text="Zuletzt benutzt"
+                               TextColor="#9DA3C4"
+                               FontSize="13"
+                               FontAttributes="Bold"/>
+                        <Label Text="Tippe oben auf Schnellstart um sofort weiterzuarbeiten."
+                               TextColor="White"
+                               FontSize="15"
+                               LineBreakMode="WordWrap"/>
+                    </VerticalStackLayout>
+                </Border>
+                <Border StrokeThickness="0"
+                        Padding="18"
+                        BackgroundColor="#1A1F33"
+                        HeightRequest="120">
+                    <Border.StrokeShape>
+                        <RoundRectangle CornerRadius="24" />
+                    </Border.StrokeShape>
+                    <Border.Shadow>
+                        <Shadow Brush="#25000000" Radius="12" Offset="0,6" />
+                    </Border.Shadow>
+                    <VerticalStackLayout Spacing="6">
+                        <Label Text="Neue Optionen"
+                               TextColor="#9DA3C4"
+                               FontSize="13"
+                               FontAttributes="Bold"/>
+                        <Label Text="Wähle unten eine Karte aus, um detaillierte Passphrasen zu generieren."
+                               TextColor="White"
+                               FontSize="15"
+                               LineBreakMode="WordWrap"/>
+                    </VerticalStackLayout>
+                </Border>
+            </Grid>
+
+            <VerticalStackLayout Spacing="6">
+                <Label Text="Generatoren"
+                       FontSize="20"
+                       FontAttributes="Bold"
+                       TextColor="White"/>
+                <Label Text="Erkunde alle verfügbaren Modi und finde den idealen Ansatz für dein Passwort."
+                       TextColor="#C2C6E2"
+                       FontSize="15"
+                       LineBreakMode="WordWrap"/>
+            </VerticalStackLayout>
+
             <CollectionView ItemsSource="{Binding ModeOptions}"
-                            SelectionMode="None">
+                            SelectionMode="None"
+                            Margin="0,4,0,0">
                 <CollectionView.ItemsLayout>
-                    <GridItemsLayout Orientation="Vertical" Span="1" VerticalItemSpacing="18"/>
+                    <GridItemsLayout Orientation="Vertical"
+                                     VerticalItemSpacing="18"
+                                     HorizontalItemSpacing="18">
+                        <GridItemsLayout.Span>
+                            <OnIdiom x:TypeArguments="x:Int32">
+                                <OnIdiom.Phone>1</OnIdiom.Phone>
+                                <OnIdiom.Tablet>2</OnIdiom.Tablet>
+                                <OnIdiom.Desktop>3</OnIdiom.Desktop>
+                            </OnIdiom>
+                        </GridItemsLayout.Span>
+                    </GridItemsLayout>
                 </CollectionView.ItemsLayout>
                 <CollectionView.ItemTemplate>
                     <DataTemplate x:DataType="local:PasswordModeOption">
-                        <Border BackgroundColor="#1E1E1E"
-                                Padding="20"
-                                StrokeThickness="0">
+                        <Border Padding="22"
+                                StrokeThickness="0"
+                                Margin="0,0,0,6">
                             <Border.StrokeShape>
-                                <RoundRectangle CornerRadius="24" />
+                                <RoundRectangle CornerRadius="26" />
                             </Border.StrokeShape>
+                            <Border.Background>
+                                <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
+                                    <GradientStop Color="#252941" Offset="0" />
+                                    <GradientStop Color="#1A1D2C" Offset="1" />
+                                </LinearGradientBrush>
+                            </Border.Background>
+                            <Border.Shadow>
+                                <Shadow Brush="#25000000" Radius="14" Offset="0,8" />
+                            </Border.Shadow>
                             <Border.GestureRecognizers>
                                 <TapGestureRecognizer Command="{Binding BindingContext.NavigateToModeCommand, Source={RelativeSource AncestorType={x:Type local:StartPage}}}"
                                                      CommandParameter="{Binding}"/>
                             </Border.GestureRecognizers>
                             <Grid ColumnDefinitions="Auto,*"
                                   RowDefinitions="Auto,Auto"
-                                  ColumnSpacing="18">
-                                <Frame Padding="14"
-                                       HasShadow="False"
-                                       BackgroundColor="#2D2D2D"
-                                       CornerRadius="18"
-                                       VerticalOptions="Start"
-                                       HeightRequest="56"
-                                       WidthRequest="56">
+                                  ColumnSpacing="18"
+                                  RowSpacing="8">
+                                <Border Padding="16"
+                                        StrokeThickness="0"
+                                        WidthRequest="64"
+                                        HeightRequest="64"
+                                        VerticalOptions="Start">
+                                    <Border.StrokeShape>
+                                        <RoundRectangle CornerRadius="20" />
+                                    </Border.StrokeShape>
+                                    <Border.Background>
+                                        <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
+                                            <GradientStop Color="#3C3F63" Offset="0" />
+                                            <GradientStop Color="#26293F" Offset="1" />
+                                        </LinearGradientBrush>
+                                    </Border.Background>
                                     <Label Text="{Binding Icon}"
-                                           FontSize="26"
+                                           FontSize="28"
                                            HorizontalOptions="Center"
                                            VerticalOptions="Center"/>
-                                </Frame>
+                                </Border>
                                 <Label Grid.Column="1"
                                        Text="{Binding Title}"
-                                       FontSize="20"
+                                       FontSize="18"
                                        FontAttributes="Bold"
                                        TextColor="White"/>
                                 <Label Grid.Column="1"
                                        Grid.Row="1"
                                        Text="{Binding Description}"
                                        FontSize="14"
-                                       TextColor="#B0B0B0"
+                                       TextColor="#C8CBDF"
                                        LineBreakMode="WordWrap"/>
                             </Grid>
                         </Border>

--- a/Password Phrase Producer/ViewModels/StartPageViewModel.cs
+++ b/Password Phrase Producer/ViewModels/StartPageViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Windows.Input;
 using Microsoft.Maui.Controls;
 using Password_Phrase_Producer.Services;
@@ -11,10 +12,13 @@ public class StartPageViewModel
     public StartPageViewModel()
     {
         ModeOptions = new ObservableCollection<PasswordModeOption>(ModeCatalog.AllModes);
+        FeaturedMode = ModeOptions.FirstOrDefault();
         NavigateToModeCommand = new Command<PasswordModeOption>(NavigateToMode);
     }
 
     public ObservableCollection<PasswordModeOption> ModeOptions { get; }
+
+    public PasswordModeOption? FeaturedMode { get; }
 
     public ICommand NavigateToModeCommand { get; }
 

--- a/Password Phrase Producer/Views/ModeHostPage.xaml
+++ b/Password Phrase Producer/Views/ModeHostPage.xaml
@@ -2,27 +2,53 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Password_Phrase_Producer.Views.ModeHostPage"
-             BackgroundColor="#121212"
-             Padding="24,48,24,36">
-    <VerticalStackLayout Spacing="20">
-        <VerticalStackLayout Spacing="6">
-            <Label Text="{Binding Title}"
-                   FontSize="28"
-                   FontAttributes="Bold"
-                   TextColor="White"/>
-            <Label Text="{Binding Description}"
-                   TextColor="#C8C8C8"
-                   FontSize="15"
-                   LineBreakMode="WordWrap"/>
-        </VerticalStackLayout>
+             Padding="0">
+    <ContentPage.Background>
+        <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
+            <GradientStop Color="#101018" Offset="0" />
+            <GradientStop Color="#131321" Offset="0.6" />
+            <GradientStop Color="#0F111A" Offset="1" />
+        </LinearGradientBrush>
+    </ContentPage.Background>
 
-        <Border StrokeThickness="0"
-                BackgroundColor="#1E1E1E"
-                Padding="18">
-            <Border.StrokeShape>
-                <RoundRectangle CornerRadius="24" />
-            </Border.StrokeShape>
-            <ContentView x:Name="ContentHost"/>
-        </Border>
-    </VerticalStackLayout>
+    <ScrollView>
+        <VerticalStackLayout Spacing="28"
+                             Padding="24,48,24,40">
+            <Grid ColumnDefinitions="Auto,*"
+                  ColumnSpacing="18"
+                  RowSpacing="4">
+                <Button Text="‹ Zurück"
+                        Padding="20,12"
+                        BackgroundColor="#1F2338"
+                        TextColor="#C5CAFF"
+                        CornerRadius="22"
+                        Clicked="OnBackClicked"
+                        FontSize="14"
+                        FontAttributes="Bold"/>
+                <VerticalStackLayout Grid.Column="1"
+                                     Spacing="8">
+                    <Label Text="{Binding Title}"
+                           FontSize="28"
+                           FontAttributes="Bold"
+                           TextColor="White"/>
+                    <Label Text="{Binding Description}"
+                           TextColor="#C6CAE6"
+                           FontSize="15"
+                           LineBreakMode="WordWrap"/>
+                </VerticalStackLayout>
+            </Grid>
+
+            <Border StrokeThickness="0"
+                    Padding="20"
+                    BackgroundColor="#181B2A">
+                <Border.StrokeShape>
+                    <RoundRectangle CornerRadius="28" />
+                </Border.StrokeShape>
+                <Border.Shadow>
+                    <Shadow Brush="#25000000" Radius="18" Offset="0,10" />
+                </Border.Shadow>
+                <ContentView x:Name="ContentHost"/>
+            </Border>
+        </VerticalStackLayout>
+    </ScrollView>
 </ContentPage>

--- a/Password Phrase Producer/Views/ModeHostPage.xaml.cs
+++ b/Password Phrase Producer/Views/ModeHostPage.xaml.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Maui.Controls;
 using PasswordModeOption = Password_Phrase_Producer.PasswordModeOption;
 
@@ -11,5 +12,10 @@ public partial class ModeHostPage : ContentPage
         BindingContext = option;
         Title = option.Title;
         ContentHost.Content = option.CreateView();
+    }
+
+    private async void OnBackClicked(object? sender, EventArgs e)
+    {
+        await Shell.Current.GoToAsync("//home");
     }
 }

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/ConcatenationTechniquesUiPage.xaml
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/ConcatenationTechniquesUiPage.xaml
@@ -2,30 +2,64 @@
 <ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Password_Phrase_Producer.Windows.PasswordGenerationWindows.ConcatenationTechniquesUiPage">
-    <VerticalStackLayout Padding="20" Spacing="15">
-        <ScrollView HeightRequest="250">
-            <VerticalStackLayout x:Name="phraseContainer" Spacing="10" />
-        </ScrollView>
+    <VerticalStackLayout Spacing="24">
+        <Border StrokeThickness="0"
+                Padding="18"
+                BackgroundColor="#1F2438">
+            <Border.StrokeShape>
+                <RoundRectangle CornerRadius="22" />
+            </Border.StrokeShape>
+            <VerticalStackLayout Spacing="14">
+                <Label Text="Passphrase-Bausteine"
+                       FontSize="18"
+                       FontAttributes="Bold"
+                       TextColor="White"/>
+                <Label Text="Füge beliebig viele Wörter oder Phrasen hinzu, die du kombinieren möchtest."
+                       TextColor="#BDC2E8"
+                       FontSize="14"
+                       LineBreakMode="WordWrap"/>
+                <Border StrokeThickness="0"
+                        BackgroundColor="#15192A"
+                        Padding="12">
+                    <Border.StrokeShape>
+                        <RoundRectangle CornerRadius="18" />
+                    </Border.StrokeShape>
+                    <ScrollView HeightRequest="240">
+                        <VerticalStackLayout x:Name="phraseContainer" Spacing="10" />
+                    </ScrollView>
+                </Border>
+                <Button Text="Eintrag hinzufügen"
+                        Style="{StaticResource PrimaryActionButtonStyle}"
+                        Clicked="OnAddNewTextField" />
+            </VerticalStackLayout>
+        </Border>
 
-        <Button Text="New Entry"
-                Style="{StaticResource PrimaryActionButtonStyle}"
-                Clicked="OnAddNewTextField" />
-
-        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
-            <Entry x:Name="resultEntry"
-                   Placeholder="Result"
-                   Style="{StaticResource DarkEntryStyle}"
-                   IsReadOnly="True"
-                   Margin="0,5,0,5" />
-            <Button Grid.Column="1"
-                    Text="Copy"
-                    Style="{StaticResource PrimaryActionButtonStyle}"
-                    Clicked="OnCopyClicked"
-                    HorizontalOptions="End" />
-        </Grid>
-
-        <Button Text="Create"
-                Style="{StaticResource PrimaryActionButtonStyle}"
-                Clicked="OnCreateClicked" />
+        <Border StrokeThickness="0"
+                Padding="18"
+                BackgroundColor="#1F2438">
+            <Border.StrokeShape>
+                <RoundRectangle CornerRadius="22" />
+            </Border.StrokeShape>
+            <VerticalStackLayout Spacing="16">
+                <Label Text="Ergebnis"
+                       FontSize="18"
+                       FontAttributes="Bold"
+                       TextColor="White"/>
+                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
+                    <Entry x:Name="resultEntry"
+                           Placeholder="Generierte Passphrase"
+                           Style="{StaticResource DarkEntryStyle}"
+                           IsReadOnly="True" />
+                    <Button Grid.Column="1"
+                            Text="Kopieren"
+                            Style="{StaticResource PrimaryActionButtonStyle}"
+                            Clicked="OnCopyClicked"
+                            HorizontalOptions="End" />
+                </Grid>
+                <Button Text="Passphrase erzeugen"
+                        Style="{StaticResource PrimaryActionButtonStyle}"
+                        Clicked="OnCreateClicked" />
+            </VerticalStackLayout>
+        </Border>
     </VerticalStackLayout>
 </ContentView>

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/HachBasedTechniquesUiPage.xaml
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/HachBasedTechniquesUiPage.xaml
@@ -2,26 +2,54 @@
 <ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Password_Phrase_Producer.Windows.PasswordGenerationWindows.HachBasedTechniquesUiPage">
-    <VerticalStackLayout Padding="20" Spacing="15">
-        <Entry x:Name="passwordEntry"
-               Placeholder="Password phrase"
-               Style="{StaticResource DarkEntryStyle}" />
+    <VerticalStackLayout Spacing="24">
+        <Border StrokeThickness="0"
+                Padding="18"
+                BackgroundColor="#1F2438">
+            <Border.StrokeShape>
+                <RoundRectangle CornerRadius="22" />
+            </Border.StrokeShape>
+            <VerticalStackLayout Spacing="14">
+                <Label Text="Eingabe"
+                       FontSize="18"
+                       FontAttributes="Bold"
+                       TextColor="White"/>
+                <Label Text="Gib ein Wort oder eine Phrase ein, die als Grundlage für den Hash dient."
+                       TextColor="#BDC2E8"
+                       FontSize="14"
+                       LineBreakMode="WordWrap"/>
+                <Entry x:Name="passwordEntry"
+                       Placeholder="Ausgangsphrase"
+                       Style="{StaticResource DarkEntryStyle}" />
+            </VerticalStackLayout>
+        </Border>
 
-        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
-            <Entry x:Name="resultEntry"
-                   Placeholder="Result"
-                   Style="{StaticResource DarkEntryStyle}"
-                   IsReadOnly="True"
-                   Margin="0,5,0,5" />
-            <Button Grid.Column="1"
-                    Text="Copy"
-                    Style="{StaticResource PrimaryActionButtonStyle}"
-                    Clicked="OnCopyClicked"
-                    HorizontalOptions="End" />
-        </Grid>
-
-        <Button Text="Create"
-                Style="{StaticResource PrimaryActionButtonStyle}"
-                Clicked="OnCreateClicked" />
+        <Border StrokeThickness="0"
+                Padding="18"
+                BackgroundColor="#1F2438">
+            <Border.StrokeShape>
+                <RoundRectangle CornerRadius="22" />
+            </Border.StrokeShape>
+            <VerticalStackLayout Spacing="16">
+                <Label Text="Gehashtes Ergebnis"
+                       FontSize="18"
+                       FontAttributes="Bold"
+                       TextColor="White"/>
+                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
+                    <Entry x:Name="resultEntry"
+                           Placeholder="Hash-Ausgabe"
+                           Style="{StaticResource DarkEntryStyle}"
+                           IsReadOnly="True" />
+                    <Button Grid.Column="1"
+                            Text="Kopieren"
+                            Style="{StaticResource PrimaryActionButtonStyle}"
+                            Clicked="OnCopyClicked"
+                            HorizontalOptions="End" />
+                </Grid>
+                <Button Text="Hash erzeugen"
+                        Style="{StaticResource PrimaryActionButtonStyle}"
+                        Clicked="OnCreateClicked" />
+            </VerticalStackLayout>
+        </Border>
     </VerticalStackLayout>
 </ContentView>

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/TbvUiPage.xaml
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/TbvUiPage.xaml
@@ -2,36 +2,73 @@
 <ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Password_Phrase_Producer.Windows.PasswordGenerationWindows.TbvUiPage">
-    <VerticalStackLayout Padding="20" Spacing="15">
-        <Entry x:Name="passwordEntry"
-               Placeholder="Password phrase"
-               Style="{StaticResource DarkEntryStyle}" />
-        <Entry x:Name="code1Entry"
-               Placeholder="Code 1"
-               Keyboard="Numeric"
-               Style="{StaticResource DarkEntryStyle}" />
-        <Entry x:Name="code2Entry"
-               Placeholder="Code 2"
-               Keyboard="Numeric"
-               Style="{StaticResource DarkEntryStyle}" />
-        <Entry x:Name="code3Entry"
-               Placeholder="Code 3"
-               Keyboard="Numeric"
-               Style="{StaticResource DarkEntryStyle}" />
-        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
-            <Entry x:Name="resultEntry"
-                   Placeholder="Result"
-                   Style="{StaticResource DarkEntryStyle}"
-                   IsReadOnly="True"
-                   Margin="0,5,0,5" />
-            <Button Grid.Column="1"
-                    Text="Copy"
-                    Style="{StaticResource PrimaryActionButtonStyle}"
-                    Clicked="OnCopyClicked"
-                    HorizontalOptions="End" />
-        </Grid>
-        <Button Text="Create"
-                Style="{StaticResource PrimaryActionButtonStyle}"
-                Clicked="OnCreateClicked" />
+    <VerticalStackLayout Spacing="24">
+        <Border StrokeThickness="0"
+                Padding="18"
+                BackgroundColor="#1F2438">
+            <Border.StrokeShape>
+                <RoundRectangle CornerRadius="22" />
+            </Border.StrokeShape>
+            <VerticalStackLayout Spacing="14">
+                <Label Text="Eingaben"
+                       FontSize="18"
+                       FontAttributes="Bold"
+                       TextColor="White"/>
+                <Label Text="Kombiniere deine Phrase mit bis zu drei Prüf-Codes für zusätzliche Sicherheit."
+                       TextColor="#BDC2E8"
+                       FontSize="14"
+                       LineBreakMode="WordWrap"/>
+                <Entry x:Name="passwordEntry"
+                       Placeholder="Password Phrase"
+                       Style="{StaticResource DarkEntryStyle}" />
+                <Grid ColumnDefinitions="*,*"
+                      ColumnSpacing="12"
+                      RowSpacing="12">
+                    <Entry x:Name="code1Entry"
+                           Placeholder="Code 1"
+                           Keyboard="Numeric"
+                           Style="{StaticResource DarkEntryStyle}" />
+                    <Entry Grid.Column="1"
+                           x:Name="code2Entry"
+                           Placeholder="Code 2"
+                           Keyboard="Numeric"
+                           Style="{StaticResource DarkEntryStyle}" />
+                    <Entry Grid.ColumnSpan="2"
+                           Grid.Row="1"
+                           x:Name="code3Entry"
+                           Placeholder="Code 3 (optional)"
+                           Keyboard="Numeric"
+                           Style="{StaticResource DarkEntryStyle}" />
+                </Grid>
+            </VerticalStackLayout>
+        </Border>
+
+        <Border StrokeThickness="0"
+                Padding="18"
+                BackgroundColor="#1F2438">
+            <Border.StrokeShape>
+                <RoundRectangle CornerRadius="22" />
+            </Border.StrokeShape>
+            <VerticalStackLayout Spacing="16">
+                <Label Text="Ergebnis"
+                       FontSize="18"
+                       FontAttributes="Bold"
+                       TextColor="White"/>
+                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
+                    <Entry x:Name="resultEntry"
+                           Placeholder="TBV-Ausgabe"
+                           Style="{StaticResource DarkEntryStyle}"
+                           IsReadOnly="True" />
+                    <Button Grid.Column="1"
+                            Text="Kopieren"
+                            Style="{StaticResource PrimaryActionButtonStyle}"
+                            Clicked="OnCopyClicked"
+                            HorizontalOptions="End" />
+                </Grid>
+                <Button Text="TBV generieren"
+                        Style="{StaticResource PrimaryActionButtonStyle}"
+                        Clicked="OnCreateClicked" />
+            </VerticalStackLayout>
+        </Border>
     </VerticalStackLayout>
 </ContentView>


### PR DESCRIPTION
## Summary
- redesign the start page with a gradient hero, quick info cards, and a responsive generator grid
- refresh the shared button/entry styling and update each generator subpage with card-based layouts
- add an in-page back action on generator screens for a direct return to the main menu

## Testing
- dotnet build 'Password Phrase Producer/PasswordPhraseProducer.csproj' *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68eb9ff8c14c832ab2320c4b15473f7e