### PR TITLE
Fix biometric plugin restore failure

### DIFF
--- a/Password Phrase Producer/PasswordPhraseProducer.csproj
+++ b/Password Phrase Producer/PasswordPhraseProducer.csproj
@@ -78,7 +78,7 @@
                 <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
                 <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
                 <PackageReference Include="CommunityToolkit.Maui" Version="8.0.0" />
-                <PackageReference Include="Plugin.Maui.Biometric" Version="2.0.2" />
+                <PackageReference Include="Plugin.Maui.Biometric" Version="0.0.9" />
         </ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary
- change the Plugin.Maui.Biometric package reference to version 0.0.9 so that restore succeeds on the build agents

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f5601a6f14832a8d2ddd83cb19e772