### PR TITLE
Fix Plugin.Fingerprint package restore failure

### DIFF
--- a/Password Phrase Producer/PasswordPhraseProducer.csproj
+++ b/Password Phrase Producer/PasswordPhraseProducer.csproj
@@ -78,7 +78,7 @@
                 <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
                 <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
                 <PackageReference Include="CommunityToolkit.Maui" Version="8.0.0" />
-                <PackageReference Include="Plugin.Fingerprint" Version="3.0.0" />
+                <PackageReference Include="Plugin.Fingerprint" Version="3.0.0-beta.1" />
         </ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary
- update the Plugin.Fingerprint package reference to target the available 3.0.0-beta.1 release so restore can succeed

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f4e6e20bc8832ab9272bef47eec756