### PR TITLE
Improve Android biometric unlock and expose password management UI

### DIFF
--- a/Password Phrase Producer/PasswordPhraseProducer.csproj
+++ b/Password Phrase Producer/PasswordPhraseProducer.csproj
@@ -79,6 +79,7 @@
                 <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
                 <PackageReference Include="CommunityToolkit.Maui" Version="8.0.0" />
                 <PackageReference Include="Plugin.Maui.Biometric" Version="0.0.7" />
+                <PackageReference Include="Xamarin.AndroidX.Biometric" Version="1.1.0.13" Condition="'$(TargetFramework)' == 'net9.0-android'" />
         </ItemGroup>
 
 	<ItemGroup>

--- a/Password Phrase Producer/Platforms/Android/AndroidManifest.xml
+++ b/Password Phrase Producer/Platforms/Android/AndroidManifest.xml
@@ -4,4 +4,6 @@
         <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
         <uses-permission android:name="android.permission.INTERNET" />
         <uses-permission android:name="android.permission.USE_BIOMETRIC" />
+        <uses-permission android:name="android.permission.USE_FINGERPRINT" />
+        <uses-feature android:name="android.hardware.fingerprint" android:required="false" />
 </manifest>

--- a/Password Phrase Producer/Services/Security/BiometricAuthenticationService.cs
+++ b/Password Phrase Producer/Services/Security/BiometricAuthenticationService.cs
@@ -2,16 +2,138 @@ using System;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using Plugin.Maui.Biometric;
-using PluginBiometricService = Plugin.Maui.Biometric.BiometricAuthenticationService;
 
 namespace Password_Phrase_Producer.Services.Security;
 
 public class BiometricAuthenticationService : IBiometricAuthenticationService
 {
+#if ANDROID
+    public Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default)
+    {
+        var context = Microsoft.Maui.ApplicationModel.Platform.CurrentActivity ?? Microsoft.Maui.ApplicationModel.Platform.AppContext;
+        if (context is null)
+        {
+            return Task.FromResult(false);
+        }
+
+        var manager = AndroidX.Biometric.BiometricManager.From(context);
+        if (manager is null)
+        {
+            return Task.FromResult(false);
+        }
+
+        int status;
+        if (OperatingSystem.IsAndroidVersionAtLeast(30))
+        {
+            status = manager.CanAuthenticate((int)(AndroidX.Biometric.BiometricManager.Authenticators.BiometricStrong |
+                                                    AndroidX.Biometric.BiometricManager.Authenticators.BiometricWeak));
+        }
+        else
+        {
+#pragma warning disable CA1416 // Validate platform compatibility
+            status = manager.CanAuthenticate();
+#pragma warning restore CA1416 // Validate platform compatibility
+        }
+
+        return Task.FromResult(status == AndroidX.Biometric.BiometricManager.BiometricSuccess);
+    }
+
+    public async Task<bool> AuthenticateAsync(string reason, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(reason))
+        {
+            reason = "Authentifizierung erforderlich";
+        }
+
+        var activity = Microsoft.Maui.ApplicationModel.Platform.CurrentActivity;
+        if (activity is null)
+        {
+            return false;
+        }
+
+        var callback = new AndroidBiometricAuthCallback();
+        await Microsoft.Maui.ApplicationModel.MainThread.InvokeOnMainThreadAsync(() =>
+        {
+            var executor = AndroidX.Core.Content.ContextCompat.GetMainExecutor(activity);
+            var prompt = new AndroidX.Biometric.BiometricPrompt(activity, executor, callback);
+            callback.SetPrompt(prompt);
+
+            var promptInfoBuilder = new AndroidX.Biometric.BiometricPrompt.PromptInfo.Builder()
+                .SetTitle("Tresor entsperren")
+                .SetSubtitle(reason)
+                .SetNegativeButtonText("Abbrechen")
+                .SetConfirmationRequired(false);
+
+            if (OperatingSystem.IsAndroidVersionAtLeast(30))
+            {
+                promptInfoBuilder.SetAllowedAuthenticators((int)(AndroidX.Biometric.BiometricManager.Authenticators.BiometricStrong |
+                                                                 AndroidX.Biometric.BiometricManager.Authenticators.BiometricWeak));
+            }
+
+            var promptInfo = promptInfoBuilder.Build();
+            prompt.Authenticate(promptInfo);
+        });
+
+        using var registration = cancellationToken.Register(callback.Cancel);
+
+        try
+        {
+            return await callback.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            return false;
+        }
+    }
+
+    private sealed class AndroidBiometricAuthCallback : AndroidX.Biometric.BiometricPrompt.AuthenticationCallback
+    {
+        private readonly TaskCompletionSource<bool> _taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private AndroidX.Biometric.BiometricPrompt? _prompt;
+
+        public Task<bool> Task => _taskCompletionSource.Task;
+
+        public void SetPrompt(AndroidX.Biometric.BiometricPrompt prompt)
+        {
+            _prompt = prompt;
+        }
+
+        public void Cancel()
+        {
+            var prompt = _prompt;
+            if (prompt is null)
+            {
+                return;
+            }
+
+            Microsoft.Maui.ApplicationModel.MainThread.BeginInvokeOnMainThread(prompt.CancelAuthentication);
+        }
+
+        public override void OnAuthenticationSucceeded(AndroidX.Biometric.BiometricPrompt.AuthenticationResult result)
+        {
+            _taskCompletionSource.TrySetResult(true);
+        }
+
+        public override void OnAuthenticationFailed()
+        {
+            // keep waiting for another attempt
+        }
+
+        public override void OnAuthenticationError(int errorCode, Java.Lang.ICharSequence? errString)
+        {
+            if (errorCode == AndroidX.Biometric.BiometricPrompt.ErrorCanceled)
+            {
+                _taskCompletionSource.TrySetCanceled();
+                return;
+            }
+
+            _taskCompletionSource.TrySetResult(false);
+        }
+    }
+#else
     public async Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default)
     {
-        var status = await PluginBiometricService.Default
+        var status = await Plugin.Maui.Biometric.BiometricAuthenticationService.Default
             .GetAuthenticationStatusAsync()
             .WaitAsync(cancellationToken)
             .ConfigureAwait(false);
@@ -21,18 +143,18 @@ public class BiometricAuthenticationService : IBiometricAuthenticationService
 
     public async Task<bool> AuthenticateAsync(string reason, CancellationToken cancellationToken = default)
     {
-        var request = new AuthenticationRequest
+        var request = new Plugin.Maui.Biometric.AuthenticationRequest
         {
             Title = "Tresor entsperren",
             Subtitle = reason,
             NegativeText = "Abbrechen"
         };
 
-        var result = await PluginBiometricService.Default
+        var result = await Plugin.Maui.Biometric.BiometricAuthenticationService.Default
             .AuthenticateAsync(request, cancellationToken)
             .ConfigureAwait(false);
 
-        return result.Status == BiometricResponseStatus.Success;
+        return result.Status == Plugin.Maui.Biometric.BiometricResponseStatus.Success;
     }
 
     private static bool IsAvailable(object? status)
@@ -77,4 +199,5 @@ public class BiometricAuthenticationService : IBiometricAuthenticationService
 
         return string.Equals(status.ToString(), "Available", StringComparison.Ordinal);
     }
+#endif
 }

--- a/Password Phrase Producer/Views/VaultPage.xaml
+++ b/Password Phrase Producer/Views/VaultPage.xaml
@@ -92,7 +92,7 @@
                     </Border>
                 </Grid>
 
-                <Grid Grid.Row="1" ColumnDefinitions="*,Auto" ColumnSpacing="14">
+                <Grid Grid.Row="1" ColumnDefinitions="*,Auto,Auto" ColumnSpacing="14">
                     <Border
                         StrokeThickness="0"
                         BackgroundColor="#3B4AD1"
@@ -158,6 +158,31 @@
                         </Border.GestureRecognizers>
                         <Label
                             Text="⟳"
+                            FontSize="20"
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center"
+                            TextColor="#CFD3FF" />
+                    </Border>
+
+                    <Border
+                        Grid.Column="2"
+                        WidthRequest="52"
+                        HeightRequest="52"
+                        BackgroundColor="#1F2338"
+                        StrokeThickness="0"
+                        HorizontalOptions="End"
+                        VerticalOptions="Center">
+                        <Border.StrokeShape>
+                            <RoundRectangle CornerRadius="18" />
+                        </Border.StrokeShape>
+                        <Border.Shadow>
+                            <Shadow Brush="#1A000000" Radius="12" Offset="0,8" />
+                        </Border.Shadow>
+                        <Border.GestureRecognizers>
+                            <TapGestureRecognizer Tapped="OnChangePasswordTapped" />
+                        </Border.GestureRecognizers>
+                        <Label
+                            Text="🔑"
                             FontSize="20"
                             HorizontalOptions="Center"
                             VerticalOptions="Center"
@@ -537,7 +562,7 @@
                             TextColor="#D7DBF7"
                             BorderColor="#3B4AD1"
                             BorderWidth="1"
-                            IsVisible="{Binding IsBiometricConfigured}" />
+                            IsVisible="{Binding CanUseBiometric}" />
                     </VerticalStackLayout>
                 </VerticalStackLayout>
             </ScrollView>

--- a/Password Phrase Producer/Views/VaultPage.xaml.cs
+++ b/Password Phrase Producer/Views/VaultPage.xaml.cs
@@ -174,6 +174,17 @@ public partial class VaultPage : ContentPage
         }
     }
 
+    private async void OnChangePasswordTapped(object? sender, TappedEventArgs e)
+    {
+        if (!_viewModel.IsUnlocked)
+        {
+            await DisplayAlert("Tresor gesperrt", "Bitte entsperre den Tresor, bevor du das Master-Passwort ändern kannst.", "OK");
+            return;
+        }
+
+        await ChangeMasterPasswordAsync();
+    }
+
     private async Task ExportBackupAsync()
     {
         var backupBytes = await _viewModel.CreateBackupAsync();


### PR DESCRIPTION
## Summary
- implement a native Android biometric prompt and availability detection for fingerprint unlock
- show the fingerprint unlock button whenever biometrics are supported and add a quick access control to change the master password
- update Android permissions and package references required for biometric authentication

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f613ef698c832aaead5d30de51f6d5