### PR TITLE
Revamp start page layout and mode headers

### DIFF
--- a/Password Phrase Producer/StartPage.xaml
+++ b/Password Phrase Producer/StartPage.xaml
@@ -13,48 +13,53 @@
     </ContentPage.Background>
 
     <ScrollView>
-        <VerticalStackLayout Spacing="32"
+        <VerticalStackLayout Spacing="28"
                              Padding="24,48,24,40">
-            <Border StrokeThickness="0"
-                    Padding="18"
-                    BackgroundColor="#1E1E29"
-                    HeightRequest="120">
-                <Border.StrokeShape>
-                    <RoundRectangle CornerRadius="24" />
-                </Border.StrokeShape>
-                <Border.Shadow>
-                    <Shadow Brush="#25000000" Radius="12" Offset="0,6" />
-                </Border.Shadow>
-                <VerticalStackLayout Spacing="6">
-                    <Label Text="Zuletzt benutzt"
-                           TextColor="#9DA3C4"
-                           FontSize="13"
-                           FontAttributes="Bold"/>
-                    <Label Text="Tippe eine Karte an, um sofort weiterzuarbeiten."
-                           TextColor="White"
-                           FontSize="15"
-                           LineBreakMode="WordWrap"/>
+            <Grid ColumnDefinitions="*,Auto"
+                  RowDefinitions="Auto"
+                  Padding="0,0,0,12">
+                <VerticalStackLayout Spacing="2"
+                                      VerticalOptions="Center">
+                    <Label Text="Modi auswählen"
+                           FontSize="26"
+                           FontAttributes="Bold"
+                           TextColor="White"/>
+                    <Label Text="Deine Modi im Überblick"
+                           FontSize="14"
+                           TextColor="#9EA3C4"/>
                 </VerticalStackLayout>
-            </Border>
-
-            <VerticalStackLayout Spacing="6">
-                <Label Text="Generatoren"
-                       FontSize="20"
-                       FontAttributes="Bold"
-                       TextColor="White"/>
-                <Label Text="Erkunde alle verfügbaren Modi und finde den idealen Ansatz für dein Passwort."
-                       TextColor="#C2C6E2"
-                       FontSize="15"
-                       LineBreakMode="WordWrap"/>
-            </VerticalStackLayout>
+                <Border Grid.Column="1"
+                        WidthRequest="52"
+                        HeightRequest="52"
+                        BackgroundColor="#1F2336"
+                        StrokeThickness="0"
+                        HorizontalOptions="End"
+                        VerticalOptions="Center">
+                    <Border.StrokeShape>
+                        <RoundRectangle CornerRadius="18" />
+                    </Border.StrokeShape>
+                    <Border.Shadow>
+                        <Shadow Brush="#20000000" Radius="10" Offset="0,6" />
+                    </Border.Shadow>
+                    <Border.GestureRecognizers>
+                        <TapGestureRecognizer Tapped="OnOpenMenuTapped" />
+                    </Border.GestureRecognizers>
+                    <Label Text="☰"
+                           FontSize="20"
+                           HorizontalOptions="Center"
+                           VerticalOptions="Center"
+                           TextColor="#CFD3FF"/>
+                </Border>
+            </Grid>
 
             <CollectionView ItemsSource="{Binding ModeOptions}"
                             SelectionMode="None"
-                            Margin="0,4,0,0">
+                            Margin="0,8,0,0"
+                            ItemSizingStrategy="MeasureAllItems">
                 <CollectionView.ItemsLayout>
                     <GridItemsLayout Orientation="Vertical"
-                                     VerticalItemSpacing="18"
-                                     HorizontalItemSpacing="18">
+                                     VerticalItemSpacing="22"
+                                     HorizontalItemSpacing="22">
                         <GridItemsLayout.Span>
                             <OnIdiom x:TypeArguments="x:Int32">
                                 <OnIdiom.Phone>1</OnIdiom.Phone>
@@ -66,45 +71,47 @@
                 </CollectionView.ItemsLayout>
                 <CollectionView.ItemTemplate>
                     <DataTemplate x:DataType="local:PasswordModeOption">
-                        <Border Padding="22"
+                        <Border Padding="0"
                                 StrokeThickness="0"
-                                Margin="0,0,0,6">
+                                Margin="0,0,0,6"
+                                HeightRequest="168">
                             <Border.StrokeShape>
-                                <RoundRectangle CornerRadius="26" />
+                                <RoundRectangle CornerRadius="30" />
                             </Border.StrokeShape>
                             <Border.Background>
                                 <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
-                                    <GradientStop Color="#252941" Offset="0" />
-                                    <GradientStop Color="#1A1D2C" Offset="1" />
+                                    <GradientStop Color="#2D3252" Offset="0" />
+                                    <GradientStop Color="#1B1E30" Offset="1" />
                                 </LinearGradientBrush>
                             </Border.Background>
                             <Border.Shadow>
-                                <Shadow Brush="#25000000" Radius="14" Offset="0,8" />
+                                <Shadow Brush="#25000000" Radius="16" Offset="0,10" />
                             </Border.Shadow>
                             <Border.GestureRecognizers>
                                 <TapGestureRecognizer Command="{Binding BindingContext.NavigateToModeCommand, Source={RelativeSource AncestorType={x:Type local:StartPage}}}"
                                                      CommandParameter="{Binding}"/>
                             </Border.GestureRecognizers>
-                            <Grid ColumnDefinitions="Auto,*"
+                            <Grid Padding="26,24"
+                                  ColumnDefinitions="Auto,*"
                                   RowDefinitions="Auto,Auto"
-                                  ColumnSpacing="18"
-                                  RowSpacing="8">
-                                <Border Padding="12"
+                                  ColumnSpacing="24"
+                                  RowSpacing="14">
+                                <Border Padding="16"
                                         StrokeThickness="0"
-                                        WidthRequest="72"
-                                        HeightRequest="72"
+                                        WidthRequest="88"
+                                        HeightRequest="88"
                                         VerticalOptions="Start">
                                     <Border.StrokeShape>
-                                        <RoundRectangle CornerRadius="20" />
+                                        <RoundRectangle CornerRadius="26" />
                                     </Border.StrokeShape>
                                     <Border.Background>
                                         <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
-                                            <GradientStop Color="#3C3F63" Offset="0" />
-                                            <GradientStop Color="#26293F" Offset="1" />
+                                            <GradientStop Color="#3E4266" Offset="0" />
+                                            <GradientStop Color="#272B43" Offset="1" />
                                         </LinearGradientBrush>
                                     </Border.Background>
                                     <Label Text="{Binding Icon}"
-                                           FontSize="24"
+                                           FontSize="32"
                                            HorizontalOptions="Center"
                                            VerticalOptions="Center"
                                            HorizontalTextAlignment="Center"
@@ -112,15 +119,36 @@
                                 </Border>
                                 <Label Grid.Column="1"
                                        Text="{Binding Title}"
-                                       FontSize="18"
+                                       FontSize="20"
                                        FontAttributes="Bold"
                                        TextColor="White"/>
-                                <Label Grid.Column="1"
-                                       Grid.Row="1"
-                                       Text="{Binding Description}"
-                                       FontSize="14"
-                                       TextColor="#C8CBDF"
-                                       LineBreakMode="WordWrap"/>
+                                <Grid Grid.Column="1"
+                                      Grid.Row="1"
+                                      ColumnDefinitions="*,Auto"
+                                      VerticalOptions="Center">
+                                    <Label Text="{Binding Description}"
+                                           FontSize="15"
+                                           TextColor="#C8CBDF"
+                                           LineBreakMode="WordWrap"
+                                           MaxLines="2"
+                                           VerticalTextAlignment="Center"/>
+                                    <Border Grid.Column="1"
+                                            WidthRequest="44"
+                                            HeightRequest="44"
+                                            BackgroundColor="#2F3452"
+                                            StrokeThickness="0"
+                                            HorizontalOptions="End"
+                                            VerticalOptions="Center">
+                                        <Border.StrokeShape>
+                                            <RoundRectangle CornerRadius="16" />
+                                        </Border.StrokeShape>
+                                        <Label Text="➜"
+                                               FontSize="20"
+                                               HorizontalOptions="Center"
+                                               VerticalOptions="Center"
+                                               TextColor="#D6DAFF"/>
+                                    </Border>
+                                </Grid>
                             </Grid>
                         </Border>
                     </DataTemplate>

--- a/Password Phrase Producer/StartPage.xaml.cs
+++ b/Password Phrase Producer/StartPage.xaml.cs
@@ -1,3 +1,4 @@
+using Microsoft.Maui.Controls;
 using Password_Phrase_Producer.ViewModels;
 
 namespace Password_Phrase_Producer;
@@ -8,5 +9,13 @@ public partial class StartPage : ContentPage
     {
         InitializeComponent();
         BindingContext = new StartPageViewModel();
+    }
+
+    private void OnOpenMenuTapped(object? sender, TappedEventArgs e)
+    {
+        if (Shell.Current is not null)
+        {
+            Shell.Current.FlyoutIsPresented = true;
+        }
     }
 }

--- a/Password Phrase Producer/Views/ModeHostPage.xaml
+++ b/Password Phrase Producer/Views/ModeHostPage.xaml
@@ -10,32 +10,82 @@
             <GradientStop Color="#0F111A" Offset="1" />
         </LinearGradientBrush>
     </ContentPage.Background>
-
-    <ScrollView>
-        <VerticalStackLayout Spacing="24"
-                             Padding="24,48,24,40">
-            <Button Text="‹ Zurück"
-                    Padding="12,8"
+    <Grid RowDefinitions="Auto,*">
+        <Grid RowSpacing="6"
+              ColumnDefinitions="Auto,*,Auto"
+              Padding="24,48,24,24">
+            <Border WidthRequest="52"
+                    HeightRequest="52"
                     BackgroundColor="#1F2338"
-                    TextColor="#C5CAFF"
-                    CornerRadius="18"
-                    Clicked="OnBackClicked"
-                    FontSize="12"
-                    FontAttributes="Bold"
-                    HorizontalOptions="Start"
-                    WidthRequest="110"/>
-
-            <Border StrokeThickness="0"
-                    Padding="20"
-                    BackgroundColor="#181B2A">
+                    StrokeThickness="0"
+                    VerticalOptions="Center">
                 <Border.StrokeShape>
-                    <RoundRectangle CornerRadius="28" />
+                    <RoundRectangle CornerRadius="18" />
                 </Border.StrokeShape>
                 <Border.Shadow>
-                    <Shadow Brush="#25000000" Radius="18" Offset="0,10" />
+                    <Shadow Brush="#25000000" Radius="12" Offset="0,8" />
                 </Border.Shadow>
-                <ContentView x:Name="ContentHost"/>
+                <Border.GestureRecognizers>
+                    <TapGestureRecognizer Tapped="OnBackTapped" />
+                </Border.GestureRecognizers>
+                <Label Text="‹"
+                       FontSize="22"
+                       HorizontalOptions="Center"
+                       VerticalOptions="Center"
+                       TextColor="#C5CAFF"/>
             </Border>
-        </VerticalStackLayout>
-    </ScrollView>
+
+            <VerticalStackLayout Grid.Column="1"
+                                  Spacing="2"
+                                  VerticalOptions="Center">
+                <Label Text="{Binding Title}"
+                       FontSize="24"
+                       FontAttributes="Bold"
+                       TextColor="White"/>
+                <Label Text="Modusübersicht"
+                       FontSize="14"
+                       TextColor="#9EA3C4"/>
+            </VerticalStackLayout>
+
+            <Border Grid.Column="2"
+                    WidthRequest="52"
+                    HeightRequest="52"
+                    BackgroundColor="#1F2338"
+                    StrokeThickness="0"
+                    HorizontalOptions="End"
+                    VerticalOptions="Center">
+                <Border.StrokeShape>
+                    <RoundRectangle CornerRadius="18" />
+                </Border.StrokeShape>
+                <Border.Shadow>
+                    <Shadow Brush="#20000000" Radius="10" Offset="0,6" />
+                </Border.Shadow>
+                <Border.GestureRecognizers>
+                    <TapGestureRecognizer Tapped="OnOpenMenuTapped" />
+                </Border.GestureRecognizers>
+                <Label Text="☰"
+                       FontSize="20"
+                       HorizontalOptions="Center"
+                       VerticalOptions="Center"
+                       TextColor="#CFD3FF"/>
+            </Border>
+        </Grid>
+
+        <ScrollView Grid.Row="1">
+            <VerticalStackLayout Spacing="24"
+                                 Padding="24,0,24,40">
+                <Border StrokeThickness="0"
+                        Padding="22"
+                        BackgroundColor="#181B2A">
+                    <Border.StrokeShape>
+                        <RoundRectangle CornerRadius="28" />
+                    </Border.StrokeShape>
+                    <Border.Shadow>
+                        <Shadow Brush="#25000000" Radius="18" Offset="0,10" />
+                    </Border.Shadow>
+                    <ContentView x:Name="ContentHost"/>
+                </Border>
+            </VerticalStackLayout>
+        </ScrollView>
+    </Grid>
 </ContentPage>

--- a/Password Phrase Producer/Views/ModeHostPage.xaml.cs
+++ b/Password Phrase Producer/Views/ModeHostPage.xaml.cs
@@ -14,8 +14,16 @@ public partial class ModeHostPage : ContentPage
         ContentHost.Content = option.CreateView();
     }
 
-    private async void OnBackClicked(object? sender, EventArgs e)
+    private async void OnBackTapped(object? sender, TappedEventArgs e)
     {
         await Shell.Current.GoToAsync("//home");
+    }
+
+    private void OnOpenMenuTapped(object? sender, TappedEventArgs e)
+    {
+        if (Shell.Current is not null)
+        {
+            Shell.Current.FlyoutIsPresented = true;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- streamline the start page around the mode quick selection with refreshed, larger tiles
- add custom headers with a right-aligned flyout toggle and move the mode back action into the header
- wire up code-behind handlers so both pages can open the shell menu from the new header controls

## Testing
- dotnet build *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ecaf025ca4832ab2fef043738bd894