### PR TITLE
Fix MAUI view lookup to support IView children

### DIFF
--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/ConcatenationTechniquesUiPage.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/ConcatenationTechniquesUiPage.xaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Shapes;
 using Microsoft.Maui.Graphics;
@@ -125,7 +126,7 @@ public partial class ConcatenationTechniquesUiPage : ContentView
         return grid;
     }
 
-    private static bool TryGetEntry(View container, out Entry? entry)
+    private static bool TryGetEntry(IView container, out Entry? entry)
     {
         switch (container)
         {
@@ -154,7 +155,7 @@ public partial class ConcatenationTechniquesUiPage : ContentView
 
                 entry = null;
                 return false;
-            case Border border when border.Content is View view:
+            case Border border when border.Content is IView view:
                 return TryGetEntry(view, out entry);
             default:
                 entry = null;


### PR DESCRIPTION
## Summary
- update the concatenation techniques view helper to accept `IView` children when searching for entries
- ensure border content pattern matching operates on `IView` to align with .NET 8 MAUI APIs

## Testing
- `dotnet build "Password Phrase Producer/Password Phrase Producer.sln"` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ecf4d5e9f8832aa8f91442b46e1ec3