### PR TITLE
Add entropy analyzer service and strength visualizations

### DIFF
--- a/Password Phrase Producer/Services/EntropyAnalyzer/EntropyAnalysisResult.cs
+++ b/Password Phrase Producer/Services/EntropyAnalyzer/EntropyAnalysisResult.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+
+namespace Password_Phrase_Producer.Services.EntropyAnalyzer;
+
+public sealed record CharacterBreakdown(int Uppercase, int Lowercase, int Digits, int Symbols, int Spaces);
+
+public sealed record EntropyAnalysisResult(
+    string Password,
+    int Length,
+    double Entropy,
+    double StrengthScore,
+    string StrengthLabel,
+    int CharacterSetSize,
+    int CharacterGroupCount,
+    CharacterBreakdown Breakdown,
+    IReadOnlyList<string> Suggestions)
+{
+    public static EntropyAnalysisResult Empty { get; } = new(
+        string.Empty,
+        0,
+        0,
+        0,
+        "Unbewertet",
+        0,
+        0,
+        new CharacterBreakdown(0, 0, 0, 0, 0),
+        Array.Empty<string>());
+}

--- a/Password Phrase Producer/Services/EntropyAnalyzer/IPasswordEntropyAnalyzer.cs
+++ b/Password Phrase Producer/Services/EntropyAnalyzer/IPasswordEntropyAnalyzer.cs
@@ -1,0 +1,6 @@
+namespace Password_Phrase_Producer.Services.EntropyAnalyzer;
+
+public interface IPasswordEntropyAnalyzer
+{
+    EntropyAnalysisResult Analyze(string password);
+}

--- a/Password Phrase Producer/Services/EntropyAnalyzer/PasswordEntropyAnalyzer.cs
+++ b/Password Phrase Producer/Services/EntropyAnalyzer/PasswordEntropyAnalyzer.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Collections.Generic;
+
+namespace Password_Phrase_Producer.Services.EntropyAnalyzer;
+
+public sealed class PasswordEntropyAnalyzer : IPasswordEntropyAnalyzer
+{
+    private const double TargetEntropy = 120d;
+    private const double MaxLengthReference = 24d;
+
+    public EntropyAnalysisResult Analyze(string password)
+    {
+        if (string.IsNullOrWhiteSpace(password))
+        {
+            return EntropyAnalysisResult.Empty;
+        }
+
+        var normalizedPassword = password;
+        int length = normalizedPassword.Length;
+
+        int uppercase = 0;
+        int lowercase = 0;
+        int digits = 0;
+        int symbols = 0;
+        int spaces = 0;
+
+        var uniqueCharacters = new HashSet<char>();
+
+        foreach (var c in normalizedPassword)
+        {
+            uniqueCharacters.Add(c);
+
+            if (char.IsUpper(c))
+            {
+                uppercase++;
+            }
+            else if (char.IsLower(c))
+            {
+                lowercase++;
+            }
+            else if (char.IsDigit(c))
+            {
+                digits++;
+            }
+            else if (char.IsWhiteSpace(c))
+            {
+                spaces++;
+            }
+            else
+            {
+                symbols++;
+            }
+        }
+
+        int characterSetSize = CalculateCharacterSpace(uppercase, lowercase, digits, symbols, uniqueCharacters.Count);
+        int characterGroups = CountCharacterGroups(uppercase, lowercase, digits, symbols);
+
+        double entropy = CalculateEntropy(length, characterSetSize);
+        double score = CalculateScore(entropy, length, characterGroups);
+        string strengthLabel = GetStrengthLabel(score);
+
+        var suggestions = BuildSuggestions(length, uppercase, lowercase, digits, symbols, uniqueCharacters.Count);
+
+        var breakdown = new CharacterBreakdown(uppercase, lowercase, digits, symbols, spaces);
+
+        return new EntropyAnalysisResult(
+            normalizedPassword,
+            length,
+            Math.Round(entropy, 2, MidpointRounding.AwayFromZero),
+            Math.Round(score, 1, MidpointRounding.AwayFromZero),
+            strengthLabel,
+            characterSetSize,
+            characterGroups,
+            breakdown,
+            suggestions);
+    }
+
+    private static int CalculateCharacterSpace(int uppercase, int lowercase, int digits, int symbols, int uniqueCharacterCount)
+    {
+        int space = 0;
+
+        if (uppercase > 0)
+        {
+            space += 26;
+        }
+
+        if (lowercase > 0)
+        {
+            space += 26;
+        }
+
+        if (digits > 0)
+        {
+            space += 10;
+        }
+
+        if (symbols > 0)
+        {
+            space += 33;
+        }
+
+        // Reward diversity of actual characters without double counting whitespace.
+        if (space == 0 && uniqueCharacterCount > 0)
+        {
+            space = uniqueCharacterCount;
+        }
+
+        return Math.Max(space, 1);
+    }
+
+    private static int CountCharacterGroups(int uppercase, int lowercase, int digits, int symbols)
+    {
+        int groups = 0;
+
+        if (uppercase > 0)
+        {
+            groups++;
+        }
+
+        if (lowercase > 0)
+        {
+            groups++;
+        }
+
+        if (digits > 0)
+        {
+            groups++;
+        }
+
+        if (symbols > 0)
+        {
+            groups++;
+        }
+
+        return groups;
+    }
+
+    private static double CalculateEntropy(int length, int characterSetSize)
+    {
+        if (length == 0 || characterSetSize <= 1)
+        {
+            return 0d;
+        }
+
+        return length * Math.Log(characterSetSize, 2);
+    }
+
+    private static double CalculateScore(double entropy, int length, int characterGroups)
+    {
+        double entropyComponent = Math.Min(entropy / TargetEntropy, 1d);
+        double lengthComponent = Math.Min(length / MaxLengthReference, 1d);
+        double varietyComponent = Math.Min(characterGroups / 4d, 1d);
+
+        double weighted = (entropyComponent * 0.5) + (lengthComponent * 0.2) + (varietyComponent * 0.3);
+
+        return weighted * 100d;
+    }
+
+    private static string GetStrengthLabel(double score)
+    {
+        if (score >= 80d)
+        {
+            return "Stark";
+        }
+
+        if (score >= 55d)
+        {
+            return "Solide";
+        }
+
+        return "Schwach";
+    }
+
+    private static IReadOnlyList<string> BuildSuggestions(
+        int length,
+        int uppercase,
+        int lowercase,
+        int digits,
+        int symbols,
+        int uniqueCharacters)
+    {
+        var suggestions = new List<string>();
+
+        if (length < 12)
+        {
+            suggestions.Add("Verlängere die Passphrase auf mindestens 12 Zeichen.");
+        }
+
+        if (uppercase == 0)
+        {
+            suggestions.Add("Füge Großbuchstaben hinzu, um den Zeichensatz zu erweitern.");
+        }
+
+        if (lowercase == 0)
+        {
+            suggestions.Add("Integriere Kleinbuchstaben für eine bessere Mischung.");
+        }
+
+        if (digits == 0)
+        {
+            suggestions.Add("Nutze Ziffern, um mehr Kombinationen zu ermöglichen.");
+        }
+
+        if (symbols == 0)
+        {
+            suggestions.Add("Sonderzeichen erhöhen die Komplexität deutlich.");
+        }
+
+        if (uniqueCharacters < length / 2)
+        {
+            suggestions.Add("Vermeide zu viele Wiederholungen von Zeichen.");
+        }
+
+        if (suggestions.Count == 0)
+        {
+            suggestions.Add("Großartig! Deine Passphrase wirkt bereits sehr robust.");
+        }
+
+        return suggestions;
+    }
+}

--- a/Password Phrase Producer/Services/ModeCatalog.cs
+++ b/Password Phrase Producer/Services/ModeCatalog.cs
@@ -3,53 +3,56 @@ using Password_Phrase_Producer.PasswordGenerationTechniques.ConcatenationTechniq
 using Password_Phrase_Producer.PasswordGenerationTechniques.HashBasedTechniques;
 using Password_Phrase_Producer.Windows.PasswordGenerationWindows;
 using PasswordPhraseProducer.PasswordGenerationTechniques.TbvTechniques;
+using Password_Phrase_Producer.Services.EntropyAnalyzer;
 
 namespace Password_Phrase_Producer.Services;
 
 public static class ModeCatalog
 {
+    private static readonly IPasswordEntropyAnalyzer EntropyAnalyzer = new PasswordEntropyAnalyzer();
+
     public static IReadOnlyList<PasswordModeOption> AllModes { get; } = new List<PasswordModeOption>
     {
         new(
             "hash-one",
             "1 Word Password",
             "Deterministisches Hash-Verfahren für ein einzelnes Wort.",
-            () => new HachBasedTechniquesUiPage(new DeterministicHashPasswordGenerator()),
+            () => new HachBasedTechniquesUiPage(new DeterministicHashPasswordGenerator(), EntropyAnalyzer),
             "mode-hash-one",
             "🔐"),
         new(
             "alternate",
             "Alternate Words",
             "Kombiniere abwechselnde Wörter zu einer starken Passphrase.",
-            () => new ConcatenationTechniquesUiPage(new AlternatingUpDownChaining()),
+            () => new ConcatenationTechniquesUiPage(new AlternatingUpDownChaining(), EntropyAnalyzer),
             "mode-alternate",
             "🧩"),
         new(
             "tbv1-errors",
             "TBV1 With Errors",
             "Dreifache Verifizierung mit intelligenter Fehlerbehandlung.",
-            () => new TbvUiPage(new TBV1WithErrors()),
+            () => new TbvUiPage(new TBV1WithErrors(), EntropyAnalyzer),
             "mode-tbv1-errors",
             "🛡️"),
         new(
             "tbv1",
             "TBV1",
             "Klassische dreifache Verifizierung für Passphrasen.",
-            () => new TbvUiPage(new TBV1()),
+            () => new TbvUiPage(new TBV1(), EntropyAnalyzer),
             "mode-tbv1",
             "🧱"),
         new(
             "tbv2",
             "TBV2",
             "Erweiterte Verifizierung mit zusätzlichen Sicherheitsstufen.",
-            () => new TbvUiPage(new TBV2()),
+            () => new TbvUiPage(new TBV2(), EntropyAnalyzer),
             "mode-tbv2",
             "⚙️"),
         new(
             "tbv3",
             "TBV3",
             "Modernes Verfahren mit erweiterten Prüfungen und Komfort.",
-            () => new TbvUiPage(new TBV3()),
+            () => new TbvUiPage(new TBV3(), EntropyAnalyzer),
             "mode-tbv3",
             "🚀")
     };

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/ConcatenationTechniquesUiPage.xaml
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/ConcatenationTechniquesUiPage.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:controls="clr-namespace:Password_Phrase_Producer.Windows.PasswordGenerationWindows.Controls"
              x:Class="Password_Phrase_Producer.Windows.PasswordGenerationWindows.ConcatenationTechniquesUiPage">
     <VerticalStackLayout Spacing="24">
         <Border StrokeThickness="0"
@@ -62,6 +63,8 @@
                 <Button Text="Passphrase erzeugen"
                         Style="{StaticResource PrimaryActionButtonStyle}"
                         Clicked="OnCreateClicked" />
+                <controls:PasswordAnalysisPanel x:Name="analysisPanel"
+                                                 IsVisible="False" />
             </VerticalStackLayout>
         </Border>
     </VerticalStackLayout>

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/ConcatenationTechniquesUiPage.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/ConcatenationTechniquesUiPage.xaml.cs
@@ -5,18 +5,23 @@ using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Shapes;
 using Microsoft.Maui.Graphics;
 using Password_Phrase_Producer.PasswordGenerationTechniques.ConcatenationTechniques;
+using Password_Phrase_Producer.Services.EntropyAnalyzer;
 
 namespace Password_Phrase_Producer.Windows.PasswordGenerationWindows;
 
 public partial class ConcatenationTechniquesUiPage : ContentView
 {
     private readonly IConcatenationTechnique concatenationTechnique;
+    private readonly IPasswordEntropyAnalyzer entropyAnalyzer;
     private const int InitialEntryCount = 4;
 
-    public ConcatenationTechniquesUiPage(IConcatenationTechnique concatenationTechnique)
+    public ConcatenationTechniquesUiPage(IConcatenationTechnique concatenationTechnique, IPasswordEntropyAnalyzer entropyAnalyzer)
     {
         InitializeComponent();
         this.concatenationTechnique = concatenationTechnique;
+        this.entropyAnalyzer = entropyAnalyzer;
+
+        analysisPanel?.Reset();
 
         for (int i = 0; i < InitialEntryCount; i++)
         {
@@ -58,9 +63,27 @@ public partial class ConcatenationTechniquesUiPage : ContentView
         }
 
         var result = concatenationTechnique.EncryptPassword(phrases);
+
+        if (string.IsNullOrWhiteSpace(result))
+        {
+            if (resultEntry is not null)
+            {
+                resultEntry.Text = string.Empty;
+            }
+
+            analysisPanel?.Reset();
+            return;
+        }
+
         if (resultEntry is not null)
         {
             resultEntry.Text = result;
+        }
+
+        if (analysisPanel is not null)
+        {
+            var analysis = entropyAnalyzer.Analyze(result);
+            analysisPanel.Update(analysis);
         }
     }
 

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/Controls/PasswordAnalysisPanel.xaml
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/Controls/PasswordAnalysisPanel.xaml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Password_Phrase_Producer.Windows.PasswordGenerationWindows.Controls.PasswordAnalysisPanel">
+    <Border StrokeThickness="0"
+            BackgroundColor="#181B2A"
+            Padding="18"
+            IsVisible="False"
+            x:Name="analysisBorder">
+        <Border.StrokeShape>
+            <RoundRectangle CornerRadius="22" />
+        </Border.StrokeShape>
+        <Border.Shadow>
+            <Shadow Brush="#15000000" Radius="12" Offset="0,6" />
+        </Border.Shadow>
+        <VerticalStackLayout Spacing="16">
+            <Grid ColumnDefinitions="*,Auto"
+                  VerticalOptions="Center">
+                <Label Text="Sicherheitsanalyse"
+                       FontSize="18"
+                       FontAttributes="Bold"
+                       TextColor="White" />
+                <Border Grid.Column="1"
+                        WidthRequest="36"
+                        HeightRequest="36"
+                        StrokeThickness="0"
+                        BackgroundColor="#242C44"
+                        HorizontalOptions="End"
+                        VerticalOptions="Center">
+                    <Border.StrokeShape>
+                        <RoundRectangle CornerRadius="12" />
+                    </Border.StrokeShape>
+                    <Border.GestureRecognizers>
+                        <TapGestureRecognizer Tapped="OnInfoTapped" />
+                    </Border.GestureRecognizers>
+                    <Label Text="ⓘ"
+                           FontSize="18"
+                           HorizontalTextAlignment="Center"
+                           VerticalTextAlignment="Center"
+                           HorizontalOptions="Center"
+                           VerticalOptions="Center"
+                           TextColor="#C5CAFF" />
+                </Border>
+            </Grid>
+
+            <VerticalStackLayout Spacing="12">
+                <VerticalStackLayout Spacing="6">
+                    <Label x:Name="strengthLabel"
+                           Text="Stärke: -"
+                           FontSize="15"
+                           TextColor="#C5CAFF" />
+                    <Grid ColumnDefinitions="Auto,*"
+                          ColumnSpacing="12"
+                          VerticalOptions="Center">
+                        <Label Text="Score"
+                               FontSize="13"
+                               TextColor="#8F95C6"
+                               VerticalOptions="Center" />
+                        <ProgressBar x:Name="strengthBar"
+                                     Grid.Column="1"
+                                     Progress="0"
+                                     HeightRequest="8"
+                                     BackgroundColor="#121426"
+                                     ProgressColor="#63F5A8" />
+                    </Grid>
+                </VerticalStackLayout>
+
+                <Border StrokeThickness="0"
+                        BackgroundColor="#15192A"
+                        Padding="14">
+                    <Border.StrokeShape>
+                        <RoundRectangle CornerRadius="16" />
+                    </Border.StrokeShape>
+                    <VerticalStackLayout Spacing="6">
+                        <Label x:Name="entropyLabel"
+                               Text="Entropie: -"
+                               FontSize="14"
+                               TextColor="#E4E7FF" />
+                        <Label x:Name="characterSetLabel"
+                               Text="Zeichenräume: -"
+                               FontSize="13"
+                               TextColor="#8F95C6" />
+                    </VerticalStackLayout>
+                </Border>
+
+                <Border x:Name="suggestionBorder"
+                        StrokeThickness="0"
+                        BackgroundColor="#14182A"
+                        Padding="14">
+                    <Border.StrokeShape>
+                        <RoundRectangle CornerRadius="16" />
+                    </Border.StrokeShape>
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Verbesserungstipps"
+                               FontSize="14"
+                               TextColor="#E4E7FF"
+                               FontAttributes="Bold" />
+                        <Label x:Name="suggestionsLabel"
+                               Text="-"
+                               FontSize="13"
+                               TextColor="#C5CAFF"
+                               LineBreakMode="WordWrap" />
+                    </VerticalStackLayout>
+                </Border>
+            </VerticalStackLayout>
+        </VerticalStackLayout>
+    </Border>
+</ContentView>

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/Controls/PasswordAnalysisPanel.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/Controls/PasswordAnalysisPanel.xaml.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Linq;
+using System.Text;
+using Microsoft.Maui.Controls;
+using Password_Phrase_Producer.Services.EntropyAnalyzer;
+
+namespace Password_Phrase_Producer.Windows.PasswordGenerationWindows.Controls;
+
+public partial class PasswordAnalysisPanel : ContentView
+{
+    private EntropyAnalysisResult? currentResult;
+
+    public PasswordAnalysisPanel()
+    {
+        InitializeComponent();
+    }
+
+    public void Update(EntropyAnalysisResult analysisResult)
+    {
+        currentResult = analysisResult;
+
+        strengthLabel.Text = $"Stärke: {analysisResult.StrengthLabel} ({analysisResult.StrengthScore:F0}%)";
+        strengthBar.Progress = Math.Clamp(analysisResult.StrengthScore / 100d, 0d, 1d);
+        entropyLabel.Text = $"Entropie: {analysisResult.Entropy:F1} Bit";
+        characterSetLabel.Text = $"Zeichenräume: {analysisResult.CharacterSetSize} · Gruppen: {analysisResult.CharacterGroupCount}";
+
+        if (analysisResult.Suggestions.Count > 0)
+        {
+            suggestionsLabel.Text = string.Join("\n", analysisResult.Suggestions.Select(s => $"• {s}"));
+            suggestionBorder.IsVisible = true;
+        }
+        else
+        {
+            suggestionBorder.IsVisible = false;
+            suggestionsLabel.Text = string.Empty;
+        }
+
+        analysisBorder.IsVisible = true;
+        IsVisible = true;
+    }
+
+    public void Reset()
+    {
+        currentResult = null;
+        analysisBorder.IsVisible = false;
+        IsVisible = false;
+        strengthBar.Progress = 0;
+        strengthLabel.Text = "Stärke: -";
+        entropyLabel.Text = "Entropie: -";
+        characterSetLabel.Text = "Zeichenräume: -";
+        suggestionsLabel.Text = string.Empty;
+        suggestionBorder.IsVisible = false;
+    }
+
+    private async void OnInfoTapped(object? sender, EventArgs e)
+    {
+        if (currentResult is null)
+        {
+            return;
+        }
+
+        var breakdown = currentResult.Breakdown;
+        var builder = new StringBuilder();
+        builder.AppendLine($"Passwortlänge: {currentResult.Length}");
+        builder.AppendLine($"Entropie: {currentResult.Entropy:F2} Bit");
+        builder.AppendLine($"Zeichensatz: {currentResult.CharacterSetSize} mögliche Zeichen");
+        builder.AppendLine();
+        builder.AppendLine("Zeichenklassen:");
+        builder.AppendLine($"  • Großbuchstaben: {breakdown.Uppercase}");
+        builder.AppendLine($"  • Kleinbuchstaben: {breakdown.Lowercase}");
+        builder.AppendLine($"  • Ziffern: {breakdown.Digits}");
+        builder.AppendLine($"  • Sonderzeichen: {breakdown.Symbols}");
+        builder.AppendLine($"  • Leerzeichen: {breakdown.Spaces}");
+
+        string details = builder.ToString();
+
+        if (Application.Current?.MainPage is not null)
+        {
+            await Application.Current.MainPage.DisplayAlert("Detaillierte Analyse", details, "Schließen");
+        }
+    }
+}

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/HachBasedTechniquesUiPage.xaml
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/HachBasedTechniquesUiPage.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:controls="clr-namespace:Password_Phrase_Producer.Windows.PasswordGenerationWindows.Controls"
              x:Class="Password_Phrase_Producer.Windows.PasswordGenerationWindows.HachBasedTechniquesUiPage">
     <VerticalStackLayout Spacing="24">
         <Border StrokeThickness="0"
@@ -49,6 +50,8 @@
                 <Button Text="Hash erzeugen"
                         Style="{StaticResource PrimaryActionButtonStyle}"
                         Clicked="OnCreateClicked" />
+                <controls:PasswordAnalysisPanel x:Name="analysisPanel"
+                                                 IsVisible="False" />
             </VerticalStackLayout>
         </Border>
     </VerticalStackLayout>

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/HachBasedTechniquesUiPage.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/HachBasedTechniquesUiPage.xaml.cs
@@ -1,17 +1,22 @@
 using System;
 using Microsoft.Maui.Controls;
 using Password_Phrase_Producer.PasswordGenerationTechniques.HashBasedTechniques;
+using Password_Phrase_Producer.Services.EntropyAnalyzer;
 
 namespace Password_Phrase_Producer.Windows.PasswordGenerationWindows;
 
 public partial class HachBasedTechniquesUiPage : ContentView
 {
     private readonly IHashBasedTechniques hashBasedTechnique;
+    private readonly IPasswordEntropyAnalyzer entropyAnalyzer;
 
-    public HachBasedTechniquesUiPage(IHashBasedTechniques hashBasedTechnique)
+    public HachBasedTechniquesUiPage(IHashBasedTechniques hashBasedTechnique, IPasswordEntropyAnalyzer entropyAnalyzer)
     {
         InitializeComponent();
         this.hashBasedTechnique = hashBasedTechnique;
+        this.entropyAnalyzer = entropyAnalyzer;
+
+        analysisPanel?.Reset();
     }
 
     private void OnCreateClicked(object sender, EventArgs e)
@@ -25,6 +30,12 @@ public partial class HachBasedTechniquesUiPage : ContentView
             {
                 resultEntry.Text = result;
             }
+
+            if (analysisPanel is not null)
+            {
+                var analysis = entropyAnalyzer.Analyze(result);
+                analysisPanel.Update(analysis);
+            }
         }
         else
         {
@@ -32,6 +43,8 @@ public partial class HachBasedTechniquesUiPage : ContentView
             {
                 resultEntry.Text = string.Empty;
             }
+
+            analysisPanel?.Reset();
         }
     }
 

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/TbvUiPage.xaml
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/TbvUiPage.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:controls="clr-namespace:Password_Phrase_Producer.Windows.PasswordGenerationWindows.Controls"
              x:Class="Password_Phrase_Producer.Windows.PasswordGenerationWindows.TbvUiPage">
     <VerticalStackLayout Spacing="24">
         <Border StrokeThickness="0"
@@ -67,6 +68,8 @@
                 <Button Text="TBV generieren"
                         Style="{StaticResource PrimaryActionButtonStyle}"
                         Clicked="OnCreateClicked" />
+                <controls:PasswordAnalysisPanel x:Name="analysisPanel"
+                                                 IsVisible="False" />
             </VerticalStackLayout>
         </Border>
     </VerticalStackLayout>

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/TbvUiPage.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/TbvUiPage.xaml.cs
@@ -1,17 +1,22 @@
 using System;
 using Microsoft.Maui.Controls;
 using Password_Phrase_Producer.PasswordGenerationTechniques.TbvTechniques;
+using Password_Phrase_Producer.Services.EntropyAnalyzer;
 
 namespace Password_Phrase_Producer.Windows.PasswordGenerationWindows;
 
 public partial class TbvUiPage : ContentView
 {
     private readonly Itbv tbv;
+    private readonly IPasswordEntropyAnalyzer entropyAnalyzer;
 
-    public TbvUiPage(Itbv itbv)
+    public TbvUiPage(Itbv itbv, IPasswordEntropyAnalyzer entropyAnalyzer)
     {
         InitializeComponent();
         tbv = itbv;
+        this.entropyAnalyzer = entropyAnalyzer;
+
+        analysisPanel?.Reset();
     }
 
     private void OnCreateClicked(object sender, EventArgs e)
@@ -35,6 +40,12 @@ public partial class TbvUiPage : ContentView
             {
                 resultEntry.Text = result;
             }
+
+            if (analysisPanel is not null)
+            {
+                var analysis = entropyAnalyzer.Analyze(result);
+                analysisPanel.Update(analysis);
+            }
         }
         else
         {
@@ -42,6 +53,8 @@ public partial class TbvUiPage : ContentView
             {
                 resultEntry.Text = string.Empty;
             }
+
+            analysisPanel?.Reset();
         }
     }
 


### PR DESCRIPTION
## Summary
- add a password entropy analyzer service that exposes strength metrics and actionable suggestions
- embed a reusable analysis panel on each password generation page to show strength bars and improvement tips
- add info popups with detailed character breakdowns for generated passwords across all modes

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f2a8818824832a82ccfa61a1a2c2ba