### PR TITLE
Fix biometric plugin compatibility with .NET 8

### DIFF
--- a/Password Phrase Producer/PasswordPhraseProducer.csproj
+++ b/Password Phrase Producer/PasswordPhraseProducer.csproj
@@ -78,7 +78,7 @@
                 <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
                 <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
                 <PackageReference Include="CommunityToolkit.Maui" Version="8.0.0" />
-                <PackageReference Include="Plugin.Maui.Biometric" Version="0.0.9" />
+                <PackageReference Include="Plugin.Maui.Biometric" Version="0.0.8" />
         </ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary
- downgrade Plugin.Maui.Biometric to version 0.0.8 so it matches the app's .NET 8 targets

## Testing
- Not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f56487c59c832a84bf7f847383b24e