### PR TITLE
Pin .NET SDK to 8.0 for CI builds

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.403",
+    "rollForward": "latestPatch"
+  }
+}


### PR DESCRIPTION
## Summary
- add a global.json to require the .NET 8.0 SDK for builds
- prevent CI from using the .NET 9 SDK that reports MAUI 8.0 workloads as EOL

## Testing
- not run (no .NET SDK available in container)

------
https://chatgpt.com/codex/tasks/task_e_68ede8085d6c832a82aede8e7a02ba85