### PR TITLE
Fix extra closing brace in VaultPage

### DIFF
--- a/Password Phrase Producer/Views/VaultPage.xaml.cs
+++ b/Password Phrase Producer/Views/VaultPage.xaml.cs
@@ -306,4 +306,3 @@ public partial class VaultPage : ContentPage
         return result;
     }
 }
-}


### PR DESCRIPTION
## Summary
- remove the extra closing brace at the end of VaultPage.xaml.cs that broke the Android build

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f5dc6e5280832abf0f10d5a90f856d