### PR TITLE
Fix biometric status call cancellation support

### DIFF
--- a/Password Phrase Producer/Services/Security/BiometricAuthenticationService.cs
+++ b/Password Phrase Producer/Services/Security/BiometricAuthenticationService.cs
@@ -12,7 +12,8 @@ public class BiometricAuthenticationService : IBiometricAuthenticationService
     public async Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default)
     {
         var status = await PluginBiometricService.Default
-            .GetAuthenticationStatusAsync(cancellationToken: cancellationToken)
+            .GetAuthenticationStatusAsync()
+            .WaitAsync(cancellationToken)
             .ConfigureAwait(false);
 
         return IsAvailable(status);


### PR DESCRIPTION
## Summary
- update the biometric availability check to wait with a cancellation token now that the plugin method no longer accepts it directly

## Testing
- Not run (dotnet CLI is unavailable in the current environment)


------
https://chatgpt.com/codex/tasks/task_e_68f5de3e4084832a89672ac4c865f474