### PR TITLE
Ensure NuGet lock file is present for pipeline caching

### DIFF
--- a/Password Phrase Producer/PasswordPhraseProducer.csproj
+++ b/Password Phrase Producer/PasswordPhraseProducer.csproj
@@ -16,8 +16,9 @@
 		<OutputType>Exe</OutputType>
 		<RootNamespace>Password_Phrase_Producer</RootNamespace>
 		<UseMaui>true</UseMaui>
-		<SingleProject>true</SingleProject>
-		<ImplicitUsings>enable</ImplicitUsings>
+                <SingleProject>true</SingleProject>
+                <ImplicitUsings>enable</ImplicitUsings>
+                <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
 		<Nullable>enable</Nullable>
 
 		<!-- Display name -->

--- a/packages.lock.json
+++ b/packages.lock.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "dependencies": {}
+}


### PR DESCRIPTION
## Summary
- enable lock file generation in the MAUI project so CI can produce packages.lock.json
- add an initial packages.lock.json placeholder for the dependency cache step

## Testing
- not run (dotnet CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68ef97728dd4832aa12995a7db63eef3