### PR TITLE
Grant release workflow permission to publish releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,9 @@ env:
   APP_BUILD: ${{ github.run_number }}
   WINDOWS_PACKAGE_VERSION: 1.0.${{ github.run_number }}.0
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Build ${{ matrix.target }} package


### PR DESCRIPTION
## Summary
- grant the build workflow contents: write permissions so the GitHub token can create releases with action-gh-release

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68ede4316110832a84bac85ad1fb4681