### PR TITLE
Update AndroidX biometric dependency version

### DIFF
--- a/Password Phrase Producer/PasswordPhraseProducer.csproj
+++ b/Password Phrase Producer/PasswordPhraseProducer.csproj
@@ -79,7 +79,7 @@
                 <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
                 <PackageReference Include="CommunityToolkit.Maui" Version="8.0.0" />
                 <PackageReference Include="Plugin.Maui.Biometric" Version="0.0.7" />
-                <PackageReference Include="Xamarin.AndroidX.Biometric" Version="1.1.0.13" Condition="'$(TargetFramework)' == 'net9.0-android'" />
+                <PackageReference Include="Xamarin.AndroidX.Biometric" Version="1.1.0.28" Condition="'$(TargetFramework)' == 'net9.0-android'" />
         </ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary
- update the Xamarin.AndroidX.Biometric package reference for the Android target to version 1.1.0.28 to match Plugin.Maui.Biometric requirements and resolve the restore failure

## Testing
- dotnet restore "Password Phrase Producer/Password Phrase Producer.sln" *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f61a1bcbac832ab583b12705c0a756