### PR TITLE
Fix framework argument usage in CI restore steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,12 +61,12 @@ jobs:
       - name: Restore Android dependencies
         if: ${{ matrix.target == 'android' }}
         shell: pwsh
-        run: dotnet restore "${{ env.PROJECT_PATH }}" -f net8.0-android
+        run: dotnet restore "${{ env.PROJECT_PATH }}" --framework net8.0-android
 
       - name: Restore Windows dependencies
         if: ${{ matrix.target == 'windows' }}
         shell: pwsh
-        run: dotnet restore "${{ env.PROJECT_PATH }}" -f net8.0-windows10.0.19041.0
+        run: dotnet restore "${{ env.PROJECT_PATH }}" --framework net8.0-windows10.0.19041.0
 
       - name: Publish Android APK
         if: ${{ matrix.target == 'android' }}


### PR DESCRIPTION
## Summary
- replace incorrect `-f` force flag usage with `--framework` when restoring Android and Windows dependencies
- ensure the CI workflow targets the intended frameworks without triggering MSBuild errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f00f1cea20832a9b07e4b8bddef38b