### PR TITLE
Downgrade biometric plugin for .NET 8 compatibility

### DIFF
--- a/Password Phrase Producer/PasswordPhraseProducer.csproj
+++ b/Password Phrase Producer/PasswordPhraseProducer.csproj
@@ -78,7 +78,7 @@
                 <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
                 <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
                 <PackageReference Include="CommunityToolkit.Maui" Version="8.0.0" />
-                <PackageReference Include="Plugin.Maui.Biometric" Version="0.0.8" />
+                <PackageReference Include="Plugin.Maui.Biometric" Version="0.0.7" />
         </ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary
- downgrade Plugin.Maui.Biometric to version 0.0.7 so it remains compatible with the project's .NET 8 targets

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f568bb0610832aada112655a5ee3e7