### PR TITLE
Fix biometric prompt activity type

### DIFF
--- a/Password Phrase Producer/Services/Security/BiometricAuthenticationService.cs
+++ b/Password Phrase Producer/Services/Security/BiometricAuthenticationService.cs
@@ -51,11 +51,16 @@ public class BiometricAuthenticationService : IBiometricAuthenticationService
             return false;
         }
 
+        if (activity is not AndroidX.Fragment.App.FragmentActivity fragmentActivity)
+        {
+            return false;
+        }
+
         var callback = new AndroidBiometricAuthCallback();
         await Microsoft.Maui.ApplicationModel.MainThread.InvokeOnMainThreadAsync(() =>
         {
-            var executor = AndroidX.Core.Content.ContextCompat.GetMainExecutor(activity);
-            var prompt = new AndroidX.Biometric.BiometricPrompt(activity, executor, callback);
+            var executor = AndroidX.Core.Content.ContextCompat.GetMainExecutor(fragmentActivity);
+            var prompt = new AndroidX.Biometric.BiometricPrompt(fragmentActivity, executor, callback);
             callback.SetPrompt(prompt);
 
             var promptInfoBuilder = new AndroidX.Biometric.BiometricPrompt.PromptInfo.Builder()


### PR DESCRIPTION
## Summary
- guard against non-FragmentActivity hosts when invoking the Android biometric prompt
- create the biometric prompt using the FragmentActivity instance required by the AndroidX API

## Testing
- `dotnet build 'Password Phrase Producer/PasswordPhraseProducer.csproj' -t:Restore,Build -c Release -f net9.0-android` *(fails: dotnet CLI is unavailable in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f634c01a78832a8325174d102f0d75