### PR TITLE
Streamline mode host layout and simplify start page

### DIFF
--- a/Password Phrase Producer/StartPage.xaml
+++ b/Password Phrase Producer/StartPage.xaml
@@ -16,113 +16,26 @@
         <VerticalStackLayout Spacing="32"
                              Padding="24,48,24,40">
             <Border StrokeThickness="0"
-                    Padding="24"
-                    Margin="0,0,0,8">
+                    Padding="18"
+                    BackgroundColor="#1E1E29"
+                    HeightRequest="120">
                 <Border.StrokeShape>
-                    <RoundRectangle CornerRadius="28" />
+                    <RoundRectangle CornerRadius="24" />
                 </Border.StrokeShape>
-                <Border.Background>
-                    <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
-                        <GradientStop Color="#2D3BFF" Offset="0" />
-                        <GradientStop Color="#7C4DFF" Offset="1" />
-                    </LinearGradientBrush>
-                </Border.Background>
                 <Border.Shadow>
-                    <Shadow Brush="#40000000" Radius="18" Offset="0,8" />
+                    <Shadow Brush="#25000000" Radius="12" Offset="0,6" />
                 </Border.Shadow>
-                <Grid ColumnDefinitions="*,Auto"
-                      RowSpacing="12">
-                    <VerticalStackLayout Spacing="10">
-                        <Label Text="Password Phrase Producer"
-                               FontSize="34"
-                               FontAttributes="Bold"
-                               TextColor="White"/>
-                        <Label Text="Erstelle in Sekunden starke Passphrasen und finde den passenden Generator für deinen Anwendungsfall."
-                               TextColor="#F2F5FF"
-                               FontSize="16"
-                               LineBreakMode="WordWrap"/>
-                        <Button Text="Schnellstart"
-                                FontAttributes="Bold"
-                                Padding="22,12"
-                                HorizontalOptions="Start"
-                                Command="{Binding NavigateToModeCommand}"
-                                CommandParameter="{Binding FeaturedMode}"
-                                BackgroundColor="#FFFFFF22"
-                                TextColor="White"
-                                CornerRadius="22"/>
-                    </VerticalStackLayout>
-                    <Border Grid.Column="1"
-                            BackgroundColor="#FFFFFF18"
-                            Padding="16"
-                            StrokeThickness="0"
-                            HeightRequest="120"
-                            WidthRequest="120"
-                            HorizontalOptions="End"
-                            VerticalOptions="Center">
-                        <Border.StrokeShape>
-                            <RoundRectangle CornerRadius="28" />
-                        </Border.StrokeShape>
-                        <VerticalStackLayout Spacing="4"
-                                             HorizontalOptions="Center"
-                                             VerticalOptions="Center">
-                            <Label Text="{Binding ModeOptions.Count}"
-                                   FontSize="32"
-                                   FontAttributes="Bold"
-                                   TextColor="White"
-                                   HorizontalOptions="Center"/>
-                            <Label Text="Generatoren"
-                                   FontSize="14"
-                                   TextColor="#D7DBFF"
-                                   HorizontalOptions="Center"/>
-                        </VerticalStackLayout>
-                    </Border>
-                </Grid>
+                <VerticalStackLayout Spacing="6">
+                    <Label Text="Zuletzt benutzt"
+                           TextColor="#9DA3C4"
+                           FontSize="13"
+                           FontAttributes="Bold"/>
+                    <Label Text="Tippe eine Karte an, um sofort weiterzuarbeiten."
+                           TextColor="White"
+                           FontSize="15"
+                           LineBreakMode="WordWrap"/>
+                </VerticalStackLayout>
             </Border>
-
-            <Grid ColumnDefinitions="*,*" ColumnSpacing="18">
-                <Border StrokeThickness="0"
-                        Padding="18"
-                        BackgroundColor="#1E1E29"
-                        HeightRequest="120">
-                    <Border.StrokeShape>
-                        <RoundRectangle CornerRadius="24" />
-                    </Border.StrokeShape>
-                    <Border.Shadow>
-                        <Shadow Brush="#25000000" Radius="12" Offset="0,6" />
-                    </Border.Shadow>
-                    <VerticalStackLayout Spacing="6">
-                        <Label Text="Zuletzt benutzt"
-                               TextColor="#9DA3C4"
-                               FontSize="13"
-                               FontAttributes="Bold"/>
-                        <Label Text="Tippe oben auf Schnellstart um sofort weiterzuarbeiten."
-                               TextColor="White"
-                               FontSize="15"
-                               LineBreakMode="WordWrap"/>
-                    </VerticalStackLayout>
-                </Border>
-                <Border StrokeThickness="0"
-                        Padding="18"
-                        BackgroundColor="#1A1F33"
-                        HeightRequest="120">
-                    <Border.StrokeShape>
-                        <RoundRectangle CornerRadius="24" />
-                    </Border.StrokeShape>
-                    <Border.Shadow>
-                        <Shadow Brush="#25000000" Radius="12" Offset="0,6" />
-                    </Border.Shadow>
-                    <VerticalStackLayout Spacing="6">
-                        <Label Text="Neue Optionen"
-                               TextColor="#9DA3C4"
-                               FontSize="13"
-                               FontAttributes="Bold"/>
-                        <Label Text="Wähle unten eine Karte aus, um detaillierte Passphrasen zu generieren."
-                               TextColor="White"
-                               FontSize="15"
-                               LineBreakMode="WordWrap"/>
-                    </VerticalStackLayout>
-                </Border>
-            </Grid>
 
             <VerticalStackLayout Spacing="6">
                 <Label Text="Generatoren"
@@ -176,10 +89,10 @@
                                   RowDefinitions="Auto,Auto"
                                   ColumnSpacing="18"
                                   RowSpacing="8">
-                                <Border Padding="16"
+                                <Border Padding="12"
                                         StrokeThickness="0"
-                                        WidthRequest="64"
-                                        HeightRequest="64"
+                                        WidthRequest="72"
+                                        HeightRequest="72"
                                         VerticalOptions="Start">
                                     <Border.StrokeShape>
                                         <RoundRectangle CornerRadius="20" />
@@ -191,9 +104,11 @@
                                         </LinearGradientBrush>
                                     </Border.Background>
                                     <Label Text="{Binding Icon}"
-                                           FontSize="28"
+                                           FontSize="24"
                                            HorizontalOptions="Center"
-                                           VerticalOptions="Center"/>
+                                           VerticalOptions="Center"
+                                           HorizontalTextAlignment="Center"
+                                           VerticalTextAlignment="Center"/>
                                 </Border>
                                 <Label Grid.Column="1"
                                        Text="{Binding Title}"

--- a/Password Phrase Producer/Views/ModeHostPage.xaml
+++ b/Password Phrase Producer/Views/ModeHostPage.xaml
@@ -12,31 +12,18 @@
     </ContentPage.Background>
 
     <ScrollView>
-        <VerticalStackLayout Spacing="28"
+        <VerticalStackLayout Spacing="24"
                              Padding="24,48,24,40">
-            <Grid ColumnDefinitions="Auto,*"
-                  ColumnSpacing="18"
-                  RowSpacing="4">
-                <Button Text="‹ Zurück"
-                        Padding="20,12"
-                        BackgroundColor="#1F2338"
-                        TextColor="#C5CAFF"
-                        CornerRadius="22"
-                        Clicked="OnBackClicked"
-                        FontSize="14"
-                        FontAttributes="Bold"/>
-                <VerticalStackLayout Grid.Column="1"
-                                     Spacing="8">
-                    <Label Text="{Binding Title}"
-                           FontSize="28"
-                           FontAttributes="Bold"
-                           TextColor="White"/>
-                    <Label Text="{Binding Description}"
-                           TextColor="#C6CAE6"
-                           FontSize="15"
-                           LineBreakMode="WordWrap"/>
-                </VerticalStackLayout>
-            </Grid>
+            <Button Text="‹ Zurück"
+                    Padding="12,8"
+                    BackgroundColor="#1F2338"
+                    TextColor="#C5CAFF"
+                    CornerRadius="18"
+                    Clicked="OnBackClicked"
+                    FontSize="12"
+                    FontAttributes="Bold"
+                    HorizontalOptions="Start"
+                    WidthRequest="110"/>
 
             <Border StrokeThickness="0"
                     Padding="20"


### PR DESCRIPTION
## Summary
- remove the hero banner and extra start page card so the generator list is the primary focus
- resize the mode icon container to avoid clipping and keep the card layout balanced
- simplify the mode host header to only show a compact back button before the embedded content

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ebe58bbd20832a9458d24f4859bb84