### PR TITLE
Fix SwipeItem TextColor usage in VaultPage

### DIFF
--- a/Password Phrase Producer/Views/VaultPage.xaml
+++ b/Password Phrase Producer/Views/VaultPage.xaml
@@ -34,13 +34,11 @@
                                     <SwipeItem
                                         Text="Bearbeiten"
                                         BackgroundColor="#007AFF"
-                                        TextColor="White"
                                         Invoked="OnEditEntry"
                                         CommandParameter="{Binding .}" />
                                     <SwipeItem
                                         Text="Löschen"
                                         BackgroundColor="#FF3B30"
-                                        TextColor="White"
                                         Invoked="OnDeleteEntry"
                                         CommandParameter="{Binding .}" />
                                 </SwipeItems>


### PR DESCRIPTION
## Summary
- remove unsupported TextColor assignments from SwipeItems in VaultPage to fix Android XAML compilation

## Testing
- `dotnet build 'Password Phrase Producer/PasswordPhraseProducer.csproj' -t:Build -f net8.0-android` *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f379055e40832aa42804f83d5ef5dc