### PR TITLE
Fix biometric auth and allow updating the vault password

### DIFF
--- a/Password Phrase Producer/PasswordPhraseProducer.csproj
+++ b/Password Phrase Producer/PasswordPhraseProducer.csproj
@@ -78,7 +78,7 @@
                 <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
                 <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
                 <PackageReference Include="CommunityToolkit.Maui" Version="8.0.0" />
-                <PackageReference Include="Plugin.Fingerprint" Version="3.0.0-beta.1" />
+                <PackageReference Include="Plugin.Maui.Biometric" Version="2.0.2" />
         </ItemGroup>
 
 	<ItemGroup>

--- a/Password Phrase Producer/Platforms/Android/AndroidManifest.xml
+++ b/Password Phrase Producer/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 	<application android:allowBackup="true" android:supportsRtl="true" android:icon="@mipmap/iconkeyconfig" android:label="Pasword Phrase Producer"></application>
-	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-	<uses-permission android:name="android.permission.INTERNET" />
+        <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+        <uses-permission android:name="android.permission.INTERNET" />
+        <uses-permission android:name="android.permission.USE_BIOMETRIC" />
 </manifest>

--- a/Password Phrase Producer/Services/Security/BiometricAuthenticationService.cs
+++ b/Password Phrase Producer/Services/Security/BiometricAuthenticationService.cs
@@ -1,7 +1,7 @@
 using System.Threading;
 using System.Threading.Tasks;
-using Plugin.Fingerprint;
-using Plugin.Fingerprint.Abstractions;
+using Plugin.Maui.Biometric;
+using PluginBiometricService = Plugin.Maui.Biometric.BiometricAuthenticationService;
 
 namespace Password_Phrase_Producer.Services.Security;
 
@@ -9,18 +9,26 @@ public class BiometricAuthenticationService : IBiometricAuthenticationService
 {
     public async Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default)
     {
-        return await CrossFingerprint.Current.IsAvailableAsync(true).ConfigureAwait(false);
+        var status = await PluginBiometricService.Default
+            .GetAuthenticationStatusAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return status == BiometricStatus.Available;
     }
 
     public async Task<bool> AuthenticateAsync(string reason, CancellationToken cancellationToken = default)
     {
-        var request = new AuthenticationRequestConfiguration("Tresor entsperren", reason)
+        var request = new AuthenticationRequest
         {
-            AllowAlternativeAuthentication = true,
-            CancelTitle = "Abbrechen"
+            Title = "Tresor entsperren",
+            Subtitle = reason,
+            NegativeText = "Abbrechen"
         };
 
-        var result = await CrossFingerprint.Current.AuthenticateAsync(request).ConfigureAwait(false);
-        return result.Authenticated;
+        var result = await PluginBiometricService.Default
+            .AuthenticateAsync(request, cancellationToken)
+            .ConfigureAwait(false);
+
+        return result.Status == BiometricResponseStatus.Success;
     }
 }

--- a/Password Phrase Producer/ViewModels/VaultPageViewModel.cs
+++ b/Password Phrase Producer/ViewModels/VaultPageViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -211,6 +212,16 @@ public class VaultPageViewModel : INotifyPropertyChanged
         }
 
         await _vaultService.DeleteEntryAsync(entry.Id, cancellationToken);
+    }
+
+    public async Task ChangeMasterPasswordAsync(string newPassword, bool enableBiometric, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(newPassword);
+
+        await _vaultService.ChangeMasterPasswordAsync(newPassword, enableBiometric && CanUseBiometric, cancellationToken);
+
+        EnableBiometric = enableBiometric && CanUseBiometric;
+        IsBiometricConfigured = EnableBiometric;
     }
 
     public Task<byte[]> CreateBackupAsync(CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary
- replace the deprecated fingerprint plugin with Plugin.Maui.Biometric and request the required Android permission
- update the biometric authentication service to use the native biometric prompt wrappers
- add master password change support in the vault view model and page so unlocked users can set a new password and opt-in to biometrics

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68f52271c4b4832a8e09bda2108d1c24