### PR TITLE
Fix Plugin.Fingerprint package version

### DIFF
--- a/Password Phrase Producer/PasswordPhraseProducer.csproj
+++ b/Password Phrase Producer/PasswordPhraseProducer.csproj
@@ -78,7 +78,7 @@
                 <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
                 <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
                 <PackageReference Include="CommunityToolkit.Maui" Version="8.0.0" />
-                <PackageReference Include="Plugin.Fingerprint" Version="3.0.3" />
+                <PackageReference Include="Plugin.Fingerprint" Version="3.0.0" />
         </ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary
- update Plugin.Fingerprint dependency to an available 3.0.0 release to allow restore

## Testing
- dotnet restore "./Password Phrase Producer/Password Phrase Producer.sln" *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f4e40143bc832a9ec9bfd60f293815