### PR TITLE
Add encrypted password vault with backup and sync support

### DIFF
--- a/Password Phrase Producer/AppShell.xaml
+++ b/Password Phrase Producer/AppShell.xaml
@@ -4,6 +4,7 @@
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:local="clr-namespace:Password_Phrase_Producer"
+    xmlns:views="clr-namespace:Password_Phrase_Producer.Views"
     Title="Password Phrase Producer"
     FlyoutBackgroundColor="#1A1A1A">
 
@@ -13,6 +14,14 @@
         <ShellContent
             Title="Startseite"
             ContentTemplate="{DataTemplate local:StartPage}" />
+    </FlyoutItem>
+
+    <FlyoutItem Title="Tresor"
+                Route="vault"
+                FlyoutDisplayOptions="AsSingleItem">
+        <ShellContent
+            Title="Tresor"
+            ContentTemplate="{DataTemplate views:VaultPage}" />
     </FlyoutItem>
 
 </Shell>

--- a/Password Phrase Producer/MauiProgram.cs
+++ b/Password Phrase Producer/MauiProgram.cs
@@ -1,25 +1,39 @@
-﻿using Microsoft.Extensions.Logging;
+using CommunityToolkit.Maui;
+using Microsoft.Extensions.Logging;
+using Password_Phrase_Producer.Services.Vault;
+using Password_Phrase_Producer.ViewModels;
+using Password_Phrase_Producer.Views;
 
-namespace Password_Phrase_Producer
+namespace Password_Phrase_Producer;
+
+public static class MauiProgram
 {
-    public static class MauiProgram
+    public static MauiApp CreateMauiApp()
     {
-        public static MauiApp CreateMauiApp()
-        {
-            var builder = MauiApp.CreateBuilder();
-            builder
-                .UseMauiApp<App>()
-                .ConfigureFonts(fonts =>
-                {
-                    fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
-                    fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
-                });
+        var builder = MauiApp.CreateBuilder();
+        builder
+            .UseMauiApp<App>()
+            .UseMauiCommunityToolkit()
+            .ConfigureFonts(fonts =>
+            {
+                fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
+                fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
+            });
 
 #if DEBUG
-    		builder.Logging.AddDebug();
+        builder.Logging.AddDebug();
 #endif
 
-            return builder.Build();
-        }
+        builder.Services.AddSingleton<PasswordVaultService>();
+        builder.Services.AddTransient<VaultPageViewModel>();
+        builder.Services.AddTransient<VaultPage>();
+        builder.Services.AddTransient<VaultEntryEditorPage>();
+
+        var app = builder.Build();
+
+        var vaultService = app.Services.GetService<PasswordVaultService>();
+        vaultService?.EnsureInitializedAsync().GetAwaiter().GetResult();
+
+        return app;
     }
 }

--- a/Password Phrase Producer/Models/PasswordVaultBackupDto.cs
+++ b/Password Phrase Producer/Models/PasswordVaultBackupDto.cs
@@ -1,0 +1,12 @@
+namespace Password_Phrase_Producer.Models;
+
+public class PasswordVaultBackupDto
+{
+    public string EncryptionKey { get; set; } = string.Empty;
+
+    public string FileName { get; set; } = "vault.json.enc";
+
+    public string CipherText { get; set; } = string.Empty;
+
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+}

--- a/Password Phrase Producer/Models/PasswordVaultEntry.cs
+++ b/Password Phrase Producer/Models/PasswordVaultEntry.cs
@@ -1,0 +1,43 @@
+using System.Text.Json.Serialization;
+
+namespace Password_Phrase_Producer.Models;
+
+public class PasswordVaultEntry
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public string Label { get; set; } = string.Empty;
+
+    public string Username { get; set; } = string.Empty;
+
+    public string Password { get; set; } = string.Empty;
+
+    public string Category { get; set; } = string.Empty;
+
+    public string Url { get; set; } = string.Empty;
+
+    public string Notes { get; set; } = string.Empty;
+
+    public string FreeText { get; set; } = string.Empty;
+
+    public DateTimeOffset ModifiedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    [JsonIgnore]
+    public string DisplayCategory => string.IsNullOrWhiteSpace(Category) ? "Allgemein" : Category.Trim();
+
+    public PasswordVaultEntry Clone()
+    {
+        return new PasswordVaultEntry
+        {
+            Id = Id,
+            Label = Label,
+            Username = Username,
+            Password = Password,
+            Category = Category,
+            Url = Url,
+            Notes = Notes,
+            FreeText = FreeText,
+            ModifiedAt = ModifiedAt
+        };
+    }
+}

--- a/Password Phrase Producer/Models/PasswordVaultEntryDto.cs
+++ b/Password Phrase Producer/Models/PasswordVaultEntryDto.cs
@@ -1,0 +1,54 @@
+namespace Password_Phrase_Producer.Models;
+
+public class PasswordVaultEntryDto
+{
+    public Guid Id { get; set; }
+
+    public string Label { get; set; } = string.Empty;
+
+    public string Username { get; set; } = string.Empty;
+
+    public string Password { get; set; } = string.Empty;
+
+    public string Category { get; set; } = string.Empty;
+
+    public string Url { get; set; } = string.Empty;
+
+    public string Notes { get; set; } = string.Empty;
+
+    public string FreeText { get; set; } = string.Empty;
+
+    public DateTimeOffset ModifiedAt { get; set; }
+
+    public static PasswordVaultEntryDto FromModel(PasswordVaultEntry entry)
+    {
+        return new PasswordVaultEntryDto
+        {
+            Id = entry.Id,
+            Label = entry.Label,
+            Username = entry.Username,
+            Password = entry.Password,
+            Category = entry.Category,
+            Url = entry.Url,
+            Notes = entry.Notes,
+            FreeText = entry.FreeText,
+            ModifiedAt = entry.ModifiedAt
+        };
+    }
+
+    public PasswordVaultEntry ToModel()
+    {
+        return new PasswordVaultEntry
+        {
+            Id = Id == Guid.Empty ? Guid.NewGuid() : Id,
+            Label = Label,
+            Username = Username,
+            Password = Password,
+            Category = Category,
+            Url = Url,
+            Notes = Notes,
+            FreeText = FreeText,
+            ModifiedAt = ModifiedAt == default ? DateTimeOffset.UtcNow : ModifiedAt
+        };
+    }
+}

--- a/Password Phrase Producer/Models/PasswordVaultSnapshotDto.cs
+++ b/Password Phrase Producer/Models/PasswordVaultSnapshotDto.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace Password_Phrase_Producer.Models;
+
+public class PasswordVaultSnapshotDto
+{
+    public IList<PasswordVaultEntryDto> Entries { get; set; } = new List<PasswordVaultEntryDto>();
+
+    public DateTimeOffset ExportedAt { get; set; } = DateTimeOffset.UtcNow;
+}

--- a/Password Phrase Producer/PasswordPhraseProducer.csproj
+++ b/Password Phrase Producer/PasswordPhraseProducer.csproj
@@ -73,11 +73,12 @@
 	  <None Remove="Resources\Splash\splashicon.png" />
 	</ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
-	</ItemGroup>
+        <ItemGroup>
+                <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+                <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
+                <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
+                <PackageReference Include="CommunityToolkit.Maui" Version="8.0.0" />
+        </ItemGroup>
 
 	<ItemGroup>
 	  <Folder Include="PasswordGenerationTechniques\ShiftTechniques\" />

--- a/Password Phrase Producer/Services/Vault/PasswordVaultService.cs
+++ b/Password Phrase Producer/Services/Vault/PasswordVaultService.cs
@@ -1,0 +1,351 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Storage;
+using Password_Phrase_Producer.Models;
+
+namespace Password_Phrase_Producer.Services.Vault;
+
+public static class VaultMessages
+{
+    public const string EntriesChanged = nameof(EntriesChanged);
+}
+
+public class PasswordVaultService
+{
+    private const string KeyStorageKey = "PasswordVaultEncryptionKey";
+    private const string VaultFileName = "vault.json.enc";
+
+    private readonly SemaphoreSlim _syncLock = new(1, 1);
+    private readonly SemaphoreSlim _keyLock = new(1, 1);
+    private readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true
+    };
+
+    private readonly string _vaultFilePath;
+    private byte[]? _encryptionKey;
+
+    public PasswordVaultService()
+    {
+        _vaultFilePath = Path.Combine(FileSystem.AppDataDirectory, VaultFileName);
+    }
+
+    public async Task EnsureInitializedAsync(CancellationToken cancellationToken = default)
+    {
+        _ = await GetKeyAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<PasswordVaultEntry>> GetEntriesAsync(CancellationToken cancellationToken = default)
+    {
+        await _syncLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var entries = await LoadEntriesInternalAsync(cancellationToken).ConfigureAwait(false);
+            return entries
+                .OrderBy(e => e.DisplayCategory, StringComparer.CurrentCultureIgnoreCase)
+                .ThenBy(e => e.Label, StringComparer.CurrentCultureIgnoreCase)
+                .ToList();
+        }
+        finally
+        {
+            _syncLock.Release();
+        }
+    }
+
+    public async Task AddOrUpdateEntryAsync(PasswordVaultEntry entry, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        await _syncLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var entries = await LoadEntriesInternalAsync(cancellationToken).ConfigureAwait(false);
+            var existingIndex = entries.FindIndex(e => e.Id == entry.Id);
+
+            if (entry.Id == Guid.Empty)
+            {
+                entry.Id = Guid.NewGuid();
+            }
+
+            entry.ModifiedAt = DateTimeOffset.UtcNow;
+
+            if (existingIndex >= 0)
+            {
+                entries[existingIndex] = entry.Clone();
+            }
+            else
+            {
+                entries.Add(entry.Clone());
+            }
+
+            await SaveEntriesInternalAsync(entries, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _syncLock.Release();
+        }
+
+        MessagingCenter.Send(this, VaultMessages.EntriesChanged);
+    }
+
+    public async Task DeleteEntryAsync(Guid entryId, CancellationToken cancellationToken = default)
+    {
+        await _syncLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var entries = await LoadEntriesInternalAsync(cancellationToken).ConfigureAwait(false);
+            var removed = entries.RemoveAll(e => e.Id == entryId);
+
+            if (removed > 0)
+            {
+                await SaveEntriesInternalAsync(entries, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            _syncLock.Release();
+        }
+
+        MessagingCenter.Send(this, VaultMessages.EntriesChanged);
+    }
+
+    public async Task<byte[]> CreateBackupAsync(CancellationToken cancellationToken = default)
+    {
+        await _syncLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var encryptedPayload = await ReadEncryptedFileAsync(cancellationToken).ConfigureAwait(false);
+            var key = await GetKeyAsync(cancellationToken).ConfigureAwait(false);
+
+            var backup = new PasswordVaultBackupDto
+            {
+                EncryptionKey = Convert.ToBase64String(key),
+                CipherText = Convert.ToBase64String(encryptedPayload),
+                CreatedAt = DateTimeOffset.UtcNow
+            };
+
+            var json = JsonSerializer.Serialize(backup, _jsonOptions);
+            return Encoding.UTF8.GetBytes(json);
+        }
+        finally
+        {
+            _syncLock.Release();
+        }
+    }
+
+    public async Task RestoreBackupAsync(Stream backupStream, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(backupStream);
+
+        using var reader = new StreamReader(backupStream, Encoding.UTF8, leaveOpen: true);
+        var json = await reader.ReadToEndAsync().ConfigureAwait(false);
+        var dto = JsonSerializer.Deserialize<PasswordVaultBackupDto>(json, _jsonOptions)
+                  ?? throw new InvalidOperationException("Ungültiges Backup-Format.");
+
+        var key = Convert.FromBase64String(dto.EncryptionKey);
+        var cipher = Convert.FromBase64String(dto.CipherText);
+
+        await SetKeyAsync(key, cancellationToken).ConfigureAwait(false);
+
+        await _syncLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(_vaultFilePath)!);
+            await File.WriteAllBytesAsync(_vaultFilePath, cipher, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _syncLock.Release();
+        }
+
+        MessagingCenter.Send(this, VaultMessages.EntriesChanged);
+    }
+
+    public async Task<byte[]> ExportEncryptedVaultAsync(CancellationToken cancellationToken = default)
+    {
+        await _syncLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            return await ReadEncryptedFileAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _syncLock.Release();
+        }
+    }
+
+    public async Task ImportEncryptedVaultAsync(Stream encryptedStream, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(encryptedStream);
+
+        using var memoryStream = new MemoryStream();
+        await encryptedStream.CopyToAsync(memoryStream, cancellationToken).ConfigureAwait(false);
+        var payload = memoryStream.ToArray();
+
+        await _syncLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(_vaultFilePath)!);
+            await File.WriteAllBytesAsync(_vaultFilePath, payload, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _syncLock.Release();
+        }
+
+        MessagingCenter.Send(this, VaultMessages.EntriesChanged);
+    }
+
+    private async Task<List<PasswordVaultEntry>> LoadEntriesInternalAsync(CancellationToken cancellationToken)
+    {
+        if (!File.Exists(_vaultFilePath))
+        {
+            return new List<PasswordVaultEntry>();
+        }
+
+        var encrypted = await File.ReadAllBytesAsync(_vaultFilePath, cancellationToken).ConfigureAwait(false);
+        if (encrypted.Length == 0)
+        {
+            return new List<PasswordVaultEntry>();
+        }
+
+        var decryptedBytes = await DecryptAsync(encrypted, cancellationToken).ConfigureAwait(false);
+        if (decryptedBytes.Length == 0)
+        {
+            return new List<PasswordVaultEntry>();
+        }
+
+        var json = Encoding.UTF8.GetString(decryptedBytes);
+        var snapshot = JsonSerializer.Deserialize<PasswordVaultSnapshotDto>(json, _jsonOptions);
+
+        if (snapshot?.Entries is null)
+        {
+            return new List<PasswordVaultEntry>();
+        }
+
+        return snapshot.Entries
+            .Select(dto => dto.ToModel())
+            .ToList();
+    }
+
+    private async Task SaveEntriesInternalAsync(IList<PasswordVaultEntry> entries, CancellationToken cancellationToken)
+    {
+        var ordered = entries
+            .OrderBy(e => e.DisplayCategory, StringComparer.CurrentCultureIgnoreCase)
+            .ThenBy(e => e.Label, StringComparer.CurrentCultureIgnoreCase)
+            .Select(PasswordVaultEntryDto.FromModel)
+            .ToList();
+
+        var snapshot = new PasswordVaultSnapshotDto
+        {
+            Entries = ordered,
+            ExportedAt = DateTimeOffset.UtcNow
+        };
+
+        var json = JsonSerializer.Serialize(snapshot, _jsonOptions);
+        var encrypted = await EncryptAsync(Encoding.UTF8.GetBytes(json), cancellationToken).ConfigureAwait(false);
+
+        Directory.CreateDirectory(Path.GetDirectoryName(_vaultFilePath)!);
+        await File.WriteAllBytesAsync(_vaultFilePath, encrypted, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<byte[]> EncryptAsync(byte[] data, CancellationToken cancellationToken)
+    {
+        var key = await GetKeyAsync(cancellationToken).ConfigureAwait(false);
+        var nonce = RandomNumberGenerator.GetBytes(12);
+        var cipher = new byte[data.Length];
+        var tag = new byte[16];
+
+        using var aes = new AesGcm(key);
+        aes.Encrypt(nonce, data, cipher, tag);
+
+        var result = new byte[nonce.Length + cipher.Length + tag.Length];
+        Buffer.BlockCopy(nonce, 0, result, 0, nonce.Length);
+        Buffer.BlockCopy(cipher, 0, result, nonce.Length, cipher.Length);
+        Buffer.BlockCopy(tag, 0, result, nonce.Length + cipher.Length, tag.Length);
+        return result;
+    }
+
+    private async Task<byte[]> DecryptAsync(byte[] data, CancellationToken cancellationToken)
+    {
+        if (data.Length < 28)
+        {
+            return Array.Empty<byte>();
+        }
+
+        var key = await GetKeyAsync(cancellationToken).ConfigureAwait(false);
+        var nonce = data.AsSpan(0, 12);
+        var tag = data.AsSpan(data.Length - 16, 16);
+        var cipher = data.AsSpan(12, data.Length - 28);
+        var plain = new byte[cipher.Length];
+
+        using var aes = new AesGcm(key);
+        aes.Decrypt(nonce, cipher, tag, plain);
+        return plain;
+    }
+
+    private async Task<byte[]> ReadEncryptedFileAsync(CancellationToken cancellationToken)
+    {
+        if (!File.Exists(_vaultFilePath))
+        {
+            return Array.Empty<byte>();
+        }
+
+        return await File.ReadAllBytesAsync(_vaultFilePath, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<byte[]> GetKeyAsync(CancellationToken cancellationToken)
+    {
+        if (_encryptionKey is not null)
+        {
+            return _encryptionKey;
+        }
+
+        await _keyLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_encryptionKey is null)
+            {
+                var storedKey = await SecureStorage.Default.GetAsync(KeyStorageKey).ConfigureAwait(false);
+                if (!string.IsNullOrEmpty(storedKey))
+                {
+                    _encryptionKey = Convert.FromBase64String(storedKey);
+                }
+                else
+                {
+                    var keyBytes = RandomNumberGenerator.GetBytes(32);
+                    await SecureStorage.Default.SetAsync(KeyStorageKey, Convert.ToBase64String(keyBytes)).ConfigureAwait(false);
+                    _encryptionKey = keyBytes;
+                }
+            }
+
+            return _encryptionKey;
+        }
+        finally
+        {
+            _keyLock.Release();
+        }
+    }
+
+    private async Task SetKeyAsync(byte[] key, CancellationToken cancellationToken)
+    {
+        await _keyLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            _encryptionKey = key;
+            await SecureStorage.Default.SetAsync(KeyStorageKey, Convert.ToBase64String(key)).ConfigureAwait(false);
+        }
+        finally
+        {
+            _keyLock.Release();
+        }
+    }
+}

--- a/Password Phrase Producer/ViewModels/VaultPageViewModel.cs
+++ b/Password Phrase Producer/ViewModels/VaultPageViewModel.cs
@@ -1,0 +1,152 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls;
+using Password_Phrase_Producer.Models;
+using Password_Phrase_Producer.Services.Vault;
+
+namespace Password_Phrase_Producer.ViewModels;
+
+public class VaultPageViewModel : INotifyPropertyChanged
+{
+    private readonly PasswordVaultService _vaultService;
+    private bool _isBusy;
+    private bool _isListening;
+
+    public VaultPageViewModel(PasswordVaultService vaultService)
+    {
+        _vaultService = vaultService;
+        Entries = new ObservableCollection<PasswordVaultEntry>();
+    }
+
+    public ObservableCollection<PasswordVaultEntry> Entries { get; }
+
+    public bool IsBusy
+    {
+        get => _isBusy;
+        private set
+        {
+            if (_isBusy != value)
+            {
+                _isBusy = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public void Activate()
+    {
+        if (_isListening)
+        {
+            return;
+        }
+
+        MessagingCenter.Subscribe<PasswordVaultService>(this, VaultMessages.EntriesChanged, OnVaultEntriesChanged);
+        _isListening = true;
+    }
+
+    public void Deactivate()
+    {
+        if (!_isListening)
+        {
+            return;
+        }
+
+        MessagingCenter.Unsubscribe<PasswordVaultService>(this, VaultMessages.EntriesChanged);
+        _isListening = false;
+    }
+
+    public async Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        if (Entries.Count > 0)
+        {
+            return;
+        }
+
+        await ReloadAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task ReloadAsync(CancellationToken cancellationToken = default)
+    {
+        if (IsBusy)
+        {
+            return;
+        }
+
+        try
+        {
+            IsBusy = true;
+            var entries = await _vaultService.GetEntriesAsync(cancellationToken).ConfigureAwait(false);
+            UpdateEntries(entries);
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    public async Task SaveEntryAsync(PasswordVaultEntry entry, CancellationToken cancellationToken = default)
+    {
+        await _vaultService.AddOrUpdateEntryAsync(entry, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task DeleteEntryAsync(PasswordVaultEntry entry, CancellationToken cancellationToken = default)
+    {
+        if (entry is null)
+        {
+            return;
+        }
+
+        await _vaultService.DeleteEntryAsync(entry.Id, cancellationToken).ConfigureAwait(false);
+    }
+
+    public Task<byte[]> CreateBackupAsync(CancellationToken cancellationToken = default)
+        => _vaultService.CreateBackupAsync(cancellationToken);
+
+    public Task RestoreBackupAsync(Stream backupStream, CancellationToken cancellationToken = default)
+        => _vaultService.RestoreBackupAsync(backupStream, cancellationToken);
+
+    public Task<byte[]> ExportEncryptedVaultAsync(CancellationToken cancellationToken = default)
+        => _vaultService.ExportEncryptedVaultAsync(cancellationToken);
+
+    public Task ImportEncryptedVaultAsync(Stream encryptedStream, CancellationToken cancellationToken = default)
+        => _vaultService.ImportEncryptedVaultAsync(encryptedStream, cancellationToken);
+
+    private void UpdateEntries(IEnumerable<PasswordVaultEntry> entries)
+    {
+        var ordered = entries
+            .OrderBy(e => e.DisplayCategory, StringComparer.CurrentCultureIgnoreCase)
+            .ThenBy(e => e.Label, StringComparer.CurrentCultureIgnoreCase)
+            .ToList();
+
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            Entries.Clear();
+            foreach (var entry in ordered)
+            {
+                Entries.Add(entry);
+            }
+        });
+    }
+
+    private async void OnVaultEntriesChanged(PasswordVaultService sender)
+    {
+        try
+        {
+            await ReloadAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Fehler beim Aktualisieren des Tresors: {ex}");
+        }
+    }
+
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+}

--- a/Password Phrase Producer/Views/VaultEntryEditorPage.xaml
+++ b/Password Phrase Producer/Views/VaultEntryEditorPage.xaml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    x:Class="Password_Phrase_Producer.Views.VaultEntryEditorPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:models="clr-namespace:Password_Phrase_Producer.Models"
+    Title="Tresor-Eintrag">
+    <ContentPage.Content>
+        <ScrollView>
+            <VerticalStackLayout Padding="24" Spacing="12">
+                <Entry Placeholder="Bezeichnung" Text="{Binding Label}" />
+                <Entry Placeholder="Kategorie" Text="{Binding Category}" />
+                <Entry Placeholder="Benutzername" Text="{Binding Username}" />
+                <Entry Placeholder="Passwort" Text="{Binding Password}" IsPassword="True" />
+                <Entry Placeholder="URL" Text="{Binding Url}" Keyboard="Url" />
+                <Editor Placeholder="Notizen" AutoSize="TextChanges" Text="{Binding Notes}" />
+                <Editor Placeholder="Freies Textfeld" AutoSize="TextChanges" Text="{Binding FreeText}" />
+                <Label Text="Änderungsdatum" FontAttributes="Bold" />
+                <Label Text="{Binding ModifiedAt, StringFormat='{0:G}'}" />
+                <HorizontalStackLayout Spacing="12" Margin="0,12,0,0">
+                    <Button Text="Speichern" Clicked="OnSaveClicked" HorizontalOptions="FillAndExpand" />
+                    <Button Text="Abbrechen" Clicked="OnCancelClicked" HorizontalOptions="FillAndExpand" />
+                </HorizontalStackLayout>
+            </VerticalStackLayout>
+        </ScrollView>
+    </ContentPage.Content>
+</ContentPage>

--- a/Password Phrase Producer/Views/VaultEntryEditorPage.xaml.cs
+++ b/Password Phrase Producer/Views/VaultEntryEditorPage.xaml.cs
@@ -1,0 +1,61 @@
+using System.Linq;
+using Microsoft.Maui.Controls;
+using Password_Phrase_Producer.Models;
+
+namespace Password_Phrase_Producer.Views;
+
+public partial class VaultEntryEditorPage : ContentPage
+{
+    private readonly TaskCompletionSource<PasswordVaultEntry?> _resultSource = new();
+
+    public VaultEntryEditorPage(PasswordVaultEntry entry, string title)
+    {
+        InitializeComponent();
+        BindingContext = entry;
+        Title = title;
+    }
+
+    public Task<PasswordVaultEntry?> Result => _resultSource.Task;
+
+    public static async Task<PasswordVaultEntry?> ShowAsync(INavigation navigation, PasswordVaultEntry entry, string title)
+    {
+        var page = new VaultEntryEditorPage(entry, title);
+        await navigation.PushModalAsync(page);
+        return await page.Result.ConfigureAwait(false);
+    }
+
+    private async void OnSaveClicked(object? sender, EventArgs e)
+    {
+        if (BindingContext is PasswordVaultEntry entry)
+        {
+            entry.ModifiedAt = DateTimeOffset.UtcNow;
+            _resultSource.TrySetResult(entry);
+        }
+
+        await CloseAsync().ConfigureAwait(false);
+    }
+
+    private async void OnCancelClicked(object? sender, EventArgs e)
+    {
+        _resultSource.TrySetResult(null);
+        await CloseAsync().ConfigureAwait(false);
+    }
+
+    protected override bool OnBackButtonPressed()
+    {
+        if (!_resultSource.Task.IsCompleted)
+        {
+            _resultSource.TrySetResult(null);
+        }
+
+        return base.OnBackButtonPressed();
+    }
+
+    private async Task CloseAsync()
+    {
+        if (Navigation.ModalStack.Contains(this))
+        {
+            await Navigation.PopModalAsync().ConfigureAwait(false);
+        }
+    }
+}

--- a/Password Phrase Producer/Views/VaultPage.xaml
+++ b/Password Phrase Producer/Views/VaultPage.xaml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    x:Class="Password_Phrase_Producer.Views.VaultPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:models="clr-namespace:Password_Phrase_Producer.Models"
+    Title="Tresor">
+    <ContentPage.ToolbarItems>
+        <ToolbarItem Text="Neu" Priority="0" Order="Primary" Clicked="OnAddEntryClicked" />
+        <ToolbarItem Text="Sync" Priority="1" Order="Secondary" Clicked="OnSyncOptionsClicked" />
+    </ContentPage.ToolbarItems>
+
+    <ContentPage.Content>
+        <Grid Padding="16" RowDefinitions="Auto,*">
+            <Label
+                Margin="0,0,0,8"
+                FontSize="14"
+                Text="Verwalte deine gespeicherten Zugangsdaten. Streiche nach links, um Einträge zu bearbeiten oder zu löschen." />
+            <CollectionView
+                x:Name="VaultCollectionView"
+                Grid.Row="1"
+                ItemsSource="{Binding Entries}"
+                SelectionMode="None">
+                <CollectionView.EmptyView>
+                    <StackLayout Padding="24" HorizontalOptions="Center" VerticalOptions="Center">
+                        <Label Text="Noch keine Einträge gespeichert." FontAttributes="Italic" />
+                    </StackLayout>
+                </CollectionView.EmptyView>
+                <CollectionView.ItemTemplate>
+                    <DataTemplate x:DataType="models:PasswordVaultEntry">
+                        <SwipeView>
+                            <SwipeView.RightItems>
+                                <SwipeItems Mode="Execute">
+                                    <SwipeItem
+                                        Text="Bearbeiten"
+                                        BackgroundColor="#007AFF"
+                                        TextColor="White"
+                                        Invoked="OnEditEntry"
+                                        CommandParameter="{Binding .}" />
+                                    <SwipeItem
+                                        Text="Löschen"
+                                        BackgroundColor="#FF3B30"
+                                        TextColor="White"
+                                        Invoked="OnDeleteEntry"
+                                        CommandParameter="{Binding .}" />
+                                </SwipeItems>
+                            </SwipeView.RightItems>
+                            <Frame Margin="0,0,0,12" Padding="12" BorderColor="#303030" BackgroundColor="#1E1E1E" CornerRadius="10">
+                                <VerticalStackLayout Spacing="4">
+                                    <Label Text="{Binding Label}" FontAttributes="Bold" FontSize="18" />
+                                    <Label Text="{Binding DisplayCategory}" FontSize="13" TextColor="#AAAAAA" />
+                                    <Grid ColumnDefinitions="Auto,*" ColumnSpacing="8" RowSpacing="4" Margin="0,6,0,0">
+                                        <Label Grid.Row="0" Grid.Column="0" Text="Benutzer" FontAttributes="Bold" />
+                                        <Label Grid.Row="0" Grid.Column="1" Text="{Binding Username}" LineBreakMode="TailTruncation" />
+                                        <Label Grid.Row="1" Grid.Column="0" Text="Passwort" FontAttributes="Bold" />
+                                        <Label Grid.Row="1" Grid.Column="1" Text="{Binding Password}" LineBreakMode="TailTruncation" />
+                                        <Label Grid.Row="2" Grid.Column="0" Text="URL" FontAttributes="Bold" />
+                                        <Label
+                                            Grid.Row="2"
+                                            Grid.Column="1"
+                                            Text="{Binding Url}"
+                                            TextColor="#4DA3FF"
+                                            TextDecorations="Underline">
+                                            <Label.GestureRecognizers>
+                                                <TapGestureRecognizer Tapped="OnOpenUrl" CommandParameter="{Binding Url}" />
+                                            </Label.GestureRecognizers>
+                                        </Label>
+                                    </Grid>
+                                    <Label Text="{Binding Notes}" LineBreakMode="WordWrap" />
+                                    <Label Text="{Binding FreeText}" LineBreakMode="WordWrap" />
+                                    <Label
+                                        FontSize="11"
+                                        Text="{Binding ModifiedAt, StringFormat='Geändert: {0:G}'}"
+                                        TextColor="#888888" />
+                                </VerticalStackLayout>
+                            </Frame>
+                        </SwipeView>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+        </Grid>
+    </ContentPage.Content>
+</ContentPage>

--- a/Password Phrase Producer/Views/VaultPage.xaml.cs
+++ b/Password Phrase Producer/Views/VaultPage.xaml.cs
@@ -1,0 +1,191 @@
+using System;
+using System.IO;
+using System.Threading;
+using CommunityToolkit.Maui.Storage;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Storage;
+using Password_Phrase_Producer.Models;
+using Password_Phrase_Producer.ViewModels;
+
+namespace Password_Phrase_Producer.Views;
+
+public partial class VaultPage : ContentPage
+{
+    private readonly VaultPageViewModel _viewModel;
+
+    public VaultPage(VaultPageViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = _viewModel = viewModel;
+    }
+
+    protected override async void OnAppearing()
+    {
+        base.OnAppearing();
+        _viewModel.Activate();
+        await _viewModel.InitializeAsync();
+    }
+
+    protected override void OnDisappearing()
+    {
+        base.OnDisappearing();
+        _viewModel.Deactivate();
+    }
+
+    private async void OnAddEntryClicked(object? sender, EventArgs e)
+    {
+        var entry = new PasswordVaultEntry();
+        var result = await VaultEntryEditorPage.ShowAsync(Navigation, entry, "Neuer Tresor-Eintrag");
+        if (result is null)
+        {
+            return;
+        }
+
+        await _viewModel.SaveEntryAsync(result);
+    }
+
+    private async void OnEditEntry(object? sender, EventArgs e)
+    {
+        if (sender is not SwipeItem swipeItem || swipeItem.CommandParameter is not PasswordVaultEntry entry)
+        {
+            return;
+        }
+
+        var editable = entry.Clone();
+        var result = await VaultEntryEditorPage.ShowAsync(Navigation, editable, "Eintrag bearbeiten");
+        if (result is null)
+        {
+            return;
+        }
+
+        await _viewModel.SaveEntryAsync(result);
+    }
+
+    private async void OnDeleteEntry(object? sender, EventArgs e)
+    {
+        if (sender is not SwipeItem swipeItem || swipeItem.CommandParameter is not PasswordVaultEntry entry)
+        {
+            return;
+        }
+
+        var confirm = await DisplayAlert("Eintrag löschen", $"Soll der Eintrag '{entry.Label}' gelöscht werden?", "Löschen", "Abbrechen");
+        if (!confirm)
+        {
+            return;
+        }
+
+        await _viewModel.DeleteEntryAsync(entry);
+    }
+
+    private async void OnOpenUrl(object? sender, TappedEventArgs e)
+    {
+        var url = e.Parameter as string;
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return;
+        }
+
+        url = url.Trim();
+        if (!url.StartsWith("http://", StringComparison.OrdinalIgnoreCase) &&
+            !url.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+        {
+            url = $"https://{url}";
+        }
+
+        try
+        {
+            await Launcher.OpenAsync(url);
+        }
+        catch (Exception ex)
+        {
+            await DisplayAlert("Fehler", $"Die URL konnte nicht geöffnet werden: {ex.Message}", "OK");
+        }
+    }
+
+    private async void OnSyncOptionsClicked(object? sender, EventArgs e)
+    {
+        var selection = await DisplayActionSheet("Tresor synchronisieren", "Abbrechen", null,
+            "Backup exportieren",
+            "Backup importieren",
+            "Verschlüsselten Tresor exportieren",
+            "Verschlüsselten Tresor importieren");
+
+        try
+        {
+            switch (selection)
+            {
+                case "Backup exportieren":
+                    await ExportBackupAsync();
+                    break;
+                case "Backup importieren":
+                    await ImportBackupAsync();
+                    break;
+                case "Verschlüsselten Tresor exportieren":
+                    await ExportEncryptedAsync();
+                    break;
+                case "Verschlüsselten Tresor importieren":
+                    await ImportEncryptedAsync();
+                    break;
+            }
+        }
+        catch (Exception ex)
+        {
+            await DisplayAlert("Fehler", ex.Message, "OK");
+        }
+    }
+
+    private async Task ExportBackupAsync()
+    {
+        var backupBytes = await _viewModel.CreateBackupAsync();
+        await using var stream = new MemoryStream(backupBytes);
+        var result = await FileSaver.Default.SaveAsync("vault-backup.json", stream, CancellationToken.None);
+        if (!result.IsSuccessful && result.Exception is not null)
+        {
+            throw new InvalidOperationException(result.Exception.Message, result.Exception);
+        }
+    }
+
+    private async Task ImportBackupAsync()
+    {
+        var file = await FilePicker.Default.PickAsync(new PickOptions
+        {
+            PickerTitle = "Backup auswählen"
+        });
+
+        if (file is null)
+        {
+            return;
+        }
+
+        await using var stream = await file.OpenReadAsync();
+        await _viewModel.RestoreBackupAsync(stream);
+    }
+
+    private async Task ExportEncryptedAsync()
+    {
+        var bytes = await _viewModel.ExportEncryptedVaultAsync();
+        await using var stream = new MemoryStream(bytes);
+        var result = await FileSaver.Default.SaveAsync("vault.json.enc", stream, CancellationToken.None);
+        if (!result.IsSuccessful && result.Exception is not null)
+        {
+            throw new InvalidOperationException(result.Exception.Message, result.Exception);
+        }
+    }
+
+    private async Task ImportEncryptedAsync()
+    {
+        var file = await FilePicker.Default.PickAsync(new PickOptions
+        {
+            PickerTitle = "Verschlüsselte Tresordatei auswählen"
+        });
+
+        if (file is null)
+        {
+            return;
+        }
+
+        await using var stream = await file.OpenReadAsync();
+        await _viewModel.ImportEncryptedVaultAsync(stream);
+    }
+}


### PR DESCRIPTION
## Summary
- add password vault models, encryption service, and messaging-driven view model for secure credential storage
- build vault management UI with list, swipe actions, editor dialog, and toolbar actions for backup/export/import workflows
- wire up dependency injection, community toolkit, and shell navigation to expose the new vault tab

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68f36361da60832aaa4c5ac71db4b947