### PR TITLE
Hide duplicated navigation chrome on mode pages

### DIFF
--- a/Password Phrase Producer/StartPage.xaml
+++ b/Password Phrase Producer/StartPage.xaml
@@ -3,7 +3,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:Password_Phrase_Producer"
              x:Class="Password_Phrase_Producer.StartPage"
-             Padding="0">
+             Padding="0"
+             Shell.NavBarIsVisible="False">
     <ContentPage.Background>
         <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
             <GradientStop Color="#121212" Offset="0" />

--- a/Password Phrase Producer/Views/ModeHostPage.xaml
+++ b/Password Phrase Producer/Views/ModeHostPage.xaml
@@ -2,7 +2,8 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Password_Phrase_Producer.Views.ModeHostPage"
-             Padding="0">
+             Padding="0"
+             Shell.NavBarIsVisible="False">
     <ContentPage.Background>
         <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
             <GradientStop Color="#101018" Offset="0" />
@@ -36,15 +37,12 @@
             </Border>
 
             <VerticalStackLayout Grid.Column="1"
-                                  Spacing="2"
+                                  Spacing="0"
                                   VerticalOptions="Center">
                 <Label Text="{Binding Title}"
                        FontSize="24"
                        FontAttributes="Bold"
                        TextColor="White"/>
-                <Label Text="Modusübersicht"
-                       FontSize="14"
-                       TextColor="#9EA3C4"/>
             </VerticalStackLayout>
 
             <Border Grid.Column="2"


### PR DESCRIPTION
## Summary
- hide the default Shell navigation bar on StartPage and ModeHostPage so only the custom header shows
- remove the redundant subtitle from the mode header to keep a single heading alongside the back button and menu

## Testing
- attempted `dotnet build "Password Phrase Producer/PasswordPhraseProducer.csproj"` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ecc4197914832aaf209d1d188ce673