### PR TITLE
Fix biometric API usage and password prompts for .NET 9

### DIFF
--- a/Password Phrase Producer/Services/Security/BiometricAuthenticationService.cs
+++ b/Password Phrase Producer/Services/Security/BiometricAuthenticationService.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Plugin.Maui.Biometric;
@@ -10,10 +12,10 @@ public class BiometricAuthenticationService : IBiometricAuthenticationService
     public async Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default)
     {
         var status = await PluginBiometricService.Default
-            .GetAuthenticationStatusAsync(cancellationToken)
+            .GetAuthenticationStatusAsync(cancellationToken: cancellationToken)
             .ConfigureAwait(false);
 
-        return status == BiometricStatus.Available;
+        return IsAvailable(status);
     }
 
     public async Task<bool> AuthenticateAsync(string reason, CancellationToken cancellationToken = default)
@@ -30,5 +32,48 @@ public class BiometricAuthenticationService : IBiometricAuthenticationService
             .ConfigureAwait(false);
 
         return result.Status == BiometricResponseStatus.Success;
+    }
+
+    private static bool IsAvailable(object? status)
+    {
+        if (status is null)
+        {
+            return false;
+        }
+
+        if (status is Enum enumStatus)
+        {
+            return string.Equals(enumStatus.ToString(), "Available", StringComparison.Ordinal);
+        }
+
+        var statusProperty = status.GetType().GetRuntimeProperty("Status") ?? status.GetType().GetProperty("Status");
+        if (statusProperty is not null)
+        {
+            var value = statusProperty.GetValue(status);
+            if (value is null)
+            {
+                return false;
+            }
+
+            if (value is Enum nestedEnum)
+            {
+                return string.Equals(nestedEnum.ToString(), "Available", StringComparison.Ordinal);
+            }
+
+            if (value is bool boolValue)
+            {
+                return boolValue;
+            }
+
+            return string.Equals(value.ToString(), "Available", StringComparison.Ordinal);
+        }
+
+        var availableProperty = status.GetType().GetRuntimeProperty("IsAvailable") ?? status.GetType().GetProperty("IsAvailable");
+        if (availableProperty?.GetValue(status) is bool isAvailable)
+        {
+            return isAvailable;
+        }
+
+        return string.Equals(status.ToString(), "Available", StringComparison.Ordinal);
     }
 }

--- a/Password Phrase Producer/Views/Dialogs/PasswordPromptPage.cs
+++ b/Password Phrase Producer/Views/Dialogs/PasswordPromptPage.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+
+namespace Password_Phrase_Producer.Views.Dialogs;
+
+public sealed class PasswordPromptPage : ContentPage
+{
+    private readonly TaskCompletionSource<string?> _taskCompletionSource = new();
+    private readonly Entry _passwordEntry;
+
+    public PasswordPromptPage(string title, string message, string acceptButtonText, string cancelButtonText)
+    {
+        Title = title;
+
+        var messageLabel = new Label
+        {
+            Text = message,
+            HorizontalOptions = LayoutOptions.Fill,
+            HorizontalTextAlignment = TextAlignment.Center,
+            Margin = new Thickness(0, 0, 0, 12)
+        };
+
+        _passwordEntry = new Entry
+        {
+            Placeholder = string.Empty,
+            IsPassword = true,
+            Keyboard = Keyboard.Text,
+            HorizontalOptions = LayoutOptions.Fill
+        };
+
+        var acceptButton = new Button
+        {
+            Text = string.IsNullOrWhiteSpace(acceptButtonText) ? "OK" : acceptButtonText,
+            HorizontalOptions = LayoutOptions.Fill,
+            Margin = new Thickness(0, 12, 0, 0)
+        };
+        acceptButton.Clicked += (_, _) => Complete(_passwordEntry.Text);
+
+        var cancelButton = new Button
+        {
+            Text = string.IsNullOrWhiteSpace(cancelButtonText) ? "Abbrechen" : cancelButtonText,
+            HorizontalOptions = LayoutOptions.Fill
+        };
+        cancelButton.Clicked += (_, _) => Complete(null);
+
+        Content = new VerticalStackLayout
+        {
+            Padding = new Thickness(24),
+            Spacing = 12,
+            HorizontalOptions = LayoutOptions.Center,
+            VerticalOptions = LayoutOptions.Center,
+            Children =
+            {
+                messageLabel,
+                _passwordEntry,
+                acceptButton,
+                cancelButton
+            }
+        };
+    }
+
+    public Task<string?> WaitForResultAsync() => _taskCompletionSource.Task;
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        _passwordEntry.Focus();
+    }
+
+    protected override void OnDisappearing()
+    {
+        base.OnDisappearing();
+        if (!_taskCompletionSource.Task.IsCompleted)
+        {
+            _taskCompletionSource.TrySetResult(null);
+        }
+    }
+
+    protected override bool OnBackButtonPressed()
+    {
+        if (!_taskCompletionSource.Task.IsCompleted)
+        {
+            _taskCompletionSource.TrySetResult(null);
+        }
+
+        return base.OnBackButtonPressed();
+    }
+
+    private void Complete(string? result)
+    {
+        if (_taskCompletionSource.Task.IsCompleted)
+        {
+            return;
+        }
+
+        _taskCompletionSource.TrySetResult(result);
+    }
+}


### PR DESCRIPTION
## Summary
- update the biometric authentication service to use the new Plugin.Maui.Biometric status API while remaining backwards compatible
- replace the removed DisplayPromptAsync password overload with a custom modal password prompt page

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68f5c69dcc68832a9b2a73ec49d285dd