### PR TITLE
Fix Android publish path in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,6 @@ jobs:
 
           dotnet publish "${{ env.PROJECT_PATH }}" `
             -c $env:CONFIGURATION `
-            --no-build `
             -f net8.0-android `
             -p:RunAnalyzers=false `
             -p:GenerateDocumentationFile=false `
@@ -140,7 +139,6 @@ jobs:
         run: |
           dotnet publish "${{ env.PROJECT_PATH }}" `
             -c $env:CONFIGURATION `
-            --no-build `
             -f net8.0-windows10.0.19041.0 `
             -p:RuntimeIdentifier=win10-x64 `
             -p:WindowsPackageType=None `

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
 env:
   DOTNET_VERSION: 8.0.x
   SOLUTION_PATH: ./Password Phrase Producer/Password Phrase Producer.sln
+  PROJECT_PATH: ./Password Phrase Producer/PasswordPhraseProducer.csproj
   VERSION_PREFIX: 1.0
   VERSION: 1.0.${{ github.run_number }}
   APP_BUILD: ${{ github.run_number }}
@@ -94,7 +95,7 @@ jobs:
             Write-Host "::warning::Android keystore not provided. APK will be unsigned."
           }
 
-          dotnet publish "${{ env.SOLUTION_PATH }}" `
+          dotnet publish "${{ env.PROJECT_PATH }}" `
             -c $env:CONFIGURATION `
             --no-build `
             -f net8.0-android `
@@ -137,7 +138,7 @@ jobs:
         if: ${{ matrix.target == 'windows' }}
         shell: pwsh
         run: |
-          dotnet publish "${{ env.SOLUTION_PATH }}" `
+          dotnet publish "${{ env.PROJECT_PATH }}" `
             -c $env:CONFIGURATION `
             --no-build `
             -f net8.0-windows10.0.19041.0 `


### PR DESCRIPTION
## Summary
- target the project file rather than the solution when publishing Android and Windows artifacts in the build workflow
- add a workflow environment variable for the MAUI project path to reuse across publish steps

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68ed4ac4ae10832a91044fd5e2d1acbf