### PR TITLE
Improve UI layouts for mode cards and inputs

### DIFF
--- a/Password Phrase Producer/StartPage.xaml
+++ b/Password Phrase Producer/StartPage.xaml
@@ -75,7 +75,7 @@
                         <Border Padding="0"
                                 StrokeThickness="0"
                                 Margin="0,0,0,6"
-                                HeightRequest="168">
+                                MinimumHeightRequest="168">
                             <Border.StrokeShape>
                                 <RoundRectangle CornerRadius="30" />
                             </Border.StrokeShape>
@@ -131,7 +131,7 @@
                                            FontSize="15"
                                            TextColor="#C8CBDF"
                                            LineBreakMode="WordWrap"
-                                           MaxLines="2"
+                                           MaxLines="3"
                                            VerticalTextAlignment="Center"/>
                                     <Border Grid.Column="1"
                                             WidthRequest="44"

--- a/Password Phrase Producer/Views/ModeHostPage.xaml
+++ b/Password Phrase Producer/Views/ModeHostPage.xaml
@@ -13,6 +13,7 @@
     </ContentPage.Background>
     <Grid RowDefinitions="Auto,*">
         <Grid RowSpacing="6"
+              ColumnSpacing="18"
               ColumnDefinitions="Auto,*,Auto"
               Padding="24,48,24,24">
             <Border WidthRequest="52"
@@ -38,11 +39,13 @@
 
             <VerticalStackLayout Grid.Column="1"
                                   Spacing="0"
-                                  VerticalOptions="Center">
+                                  VerticalOptions="Center"
+                                  HorizontalOptions="Center">
                 <Label Text="{Binding Title}"
                        FontSize="24"
                        FontAttributes="Bold"
-                       TextColor="White"/>
+                       TextColor="White"
+                       HorizontalTextAlignment="Center"/>
             </VerticalStackLayout>
 
             <Border Grid.Column="2"

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/ConcatenationTechniquesUiPage.xaml
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/ConcatenationTechniquesUiPage.xaml
@@ -18,15 +18,18 @@
                        TextColor="#BDC2E8"
                        FontSize="14"
                        LineBreakMode="WordWrap"/>
+                <Label x:Name="phraseCountLabel"
+                       Text="Phrasen (0)"
+                       TextColor="#8F95C6"
+                       FontSize="13"/>
                 <Border StrokeThickness="0"
                         BackgroundColor="#15192A"
-                        Padding="12">
+                        Padding="16">
                     <Border.StrokeShape>
                         <RoundRectangle CornerRadius="18" />
                     </Border.StrokeShape>
-                    <ScrollView HeightRequest="240">
-                        <VerticalStackLayout x:Name="phraseContainer" Spacing="10" />
-                    </ScrollView>
+                    <VerticalStackLayout x:Name="phraseContainer"
+                                          Spacing="14" />
                 </Border>
                 <Button Text="Eintrag hinzufügen"
                         Style="{StaticResource PrimaryActionButtonStyle}"

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/ConcatenationTechniquesUiPage.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/ConcatenationTechniquesUiPage.xaml.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Graphics;
 using Password_Phrase_Producer.PasswordGenerationTechniques.ConcatenationTechniques;
 
 namespace Password_Phrase_Producer.Windows.PasswordGenerationWindows;
@@ -19,11 +21,14 @@ public partial class ConcatenationTechniquesUiPage : ContentView
         {
             phraseContainer.Children.Add(CreatePhraseEntry());
         }
+
+        UpdatePhraseEntryIndices();
     }
 
     private void OnAddNewTextField(object? sender, EventArgs e)
     {
         phraseContainer.Children.Add(CreatePhraseEntry());
+        UpdatePhraseEntryIndices();
     }
 
     private async void OnCopyClicked(object sender, EventArgs e)
@@ -45,7 +50,7 @@ public partial class ConcatenationTechniquesUiPage : ContentView
 
         foreach (var child in phraseContainer.Children)
         {
-            if (child is Entry entry && !string.IsNullOrWhiteSpace(entry.Text))
+            if (TryGetEntry(child, out var entry) && !string.IsNullOrWhiteSpace(entry.Text))
             {
                 phrases.Add(entry.Text);
             }
@@ -60,9 +65,34 @@ public partial class ConcatenationTechniquesUiPage : ContentView
 
     private View CreatePhraseEntry()
     {
+        var indexLabel = new Label
+        {
+            Text = "1",
+            FontSize = 16,
+            FontAttributes = FontAttributes.Bold,
+            TextColor = Colors.White,
+            HorizontalTextAlignment = TextAlignment.Center,
+            VerticalTextAlignment = TextAlignment.Center
+        };
+
+        var indexBorder = new Border
+        {
+            WidthRequest = 38,
+            HeightRequest = 38,
+            BackgroundColor = Color.FromArgb("#2F3452"),
+            StrokeThickness = 0,
+            HorizontalOptions = LayoutOptions.Center,
+            VerticalOptions = LayoutOptions.Center,
+            Content = indexLabel
+        };
+
+        indexBorder.StrokeShape = new RoundRectangle { CornerRadius = 14 };
+
         var entry = new Entry
         {
-            Placeholder = "Phrase"
+            Placeholder = "Phrase",
+            HorizontalOptions = LayoutOptions.Fill,
+            VerticalOptions = LayoutOptions.Center
         };
 
         if (Application.Current?.Resources.TryGetValue("DarkEntryStyle", out var styleObj) == true && styleObj is Style style)
@@ -70,6 +100,95 @@ public partial class ConcatenationTechniquesUiPage : ContentView
             entry.Style = style;
         }
 
-        return entry;
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = GridLength.Auto },
+                new ColumnDefinition { Width = GridLength.Star }
+            },
+            ColumnSpacing = 16,
+            RowDefinitions =
+            {
+                new RowDefinition { Height = GridLength.Auto }
+            },
+            Padding = new Thickness(0),
+            VerticalOptions = LayoutOptions.Fill
+        };
+
+        grid.Children.Add(indexBorder);
+        Grid.SetColumn(indexBorder, 0);
+
+        grid.Children.Add(entry);
+        Grid.SetColumn(entry, 1);
+
+        return grid;
+    }
+
+    private static bool TryGetEntry(View container, out Entry? entry)
+    {
+        switch (container)
+        {
+            case Entry directEntry:
+                entry = directEntry;
+                return true;
+            case Grid grid:
+                foreach (var child in grid.Children)
+                {
+                    if (TryGetEntry(child, out entry))
+                    {
+                        return true;
+                    }
+                }
+
+                entry = null;
+                return false;
+            case Layout layout:
+                foreach (var child in layout.Children)
+                {
+                    if (TryGetEntry(child, out entry))
+                    {
+                        return true;
+                    }
+                }
+
+                entry = null;
+                return false;
+            case Border border when border.Content is View view:
+                return TryGetEntry(view, out entry);
+            default:
+                entry = null;
+                return false;
+        }
+    }
+
+    private void UpdatePhraseEntryIndices()
+    {
+        int index = 1;
+
+        foreach (var child in phraseContainer.Children)
+        {
+            if (child is Grid grid)
+            {
+                foreach (var element in grid.Children)
+                {
+                    if (element is Border badge && badge.Content is Label badgeLabel)
+                    {
+                        badgeLabel.Text = index.ToString();
+                    }
+                    else if (element is Entry entry)
+                    {
+                        entry.Placeholder = $"Phrase {index}";
+                    }
+                }
+            }
+
+            index++;
+        }
+
+        if (phraseCountLabel is not null)
+        {
+            phraseCountLabel.Text = $"Phrasen ({phraseContainer.Children.Count})";
+        }
     }
 }

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/TbvUiPage.xaml
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/TbvUiPage.xaml
@@ -21,25 +21,24 @@
                 <Entry x:Name="passwordEntry"
                        Placeholder="Password Phrase"
                        Style="{StaticResource DarkEntryStyle}" />
-                <Grid ColumnDefinitions="*,*"
-                      ColumnSpacing="12"
-                      RowSpacing="12">
+                <Label Text="Bitte gib alle drei numerischen Codes ein, um die TBV-Varianten korrekt zu nutzen."
+                       TextColor="#8F95C6"
+                       FontSize="13"
+                       LineBreakMode="WordWrap"/>
+                <VerticalStackLayout Spacing="12">
                     <Entry x:Name="code1Entry"
                            Placeholder="Code 1"
                            Keyboard="Numeric"
                            Style="{StaticResource DarkEntryStyle}" />
-                    <Entry Grid.Column="1"
-                           x:Name="code2Entry"
+                    <Entry x:Name="code2Entry"
                            Placeholder="Code 2"
                            Keyboard="Numeric"
                            Style="{StaticResource DarkEntryStyle}" />
-                    <Entry Grid.ColumnSpan="2"
-                           Grid.Row="1"
-                           x:Name="code3Entry"
-                           Placeholder="Code 3 (optional)"
+                    <Entry x:Name="code3Entry"
+                           Placeholder="Code 3"
                            Keyboard="Numeric"
                            Style="{StaticResource DarkEntryStyle}" />
-                </Grid>
+                </VerticalStackLayout>
             </VerticalStackLayout>
         </Border>
 


### PR DESCRIPTION
## Summary
- allow mode selection cards to grow vertically so descriptions are no longer clipped
- center the active mode title and adjust spacing for the host toolbar
- rework TBV input fields to present three numeric codes in a single column with guidance
- redesign the alternate words list to number entries, remove the inner scroll view, and display a running total

## Testing
- dotnet build *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ece2f42cd0832a93e4733f5fbf0211