### PR TITLE
Add master password lock and biometric unlock to vault

### DIFF
--- a/Password Phrase Producer/MauiProgram.cs
+++ b/Password Phrase Producer/MauiProgram.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.Maui;
 using Microsoft.Extensions.Logging;
+using Password_Phrase_Producer.Services.Security;
 using Password_Phrase_Producer.Services.Vault;
 using Password_Phrase_Producer.ViewModels;
 using Password_Phrase_Producer.Views;
@@ -25,15 +26,11 @@ public static class MauiProgram
 #endif
 
         builder.Services.AddSingleton<PasswordVaultService>();
+        builder.Services.AddSingleton<IBiometricAuthenticationService, BiometricAuthenticationService>();
         builder.Services.AddTransient<VaultPageViewModel>();
         builder.Services.AddTransient<VaultPage>();
         builder.Services.AddTransient<VaultEntryEditorPage>();
 
-        var app = builder.Build();
-
-        var vaultService = app.Services.GetService<PasswordVaultService>();
-        vaultService?.EnsureInitializedAsync().GetAwaiter().GetResult();
-
-        return app;
+        return builder.Build();
     }
 }

--- a/Password Phrase Producer/Models/PasswordVaultBackupDto.cs
+++ b/Password Phrase Producer/Models/PasswordVaultBackupDto.cs
@@ -2,11 +2,13 @@ namespace Password_Phrase_Producer.Models;
 
 public class PasswordVaultBackupDto
 {
-    public string EncryptionKey { get; set; } = string.Empty;
-
-    public string FileName { get; set; } = "vault.json.enc";
-
     public string CipherText { get; set; } = string.Empty;
+
+    public string PasswordSalt { get; set; } = string.Empty;
+
+    public string PasswordVerifier { get; set; } = string.Empty;
+
+    public int Pbkdf2Iterations { get; set; }
 
     public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
 }

--- a/Password Phrase Producer/PasswordPhraseProducer.csproj
+++ b/Password Phrase Producer/PasswordPhraseProducer.csproj
@@ -78,6 +78,7 @@
                 <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
                 <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
                 <PackageReference Include="CommunityToolkit.Maui" Version="8.0.0" />
+                <PackageReference Include="Plugin.Fingerprint" Version="3.0.3" />
         </ItemGroup>
 
 	<ItemGroup>

--- a/Password Phrase Producer/Services/Security/BiometricAuthenticationService.cs
+++ b/Password Phrase Producer/Services/Security/BiometricAuthenticationService.cs
@@ -1,0 +1,26 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Plugin.Fingerprint;
+using Plugin.Fingerprint.Abstractions;
+
+namespace Password_Phrase_Producer.Services.Security;
+
+public class BiometricAuthenticationService : IBiometricAuthenticationService
+{
+    public async Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default)
+    {
+        return await CrossFingerprint.Current.IsAvailableAsync(true).ConfigureAwait(false);
+    }
+
+    public async Task<bool> AuthenticateAsync(string reason, CancellationToken cancellationToken = default)
+    {
+        var request = new AuthenticationRequestConfiguration("Tresor entsperren", reason)
+        {
+            AllowAlternativeAuthentication = true,
+            CancelTitle = "Abbrechen"
+        };
+
+        var result = await CrossFingerprint.Current.AuthenticateAsync(request).ConfigureAwait(false);
+        return result.Authenticated;
+    }
+}

--- a/Password Phrase Producer/Services/Security/IBiometricAuthenticationService.cs
+++ b/Password Phrase Producer/Services/Security/IBiometricAuthenticationService.cs
@@ -1,0 +1,11 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Password_Phrase_Producer.Services.Security;
+
+public interface IBiometricAuthenticationService
+{
+    Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default);
+
+    Task<bool> AuthenticateAsync(string reason, CancellationToken cancellationToken = default);
+}

--- a/Password Phrase Producer/ViewModels/VaultPageViewModel.cs
+++ b/Password Phrase Producer/ViewModels/VaultPageViewModel.cs
@@ -1,27 +1,46 @@
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Input;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Controls;
 using Password_Phrase_Producer.Models;
+using Password_Phrase_Producer.Services.Security;
 using Password_Phrase_Producer.Services.Vault;
+using System.Linq;
 
 namespace Password_Phrase_Producer.ViewModels;
 
 public class VaultPageViewModel : INotifyPropertyChanged
 {
     private readonly PasswordVaultService _vaultService;
+    private readonly IBiometricAuthenticationService _biometricAuthenticationService;
     private bool _isBusy;
     private bool _isListening;
+    private bool _isUnlocked;
+    private bool _isNewVault;
+    private bool _canUseBiometric;
+    private bool _isBiometricConfigured;
+    private bool _enableBiometric;
+    private string _password = string.Empty;
+    private string _confirmPassword = string.Empty;
+    private string? _unlockError;
 
-    public VaultPageViewModel(PasswordVaultService vaultService)
+    public VaultPageViewModel(PasswordVaultService vaultService, IBiometricAuthenticationService biometricAuthenticationService)
     {
         _vaultService = vaultService;
+        _biometricAuthenticationService = biometricAuthenticationService;
         Entries = new ObservableCollection<PasswordVaultEntry>();
+
+        UnlockCommand = new Command(async () => await UnlockAsync(), () => !IsBusy);
+        UnlockWithBiometricCommand = new Command(async () => await UnlockWithBiometricAsync(), () => !IsBusy && CanUseBiometric && IsBiometricConfigured);
     }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
 
     public ObservableCollection<PasswordVaultEntry> Entries { get; }
 
@@ -30,15 +49,101 @@ public class VaultPageViewModel : INotifyPropertyChanged
         get => _isBusy;
         private set
         {
-            if (_isBusy != value)
+            if (SetProperty(ref _isBusy, value))
             {
-                _isBusy = value;
-                OnPropertyChanged();
+                UpdateCommandStates();
             }
         }
     }
 
-    public event PropertyChangedEventHandler? PropertyChanged;
+    public bool IsUnlocked
+    {
+        get => _isUnlocked;
+        private set
+        {
+            if (SetProperty(ref _isUnlocked, value))
+            {
+                OnPropertyChanged(nameof(IsLocked));
+            }
+        }
+    }
+
+    public bool IsLocked => !IsUnlocked;
+
+    public bool IsNewVault
+    {
+        get => _isNewVault;
+        private set => SetProperty(ref _isNewVault, value);
+    }
+
+    public bool CanUseBiometric
+    {
+        get => _canUseBiometric;
+        private set
+        {
+            if (SetProperty(ref _canUseBiometric, value))
+            {
+                UpdateCommandStates();
+            }
+        }
+    }
+
+    public bool IsBiometricConfigured
+    {
+        get => _isBiometricConfigured;
+        private set
+        {
+            if (SetProperty(ref _isBiometricConfigured, value))
+            {
+                if (!value && EnableBiometric)
+                {
+                    EnableBiometric = false;
+                }
+
+                UpdateCommandStates();
+            }
+        }
+    }
+
+    public bool EnableBiometric
+    {
+        get => _enableBiometric;
+        set => SetProperty(ref _enableBiometric, value);
+    }
+
+    public string Password
+    {
+        get => _password;
+        set
+        {
+            if (SetProperty(ref _password, value) && !string.IsNullOrEmpty(_unlockError))
+            {
+                UnlockError = null;
+            }
+        }
+    }
+
+    public string ConfirmPassword
+    {
+        get => _confirmPassword;
+        set
+        {
+            if (SetProperty(ref _confirmPassword, value) && !string.IsNullOrEmpty(_unlockError))
+            {
+                UnlockError = null;
+            }
+        }
+    }
+
+    public string? UnlockError
+    {
+        get => _unlockError;
+        private set => SetProperty(ref _unlockError, value);
+    }
+
+    public ICommand UnlockCommand { get; }
+
+    public ICommand UnlockWithBiometricCommand { get; }
 
     public void Activate()
     {
@@ -53,28 +158,30 @@ public class VaultPageViewModel : INotifyPropertyChanged
 
     public void Deactivate()
     {
-        if (!_isListening)
+        if (_isListening)
         {
-            return;
+            MessagingCenter.Unsubscribe<PasswordVaultService>(this, VaultMessages.EntriesChanged);
+            _isListening = false;
         }
 
-        MessagingCenter.Unsubscribe<PasswordVaultService>(this, VaultMessages.EntriesChanged);
-        _isListening = false;
+        _vaultService.Lock();
+        IsUnlocked = false;
+        MainThread.BeginInvokeOnMainThread(() => Entries.Clear());
     }
 
     public async Task InitializeAsync(CancellationToken cancellationToken = default)
     {
-        if (Entries.Count > 0)
-        {
-            return;
-        }
+        await EnsureAccessStateAsync(cancellationToken);
 
-        await ReloadAsync(cancellationToken).ConfigureAwait(false);
+        if (IsUnlocked)
+        {
+            await ReloadAsync(cancellationToken);
+        }
     }
 
     public async Task ReloadAsync(CancellationToken cancellationToken = default)
     {
-        if (IsBusy)
+        if (IsBusy || !IsUnlocked)
         {
             return;
         }
@@ -82,7 +189,7 @@ public class VaultPageViewModel : INotifyPropertyChanged
         try
         {
             IsBusy = true;
-            var entries = await _vaultService.GetEntriesAsync(cancellationToken).ConfigureAwait(false);
+            var entries = await _vaultService.GetEntriesAsync(cancellationToken);
             UpdateEntries(entries);
         }
         finally
@@ -93,7 +200,7 @@ public class VaultPageViewModel : INotifyPropertyChanged
 
     public async Task SaveEntryAsync(PasswordVaultEntry entry, CancellationToken cancellationToken = default)
     {
-        await _vaultService.AddOrUpdateEntryAsync(entry, cancellationToken).ConfigureAwait(false);
+        await _vaultService.AddOrUpdateEntryAsync(entry, cancellationToken);
     }
 
     public async Task DeleteEntryAsync(PasswordVaultEntry entry, CancellationToken cancellationToken = default)
@@ -103,7 +210,7 @@ public class VaultPageViewModel : INotifyPropertyChanged
             return;
         }
 
-        await _vaultService.DeleteEntryAsync(entry.Id, cancellationToken).ConfigureAwait(false);
+        await _vaultService.DeleteEntryAsync(entry.Id, cancellationToken);
     }
 
     public Task<byte[]> CreateBackupAsync(CancellationToken cancellationToken = default)
@@ -117,6 +224,124 @@ public class VaultPageViewModel : INotifyPropertyChanged
 
     public Task ImportEncryptedVaultAsync(Stream encryptedStream, CancellationToken cancellationToken = default)
         => _vaultService.ImportEncryptedVaultAsync(encryptedStream, cancellationToken);
+
+    public async Task EnsureAccessStateAsync(CancellationToken cancellationToken = default)
+    {
+        IsUnlocked = _vaultService.IsUnlocked;
+        IsNewVault = !await _vaultService.HasMasterPasswordAsync(cancellationToken);
+        CanUseBiometric = await _biometricAuthenticationService.IsAvailableAsync(cancellationToken);
+        IsBiometricConfigured = CanUseBiometric && await _vaultService.HasBiometricKeyAsync(cancellationToken);
+        EnableBiometric = IsBiometricConfigured;
+        UnlockError = null;
+
+        if (!IsUnlocked)
+        {
+            MainThread.BeginInvokeOnMainThread(Entries.Clear);
+        }
+    }
+
+    private async Task UnlockAsync(CancellationToken cancellationToken = default)
+    {
+        if (IsBusy)
+        {
+            return;
+        }
+
+        try
+        {
+            IsBusy = true;
+            UnlockError = null;
+
+            if (string.IsNullOrWhiteSpace(Password))
+            {
+                UnlockError = "Bitte gib ein Passwort ein.";
+                return;
+            }
+
+            if (IsNewVault)
+            {
+                if (!string.Equals(Password, ConfirmPassword, StringComparison.Ordinal))
+                {
+                    UnlockError = "Die Passwörter stimmen nicht überein.";
+                    return;
+                }
+
+                await _vaultService.SetMasterPasswordAsync(Password, EnableBiometric && CanUseBiometric, cancellationToken);
+                IsBiometricConfigured = EnableBiometric && CanUseBiometric;
+                await OnUnlockedAsync(cancellationToken);
+            }
+            else
+            {
+                var unlocked = await _vaultService.UnlockAsync(Password, cancellationToken);
+                if (!unlocked)
+                {
+                    UnlockError = "Das eingegebene Passwort ist ungültig.";
+                    return;
+                }
+
+                if (CanUseBiometric)
+                {
+                    await _vaultService.SetBiometricUnlockAsync(EnableBiometric, cancellationToken);
+                    IsBiometricConfigured = EnableBiometric;
+                }
+
+                await OnUnlockedAsync(cancellationToken);
+            }
+        }
+        finally
+        {
+            IsBusy = false;
+            UpdateCommandStates();
+        }
+    }
+
+    private async Task UnlockWithBiometricAsync(CancellationToken cancellationToken = default)
+    {
+        if (IsBusy || !CanUseBiometric || !IsBiometricConfigured)
+        {
+            return;
+        }
+
+        try
+        {
+            IsBusy = true;
+            UnlockError = null;
+
+            var authenticated = await _biometricAuthenticationService.AuthenticateAsync("Authentifiziere dich, um den Tresor zu entsperren.", cancellationToken);
+            if (!authenticated)
+            {
+                UnlockError = "Die biometrische Authentifizierung wurde abgebrochen.";
+                return;
+            }
+
+            var unlocked = await _vaultService.TryUnlockWithStoredKeyAsync(cancellationToken);
+            if (!unlocked)
+            {
+                UnlockError = "Der gespeicherte biometrische Schlüssel ist nicht mehr gültig. Bitte gib dein Passwort ein.";
+                IsBiometricConfigured = false;
+                return;
+            }
+
+            EnableBiometric = true;
+            IsBiometricConfigured = true;
+            await OnUnlockedAsync(cancellationToken);
+        }
+        finally
+        {
+            IsBusy = false;
+            UpdateCommandStates();
+        }
+    }
+
+    private async Task OnUnlockedAsync(CancellationToken cancellationToken)
+    {
+        Password = string.Empty;
+        ConfirmPassword = string.Empty;
+        UnlockError = null;
+        IsUnlocked = true;
+        IsNewVault = false;
+        await ReloadAsync(cancellationToken);
+    }
 
     private void UpdateEntries(IEnumerable<PasswordVaultEntry> entries)
     {
@@ -139,12 +364,41 @@ public class VaultPageViewModel : INotifyPropertyChanged
     {
         try
         {
-            await ReloadAsync().ConfigureAwait(false);
+            await EnsureAccessStateAsync();
+            if (IsUnlocked)
+            {
+                await ReloadAsync();
+            }
         }
         catch (Exception ex)
         {
             Debug.WriteLine($"Fehler beim Aktualisieren des Tresors: {ex}");
         }
+    }
+
+    private void UpdateCommandStates()
+    {
+        if (UnlockCommand is Command unlockCommand)
+        {
+            MainThread.BeginInvokeOnMainThread(unlockCommand.ChangeCanExecute);
+        }
+
+        if (UnlockWithBiometricCommand is Command biometricCommand)
+        {
+            MainThread.BeginInvokeOnMainThread(biometricCommand.ChangeCanExecute);
+        }
+    }
+
+    private bool SetProperty<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value))
+        {
+            return false;
+        }
+
+        field = value;
+        OnPropertyChanged(propertyName);
+        return true;
     }
 
     private void OnPropertyChanged([CallerMemberName] string? propertyName = null)

--- a/Password Phrase Producer/Views/VaultPage.xaml
+++ b/Password Phrase Producer/Views/VaultPage.xaml
@@ -22,135 +22,159 @@
         </LinearGradientBrush>
     </ContentPage.Background>
 
-    <Grid RowDefinitions="Auto,*">
-        <Grid
-            Padding="24,48,24,20"
-            RowSpacing="18"
-            RowDefinitions="Auto,Auto">
+    <Grid>
+        <Grid RowDefinitions="Auto,*">
             <Grid
-                ColumnDefinitions="*,Auto"
-                VerticalOptions="Start">
-                <VerticalStackLayout Spacing="4">
-                    <Label
-                        Text="Tresor"
-                        FontSize="28"
-                        FontAttributes="Bold"
-                        TextColor="White" />
-                    <Label
-                        Text="Behalte deine Zugangsdaten im Blick und verwalte sie sicher."
-                        FontSize="14"
-                        TextColor="#AEB5DA" />
-                </VerticalStackLayout>
+                Padding="24,48,24,20"
+                RowSpacing="18"
+                RowDefinitions="Auto,Auto">
+                <Grid
+                    ColumnDefinitions="Auto,*,Auto"
+                    VerticalOptions="Start">
+                    <Border
+                        WidthRequest="52"
+                        HeightRequest="52"
+                        BackgroundColor="#1F2338"
+                        StrokeThickness="0"
+                        VerticalOptions="Center">
+                        <Border.StrokeShape>
+                            <RoundRectangle CornerRadius="18" />
+                        </Border.StrokeShape>
+                        <Border.Shadow>
+                            <Shadow Brush="#25000000" Radius="12" Offset="0,8" />
+                        </Border.Shadow>
+                        <Border.GestureRecognizers>
+                            <TapGestureRecognizer Tapped="OnBackTapped" />
+                        </Border.GestureRecognizers>
+                        <Label
+                            Text="←"
+                            FontSize="20"
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center"
+                            TextColor="#CFD3FF" />
+                    </Border>
 
-                <Border
-                    Grid.Column="1"
-                    WidthRequest="52"
-                    HeightRequest="52"
-                    BackgroundColor="#1F2338"
-                    StrokeThickness="0"
-                    HorizontalOptions="End"
-                    VerticalOptions="Center">
-                    <Border.StrokeShape>
-                        <RoundRectangle CornerRadius="18" />
-                    </Border.StrokeShape>
-                    <Border.Shadow>
-                        <Shadow Brush="#25000000" Radius="12" Offset="0,8" />
-                    </Border.Shadow>
-                    <Border.GestureRecognizers>
-                        <TapGestureRecognizer Tapped="OnOpenMenuTapped" />
-                    </Border.GestureRecognizers>
-                    <Label
-                        Text="☰"
-                        FontSize="20"
-                        HorizontalOptions="Center"
-                        VerticalOptions="Center"
-                        TextColor="#CFD3FF" />
-                </Border>
+                    <VerticalStackLayout Grid.Column="1" Spacing="4">
+                        <Label
+                            Text="Tresor"
+                            FontSize="28"
+                            FontAttributes="Bold"
+                            TextColor="White" />
+                        <Label
+                            Text="Behalte deine Zugangsdaten im Blick und verwalte sie sicher."
+                            FontSize="14"
+                            TextColor="#AEB5DA" />
+                    </VerticalStackLayout>
+
+                    <Border
+                        Grid.Column="2"
+                        WidthRequest="52"
+                        HeightRequest="52"
+                        BackgroundColor="#1F2338"
+                        StrokeThickness="0"
+                        HorizontalOptions="End"
+                        VerticalOptions="Center">
+                        <Border.StrokeShape>
+                            <RoundRectangle CornerRadius="18" />
+                        </Border.StrokeShape>
+                        <Border.Shadow>
+                            <Shadow Brush="#25000000" Radius="12" Offset="0,8" />
+                        </Border.Shadow>
+                        <Border.GestureRecognizers>
+                            <TapGestureRecognizer Tapped="OnOpenMenuTapped" />
+                        </Border.GestureRecognizers>
+                        <Label
+                            Text="☰"
+                            FontSize="20"
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center"
+                            TextColor="#CFD3FF" />
+                    </Border>
+                </Grid>
+
+                <Grid Grid.Row="1" ColumnDefinitions="*,Auto" ColumnSpacing="14">
+                    <Border
+                        StrokeThickness="0"
+                        BackgroundColor="#3B4AD1"
+                        Padding="18,14"
+                        HorizontalOptions="Start"
+                        VerticalOptions="Center">
+                        <Border.StrokeShape>
+                            <RoundRectangle CornerRadius="22" />
+                        </Border.StrokeShape>
+                        <Border.Shadow>
+                            <Shadow Brush="#30000000" Radius="18" Offset="0,10" />
+                        </Border.Shadow>
+                        <HorizontalStackLayout Spacing="14" VerticalOptions="Center">
+                            <Border
+                                WidthRequest="44"
+                                HeightRequest="44"
+                                BackgroundColor="#5465FF"
+                                StrokeThickness="0"
+                                VerticalOptions="Center">
+                                <Border.StrokeShape>
+                                    <RoundRectangle CornerRadius="16" />
+                                </Border.StrokeShape>
+                                <Label
+                                    Text="＋"
+                                    FontSize="22"
+                                    HorizontalOptions="Center"
+                                    VerticalOptions="Center"
+                                    TextColor="White" />
+                            </Border>
+                            <VerticalStackLayout Spacing="0" VerticalOptions="Center">
+                                <Label
+                                    Text="Neuer Eintrag"
+                                    FontSize="18"
+                                    FontAttributes="Bold"
+                                    TextColor="White" />
+                                <Label
+                                    Text="Manuell hinzufügen"
+                                    FontSize="13"
+                                    TextColor="#E3E6FF" />
+                            </VerticalStackLayout>
+                        </HorizontalStackLayout>
+                        <Border.GestureRecognizers>
+                            <TapGestureRecognizer Tapped="OnAddEntryClicked" />
+                        </Border.GestureRecognizers>
+                    </Border>
+
+                    <Border
+                        Grid.Column="1"
+                        WidthRequest="52"
+                        HeightRequest="52"
+                        BackgroundColor="#1F2338"
+                        StrokeThickness="0"
+                        HorizontalOptions="End"
+                        VerticalOptions="Center">
+                        <Border.StrokeShape>
+                            <RoundRectangle CornerRadius="18" />
+                        </Border.StrokeShape>
+                        <Border.Shadow>
+                            <Shadow Brush="#1A000000" Radius="12" Offset="0,8" />
+                        </Border.Shadow>
+                        <Border.GestureRecognizers>
+                            <TapGestureRecognizer Tapped="OnSyncOptionsClicked" />
+                        </Border.GestureRecognizers>
+                        <Label
+                            Text="⟳"
+                            FontSize="20"
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center"
+                            TextColor="#CFD3FF" />
+                    </Border>
+                </Grid>
             </Grid>
 
-            <Grid Grid.Row="1" ColumnDefinitions="*,Auto" ColumnSpacing="14">
-                <Border
-                    StrokeThickness="0"
-                    BackgroundColor="#3B4AD1"
-                    Padding="18,14"
-                    HorizontalOptions="Start"
-                    VerticalOptions="Center">
-                    <Border.StrokeShape>
-                        <RoundRectangle CornerRadius="22" />
-                    </Border.StrokeShape>
-                    <Border.Shadow>
-                        <Shadow Brush="#30000000" Radius="18" Offset="0,10" />
-                    </Border.Shadow>
-                    <Grid ColumnDefinitions="Auto,*" ColumnSpacing="12">
-                        <Border
-                            WidthRequest="44"
-                            HeightRequest="44"
-                            BackgroundColor="#5465FF"
-                            StrokeThickness="0"
-                            VerticalOptions="Center">
-                            <Border.StrokeShape>
-                                <RoundRectangle CornerRadius="16" />
-                            </Border.StrokeShape>
-                            <Label
-                                Text="＋"
-                                FontSize="22"
-                                HorizontalOptions="Center"
-                                VerticalOptions="Center"
-                                TextColor="White" />
-                        </Border>
-                        <VerticalStackLayout Spacing="0" VerticalOptions="Center">
-                            <Label
-                                Text="Neuer Eintrag"
-                                FontSize="18"
-                                FontAttributes="Bold"
-                                TextColor="White" />
-                            <Label
-                                Text="Manuell hinzufügen"
-                                FontSize="13"
-                                TextColor="#E3E6FF" />
-                        </VerticalStackLayout>
-                    </Grid>
-                    <Border.GestureRecognizers>
-                        <TapGestureRecognizer Tapped="OnAddEntryClicked" />
-                    </Border.GestureRecognizers>
-                </Border>
-
-                <Border
-                    Grid.Column="1"
-                    WidthRequest="52"
-                    HeightRequest="52"
-                    BackgroundColor="#1F2338"
-                    StrokeThickness="0"
-                    HorizontalOptions="End"
-                    VerticalOptions="Center">
-                    <Border.StrokeShape>
-                        <RoundRectangle CornerRadius="18" />
-                    </Border.StrokeShape>
-                    <Border.Shadow>
-                        <Shadow Brush="#1A000000" Radius="12" Offset="0,8" />
-                    </Border.Shadow>
-                    <Border.GestureRecognizers>
-                        <TapGestureRecognizer Tapped="OnSyncOptionsClicked" />
-                    </Border.GestureRecognizers>
-                    <Label
-                        Text="⟳"
-                        FontSize="20"
-                        HorizontalOptions="Center"
-                        VerticalOptions="Center"
-                        TextColor="#CFD3FF" />
-                </Border>
-            </Grid>
-        </Grid>
-
-        <CollectionView
-            x:Name="VaultCollectionView"
-            Grid.Row="1"
-            Margin="24,0,24,24"
-            ItemsSource="{Binding Entries}"
-            SelectionMode="None"
-            ItemSizingStrategy="MeasureAllItems"
-            VerticalOptions="FillAndExpand"
-            VerticalScrollBarVisibility="Never">
+            <CollectionView
+                x:Name="VaultCollectionView"
+                Grid.Row="1"
+                Margin="24,0,24,24"
+                ItemsSource="{Binding Entries}"
+                SelectionMode="None"
+                ItemSizingStrategy="MeasureAllItems"
+                VerticalOptions="FillAndExpand"
+                VerticalScrollBarVisibility="Never">
             <CollectionView.EmptyView>
                 <VerticalStackLayout
                     Padding="32"
@@ -395,6 +419,128 @@
                     </Border>
                 </DataTemplate>
             </CollectionView.ItemTemplate>
-        </CollectionView>
+            </CollectionView>
+        </Grid>
+
+        <Border
+            Padding="24,48,24,32"
+            BackgroundColor="#CC0B0D1A"
+            IsVisible="{Binding IsLocked}"
+            HorizontalOptions="FillAndExpand"
+            VerticalOptions="FillAndExpand">
+            <Border.StrokeShape>
+                <RoundRectangle CornerRadius="42" />
+            </Border.StrokeShape>
+            <Border.Shadow>
+                <Shadow Brush="#55000000" Radius="32" Offset="0,18" />
+            </Border.Shadow>
+            <ScrollView>
+                <VerticalStackLayout Spacing="22" VerticalOptions="Center" HorizontalOptions="Center">
+                    <Border
+                        Padding="14,10"
+                        StrokeThickness="0"
+                        BackgroundColor="#1F2338"
+                        HorizontalOptions="Start">
+                        <Border.StrokeShape>
+                            <RoundRectangle CornerRadius="16" />
+                        </Border.StrokeShape>
+                        <Border.GestureRecognizers>
+                            <TapGestureRecognizer Tapped="OnBackTapped" />
+                        </Border.GestureRecognizers>
+                        <HorizontalStackLayout Spacing="8" VerticalOptions="Center">
+                            <Label
+                                Text="←"
+                                FontSize="16"
+                                TextColor="#CFD3FF" />
+                            <Label
+                                Text="Zur Startseite"
+                                FontSize="14"
+                                TextColor="#CFD3FF" />
+                        </HorizontalStackLayout>
+                    </Border>
+
+                    <VerticalStackLayout Spacing="10" HorizontalOptions="Center" VerticalOptions="Center">
+                        <Label
+                            Text="Tresor gesperrt"
+                            FontSize="26"
+                            FontAttributes="Bold"
+                            TextColor="White"
+                            HorizontalTextAlignment="Center" />
+                        <Label
+                            Text="Bitte gib dein Master-Passwort ein, um den Tresor zu entsperren."
+                            FontSize="14"
+                            TextColor="#C4C8E8"
+                            HorizontalTextAlignment="Center" />
+                    </VerticalStackLayout>
+
+                    <VerticalStackLayout Spacing="14">
+                        <Entry
+                            Text="{Binding Password}"
+                            IsPassword="True"
+                            Placeholder="Master-Passwort"
+                            PlaceholderColor="#8489B0"
+                            TextColor="White"
+                            BackgroundColor="#1F243C"
+                            HeightRequest="48"
+                            Margin="0,6"
+                            HorizontalOptions="Fill" />
+                        <Entry
+                            Text="{Binding ConfirmPassword}"
+                            IsVisible="{Binding IsNewVault}"
+                            IsPassword="True"
+                            Placeholder="Passwort bestätigen"
+                            PlaceholderColor="#8489B0"
+                            TextColor="White"
+                            BackgroundColor="#1F243C"
+                            HeightRequest="48"
+                            Margin="0,6"
+                            HorizontalOptions="Fill" />
+
+                        <Label
+                            Text="{Binding UnlockError}"
+                            TextColor="#FF9A9A"
+                            FontSize="12"
+                            IsVisible="{Binding UnlockError, Converter={StaticResource StringNotNullOrWhiteSpaceConverter}}"
+                            HorizontalTextAlignment="Center" />
+                    </VerticalStackLayout>
+
+                    <VerticalStackLayout Spacing="12">
+                        <Grid ColumnDefinitions="Auto,*" IsVisible="{Binding CanUseBiometric}">
+                            <Switch
+                                Grid.Column="0"
+                                IsToggled="{Binding EnableBiometric}" />
+                            <Label
+                                Grid.Column="1"
+                                Text="Biometrische Anmeldung für diesen Tresor speichern"
+                                FontSize="12"
+                                TextColor="#D7DBF7"
+                                Margin="12,0,0,0"
+                                VerticalOptions="Center"
+                                LineBreakMode="WordWrap" />
+                        </Grid>
+
+                        <Button
+                            Text="Tresor entsperren"
+                            Command="{Binding UnlockCommand}"
+                            HeightRequest="52"
+                            FontAttributes="Bold"
+                            BackgroundColor="#4A5CFF"
+                            TextColor="White"
+                            CornerRadius="18" />
+
+                        <Button
+                            Text="Mit Fingerabdruck entsperren"
+                            Command="{Binding UnlockWithBiometricCommand}"
+                            HeightRequest="52"
+                            CornerRadius="18"
+                            BackgroundColor="#1F243C"
+                            TextColor="#D7DBF7"
+                            BorderColor="#3B4AD1"
+                            BorderWidth="1"
+                            IsVisible="{Binding IsBiometricConfigured}" />
+                    </VerticalStackLayout>
+                </VerticalStackLayout>
+            </ScrollView>
+        </Border>
     </Grid>
 </ContentPage>

--- a/Password Phrase Producer/Views/VaultPage.xaml.cs
+++ b/Password Phrase Producer/Views/VaultPage.xaml.cs
@@ -109,6 +109,7 @@ public partial class VaultPage : ContentPage
                     break;
                 case "Backup importieren":
                     await ImportBackupAsync();
+                    await _viewModel.EnsureAccessStateAsync();
                     break;
                 case "Verschlüsselten Tresor exportieren":
                     await ExportEncryptedAsync();
@@ -121,6 +122,14 @@ public partial class VaultPage : ContentPage
         catch (Exception ex)
         {
             await DisplayAlert("Fehler", ex.Message, "OK");
+        }
+    }
+
+    private async void OnBackTapped(object? sender, TappedEventArgs e)
+    {
+        if (Shell.Current is not null)
+        {
+            await Shell.Current.GoToAsync("//home");
         }
     }
 


### PR DESCRIPTION
## Summary
- implement master password management for the vault, including biometric unlock support
- update the vault UI with a lock overlay, back navigation, and layout tweaks for the add button
- adjust backup/export handling and register the fingerprint plugin dependency

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f4c6e07f48832a896a66e8888007c8