### PR TITLE
Enhance vault UX with grouped entries and improved filters

### DIFF
--- a/Password Phrase Producer/Models/PasswordVaultEntry.cs
+++ b/Password Phrase Producer/Models/PasswordVaultEntry.cs
@@ -1,29 +1,91 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using System.Text.Json.Serialization;
 
 namespace Password_Phrase_Producer.Models;
 
-public class PasswordVaultEntry
+public class PasswordVaultEntry : INotifyPropertyChanged
 {
-    public Guid Id { get; set; } = Guid.NewGuid();
+    private Guid _id = Guid.NewGuid();
+    private string _label = string.Empty;
+    private string _username = string.Empty;
+    private string _password = string.Empty;
+    private string _category = string.Empty;
+    private string _url = string.Empty;
+    private string _notes = string.Empty;
+    private string _freeText = string.Empty;
+    private DateTimeOffset _modifiedAt = DateTimeOffset.UtcNow;
+    private bool _isPasswordVisible;
 
-    public string Label { get; set; } = string.Empty;
+    public event PropertyChangedEventHandler? PropertyChanged;
 
-    public string Username { get; set; } = string.Empty;
+    public Guid Id
+    {
+        get => _id;
+        set => SetProperty(ref _id, value);
+    }
 
-    public string Password { get; set; } = string.Empty;
+    public string Label
+    {
+        get => _label;
+        set => SetProperty(ref _label, value);
+    }
 
-    public string Category { get; set; } = string.Empty;
+    public string Username
+    {
+        get => _username;
+        set => SetProperty(ref _username, value);
+    }
 
-    public string Url { get; set; } = string.Empty;
+    public string Password
+    {
+        get => _password;
+        set => SetProperty(ref _password, value);
+    }
 
-    public string Notes { get; set; } = string.Empty;
+    public string Category
+    {
+        get => _category;
+        set => SetProperty(ref _category, value);
+    }
 
-    public string FreeText { get; set; } = string.Empty;
+    public string Url
+    {
+        get => _url;
+        set => SetProperty(ref _url, value);
+    }
 
-    public DateTimeOffset ModifiedAt { get; set; } = DateTimeOffset.UtcNow;
+    public string Notes
+    {
+        get => _notes;
+        set => SetProperty(ref _notes, value);
+    }
+
+    public string FreeText
+    {
+        get => _freeText;
+        set => SetProperty(ref _freeText, value);
+    }
+
+    public DateTimeOffset ModifiedAt
+    {
+        get => _modifiedAt;
+        set => SetProperty(ref _modifiedAt, value);
+    }
 
     [JsonIgnore]
     public string DisplayCategory => string.IsNullOrWhiteSpace(Category) ? "Allgemein" : Category.Trim();
+
+    [JsonIgnore]
+    public DateTimeOffset LocalModifiedAt => ModifiedAt.ToLocalTime();
+
+    [JsonIgnore]
+    public bool IsPasswordVisible
+    {
+        get => _isPasswordVisible;
+        set => SetProperty(ref _isPasswordVisible, value);
+    }
 
     public PasswordVaultEntry Clone()
     {
@@ -40,4 +102,29 @@ public class PasswordVaultEntry
             ModifiedAt = ModifiedAt
         };
     }
+
+    private bool SetProperty<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value))
+        {
+            return false;
+        }
+
+        field = value;
+        OnPropertyChanged(propertyName);
+
+        if (propertyName == nameof(Category))
+        {
+            OnPropertyChanged(nameof(DisplayCategory));
+        }
+        else if (propertyName == nameof(ModifiedAt))
+        {
+            OnPropertyChanged(nameof(LocalModifiedAt));
+        }
+
+        return true;
+    }
+
+    private void OnPropertyChanged(string? propertyName)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 }

--- a/Password Phrase Producer/ViewModels/VaultEntryGroup.cs
+++ b/Password Phrase Producer/ViewModels/VaultEntryGroup.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Password_Phrase_Producer.Models;
+
+namespace Password_Phrase_Producer.ViewModels;
+
+public class VaultEntryGroup : ObservableCollection<PasswordVaultEntry>
+{
+    public VaultEntryGroup(string category, IEnumerable<PasswordVaultEntry> entries)
+        : base(entries)
+    {
+        Category = category;
+    }
+
+    public string Category { get; }
+}

--- a/Password Phrase Producer/Views/VaultEntryEditorPage.xaml
+++ b/Password Phrase Producer/Views/VaultEntryEditorPage.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage
     x:Class="Password_Phrase_Producer.Views.VaultEntryEditorPage"
+    x:Name="EditorPage"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     Shell.NavBarIsVisible="False">
@@ -134,8 +135,44 @@
                             <Border.StrokeShape>
                                 <RoundRectangle CornerRadius="16" />
                             </Border.StrokeShape>
-                            <Entry Style="{StaticResource InputEntryStyle}" Placeholder="Ordner oder Gruppe" Text="{Binding Category}" />
+                            <Entry
+                                x:Name="CategoryEntry"
+                                Style="{StaticResource InputEntryStyle}"
+                                Placeholder="Ordner oder Gruppe"
+                                Text="{Binding Category}"
+                                TextChanged="OnCategoryTextChanged"
+                                Focused="OnCategoryEntryFocused"
+                                Unfocused="OnCategoryEntryUnfocused" />
                         </Border>
+                        <FlexLayout
+                            x:Name="CategorySuggestionsView"
+                            Direction="Row"
+                            Wrap="Wrap"
+                            AlignItems="Center"
+                            Margin="0,-10,0,10"
+                            BindableLayout.ItemsSource="{Binding Source={x:Reference EditorPage}, Path=CategorySuggestions}"
+                            IsVisible="False">
+                            <BindableLayout.ItemTemplate>
+                                <DataTemplate>
+                                    <Border
+                                        Margin="0,6,10,0"
+                                        Padding="12,6"
+                                        BackgroundColor="#2A2F4A"
+                                        StrokeThickness="0">
+                                        <Border.StrokeShape>
+                                            <RoundRectangle CornerRadius="14" />
+                                        </Border.StrokeShape>
+                                        <Border.GestureRecognizers>
+                                            <TapGestureRecognizer Tapped="OnCategorySuggestionTapped" CommandParameter="{Binding .}" />
+                                        </Border.GestureRecognizers>
+                                        <Label
+                                            Text="{Binding .}"
+                                            FontSize="12"
+                                            TextColor="#CFD3FF" />
+                                    </Border>
+                                </DataTemplate>
+                            </BindableLayout.ItemTemplate>
+                        </FlexLayout>
 
                         <Label Text="Benutzername" Style="{StaticResource FieldLabelStyle}" />
                         <Border

--- a/Password Phrase Producer/Views/VaultEntryEditorPage.xaml.cs
+++ b/Password Phrase Producer/Views/VaultEntryEditorPage.xaml.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using Microsoft.Maui.Controls;
 using Password_Phrase_Producer.Models;
@@ -7,19 +10,33 @@ namespace Password_Phrase_Producer.Views;
 public partial class VaultEntryEditorPage : ContentPage
 {
     private readonly TaskCompletionSource<PasswordVaultEntry?> _resultSource = new();
+    private readonly List<string> _availableCategories;
 
-    public VaultEntryEditorPage(PasswordVaultEntry entry, string title)
+    public VaultEntryEditorPage(PasswordVaultEntry entry, string title, IEnumerable<string> availableCategories)
     {
         InitializeComponent();
         BindingContext = entry;
         Title = title;
+
+        _availableCategories = availableCategories?
+            .Where(category => !string.IsNullOrWhiteSpace(category))
+            .Select(category => category.Trim())
+            .Distinct(StringComparer.CurrentCultureIgnoreCase)
+            .OrderBy(category => category, StringComparer.CurrentCultureIgnoreCase)
+            .ToList()
+            ?? new List<string>();
+
+        CategorySuggestions = new ObservableCollection<string>();
+        UpdateCategorySuggestions(entry.Category, false);
     }
 
     public Task<PasswordVaultEntry?> Result => _resultSource.Task;
 
-    public static async Task<PasswordVaultEntry?> ShowAsync(INavigation navigation, PasswordVaultEntry entry, string title)
+    public ObservableCollection<string> CategorySuggestions { get; }
+
+    public static async Task<PasswordVaultEntry?> ShowAsync(INavigation navigation, PasswordVaultEntry entry, string title, IEnumerable<string> availableCategories)
     {
-        var page = new VaultEntryEditorPage(entry, title);
+        var page = new VaultEntryEditorPage(entry, title, availableCategories);
         await navigation.PushModalAsync(page);
         return await page.Result.ConfigureAwait(false);
     }
@@ -43,6 +60,58 @@ public partial class VaultEntryEditorPage : ContentPage
 
     private void OnCloseTapped(object? sender, TappedEventArgs e)
         => OnCancelClicked(sender, EventArgs.Empty);
+
+    private void OnCategoryTextChanged(object? sender, TextChangedEventArgs e)
+        => UpdateCategorySuggestions(e.NewTextValue, CategoryEntry.IsFocused);
+
+    private void OnCategoryEntryFocused(object? sender, FocusEventArgs e)
+        => UpdateCategorySuggestions(CategoryEntry.Text, true);
+
+    private void OnCategoryEntryUnfocused(object? sender, FocusEventArgs e)
+    {
+        CategorySuggestionsView.IsVisible = false;
+    }
+
+    private void OnCategorySuggestionTapped(object? sender, TappedEventArgs e)
+    {
+        if (e.Parameter is not string category)
+        {
+            return;
+        }
+
+        CategoryEntry.Text = category;
+        CategoryEntry.CursorPosition = category.Length;
+        CategorySuggestionsView.IsVisible = false;
+    }
+
+    private void UpdateCategorySuggestions(string? query, bool showSuggestions)
+    {
+        if (_availableCategories.Count == 0)
+        {
+            CategorySuggestions.Clear();
+            CategorySuggestionsView.IsVisible = false;
+            return;
+        }
+
+        var normalizedQuery = query?.Trim() ?? string.Empty;
+
+        var suggestions = string.IsNullOrEmpty(normalizedQuery)
+            ? _availableCategories
+            : _availableCategories.Where(category => category.Contains(normalizedQuery, StringComparison.CurrentCultureIgnoreCase));
+
+        var distinctSuggestions = suggestions
+            .Where(category => !string.Equals(category, normalizedQuery, StringComparison.CurrentCultureIgnoreCase))
+            .Take(8)
+            .ToList();
+
+        CategorySuggestions.Clear();
+        foreach (var suggestion in distinctSuggestions)
+        {
+            CategorySuggestions.Add(suggestion);
+        }
+
+        CategorySuggestionsView.IsVisible = showSuggestions && CategorySuggestions.Count > 0;
+    }
 
     protected override bool OnBackButtonPressed()
     {

--- a/Password Phrase Producer/Views/VaultPage.xaml
+++ b/Password Phrase Producer/Views/VaultPage.xaml
@@ -5,6 +5,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:converters="clr-namespace:Password_Phrase_Producer.Converters"
     xmlns:models="clr-namespace:Password_Phrase_Producer.Models"
+    xmlns:viewmodels="clr-namespace:Password_Phrase_Producer.ViewModels"
     Padding="0"
     Shell.NavBarIsVisible="False">
     <ContentPage.Resources>
@@ -30,6 +31,7 @@
                 RowDefinitions="Auto,Auto">
                 <Grid
                     ColumnDefinitions="Auto,*,Auto"
+                    ColumnSpacing="20"
                     VerticalOptions="Start">
                     <Border
                         WidthRequest="52"
@@ -92,8 +94,9 @@
                     </Border>
                 </Grid>
 
-                <Grid Grid.Row="1" ColumnDefinitions="*,Auto,Auto" ColumnSpacing="14">
+                <Grid Grid.Row="1" RowDefinitions="Auto,Auto" RowSpacing="16">
                     <Border
+                        Grid.Row="0"
                         StrokeThickness="0"
                         BackgroundColor="#3B4AD1"
                         Padding="18,14"
@@ -139,55 +142,104 @@
                         </Border.GestureRecognizers>
                     </Border>
 
-                    <Border
-                        Grid.Column="1"
-                        WidthRequest="52"
-                        HeightRequest="52"
-                        BackgroundColor="#1F2338"
-                        StrokeThickness="0"
-                        HorizontalOptions="End"
-                        VerticalOptions="Center">
-                        <Border.StrokeShape>
-                            <RoundRectangle CornerRadius="18" />
-                        </Border.StrokeShape>
-                        <Border.Shadow>
-                            <Shadow Brush="#1A000000" Radius="12" Offset="0,8" />
-                        </Border.Shadow>
-                        <Border.GestureRecognizers>
-                            <TapGestureRecognizer Tapped="OnSyncOptionsClicked" />
-                        </Border.GestureRecognizers>
-                        <Label
-                            Text="⟳"
-                            FontSize="20"
-                            HorizontalOptions="Center"
-                            VerticalOptions="Center"
-                            TextColor="#CFD3FF" />
-                    </Border>
+                    <Grid Grid.Row="1" ColumnDefinitions="*,Auto,Auto" ColumnSpacing="14">
+                        <Border
+                            BackgroundColor="#1F2338"
+                            StrokeThickness="0"
+                            Padding="16,12"
+                            HorizontalOptions="Fill"
+                            VerticalOptions="Center">
+                            <Border.StrokeShape>
+                                <RoundRectangle CornerRadius="20" />
+                            </Border.StrokeShape>
+                            <Border.Shadow>
+                                <Shadow Brush="#1A000000" Radius="12" Offset="0,8" />
+                            </Border.Shadow>
+                            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="12">
+                                <Label
+                                    Text="🔍"
+                                    FontSize="16"
+                                    VerticalOptions="Center"
+                                    TextColor="#CFD3FF" />
+                                <Entry
+                                    Grid.Column="1"
+                                    Text="{Binding SearchQuery}"
+                                    Placeholder="Suche im Tresor"
+                                    PlaceholderColor="#7F85B2"
+                                    TextColor="White"
+                                    BackgroundColor="Transparent"
+                                    ClearButtonVisibility="WhileEditing" />
+                            </Grid>
+                        </Border>
 
-                    <Border
-                        Grid.Column="2"
-                        WidthRequest="52"
-                        HeightRequest="52"
-                        BackgroundColor="#1F2338"
-                        StrokeThickness="0"
-                        HorizontalOptions="End"
-                        VerticalOptions="Center">
-                        <Border.StrokeShape>
-                            <RoundRectangle CornerRadius="18" />
-                        </Border.StrokeShape>
-                        <Border.Shadow>
-                            <Shadow Brush="#1A000000" Radius="12" Offset="0,8" />
-                        </Border.Shadow>
-                        <Border.GestureRecognizers>
-                            <TapGestureRecognizer Tapped="OnChangePasswordTapped" />
-                        </Border.GestureRecognizers>
-                        <Label
-                            Text="🔑"
-                            FontSize="20"
+                        <Border
+                            Grid.Column="1"
+                            BackgroundColor="#1F2338"
+                            StrokeThickness="0"
+                            Padding="14,10"
                             HorizontalOptions="Center"
-                            VerticalOptions="Center"
-                            TextColor="#CFD3FF" />
-                    </Border>
+                            VerticalOptions="Center">
+                            <Border.StrokeShape>
+                                <RoundRectangle CornerRadius="20" />
+                            </Border.StrokeShape>
+                            <Border.Shadow>
+                                <Shadow Brush="#1A000000" Radius="12" Offset="0,8" />
+                            </Border.Shadow>
+                            <Picker
+                                ItemsSource="{Binding CategoryFilterOptions}"
+                                SelectedItem="{Binding SelectedCategory}"
+                                Title="Kategorie wählen"
+                                FontSize="14"
+                                TextColor="#E0E4FF"
+                                TitleColor="#7F85B2" />
+                        </Border>
+
+                        <HorizontalStackLayout Grid.Column="2" Spacing="12" HorizontalOptions="End" VerticalOptions="Center">
+                            <Border
+                                WidthRequest="52"
+                                HeightRequest="52"
+                                BackgroundColor="#1F2338"
+                                StrokeThickness="0">
+                                <Border.StrokeShape>
+                                    <RoundRectangle CornerRadius="18" />
+                                </Border.StrokeShape>
+                                <Border.Shadow>
+                                    <Shadow Brush="#1A000000" Radius="12" Offset="0,8" />
+                                </Border.Shadow>
+                                <Border.GestureRecognizers>
+                                    <TapGestureRecognizer Tapped="OnSyncOptionsClicked" />
+                                </Border.GestureRecognizers>
+                                <Label
+                                    Text="⟳"
+                                    FontSize="20"
+                                    HorizontalOptions="Center"
+                                    VerticalOptions="Center"
+                                    TextColor="#CFD3FF" />
+                            </Border>
+
+                            <Border
+                                WidthRequest="52"
+                                HeightRequest="52"
+                                BackgroundColor="#1F2338"
+                                StrokeThickness="0">
+                                <Border.StrokeShape>
+                                    <RoundRectangle CornerRadius="18" />
+                                </Border.StrokeShape>
+                                <Border.Shadow>
+                                    <Shadow Brush="#1A000000" Radius="12" Offset="0,8" />
+                                </Border.Shadow>
+                                <Border.GestureRecognizers>
+                                    <TapGestureRecognizer Tapped="OnChangePasswordTapped" />
+                                </Border.GestureRecognizers>
+                                <Label
+                                    Text="🔑"
+                                    FontSize="20"
+                                    HorizontalOptions="Center"
+                                    VerticalOptions="Center"
+                                    TextColor="#CFD3FF" />
+                            </Border>
+                        </HorizontalStackLayout>
+                    </Grid>
                 </Grid>
             </Grid>
 
@@ -195,11 +247,22 @@
                 x:Name="VaultCollectionView"
                 Grid.Row="1"
                 Margin="24,0,24,24"
-                ItemsSource="{Binding Entries}"
+                ItemsSource="{Binding EntryGroups}"
                 SelectionMode="None"
                 ItemSizingStrategy="MeasureAllItems"
                 VerticalOptions="FillAndExpand"
-                VerticalScrollBarVisibility="Never">
+                VerticalScrollBarVisibility="Never"
+                IsGrouped="True">
+            <CollectionView.GroupHeaderTemplate>
+                <DataTemplate x:DataType="viewmodels:VaultEntryGroup">
+                    <Label
+                        Text="{Binding Category}"
+                        FontSize="18"
+                        FontAttributes="Bold"
+                        TextColor="#D8DCFF"
+                        Margin="0,24,0,12" />
+                </DataTemplate>
+            </CollectionView.GroupHeaderTemplate>
             <CollectionView.EmptyView>
                 <VerticalStackLayout
                     Padding="32"
@@ -350,14 +413,47 @@
                                     TextColor="#A8ACCD"
                                     FontAttributes="Bold"
                                     VerticalOptions="Center" />
-                                <Grid Grid.Column="1" ColumnDefinitions="*,Auto" ColumnSpacing="10">
+                                <Grid Grid.Column="1" ColumnDefinitions="*,Auto,Auto" ColumnSpacing="10">
                                     <Label
-                                        Text="{Binding Password, Converter={StaticResource PasswordMaskConverter}}"
                                         FontSize="15"
                                         TextColor="#ECEFFF"
-                                        LineBreakMode="TailTruncation" />
+                                        LineBreakMode="NoWrap">
+                                        <Label.Triggers>
+                                            <DataTrigger TargetType="Label" Binding="{Binding IsPasswordVisible}" Value="True">
+                                                <Setter Property="Text" Value="{Binding Password}" />
+                                            </DataTrigger>
+                                            <DataTrigger TargetType="Label" Binding="{Binding IsPasswordVisible}" Value="False">
+                                                <Setter Property="Text" Value="{Binding Password, Converter={StaticResource PasswordMaskConverter}}" />
+                                            </DataTrigger>
+                                        </Label.Triggers>
+                                    </Label>
                                     <Border
                                         Grid.Column="1"
+                                        Padding="10,4"
+                                        BackgroundColor="#2C3352"
+                                        StrokeThickness="0"
+                                        VerticalOptions="Center">
+                                        <Border.StrokeShape>
+                                            <RoundRectangle CornerRadius="14" />
+                                        </Border.StrokeShape>
+                                        <Border.GestureRecognizers>
+                                            <TapGestureRecognizer
+                                                Tapped="OnTogglePasswordVisibilityTapped"
+                                                CommandParameter="{Binding .}" />
+                                        </Border.GestureRecognizers>
+                                        <Label
+                                            FontSize="12"
+                                            TextColor="#CED4FF"
+                                            Text="Anzeigen">
+                                            <Label.Triggers>
+                                                <DataTrigger TargetType="Label" Binding="{Binding IsPasswordVisible}" Value="True">
+                                                    <Setter Property="Text" Value="Verbergen" />
+                                                </DataTrigger>
+                                            </Label.Triggers>
+                                        </Label>
+                                    </Border>
+                                    <Border
+                                        Grid.Column="2"
                                         Padding="10,4"
                                         BackgroundColor="#2C3352"
                                         StrokeThickness="0"
@@ -435,7 +531,7 @@
                                 </Label>
 
                                 <Label
-                                    Text="{Binding ModifiedAt, StringFormat='Geändert: {0:G}'}"
+                                    Text="{Binding LocalModifiedAt, StringFormat='Geändert: {0:G}'}"
                                     FontSize="11"
                                     TextColor="#8E93BA"
                                     HorizontalOptions="End" />

--- a/Password Phrase Producer/Views/VaultPage.xaml.cs
+++ b/Password Phrase Producer/Views/VaultPage.xaml.cs
@@ -157,7 +157,7 @@ public partial class VaultPage : ContentPage
         BeginModalInteraction();
         try
         {
-            var result = await VaultEntryEditorPage.ShowAsync(Navigation, entry, title);
+            var result = await VaultEntryEditorPage.ShowAsync(Navigation, entry, title, _viewModel.AvailableCategories);
             if (result is null)
             {
                 return;
@@ -185,6 +185,16 @@ public partial class VaultPage : ContentPage
 
         await Clipboard.Default.SetTextAsync(entry.Password);
         await DisplayAlert("Kopiert", "Das Passwort wurde in die Zwischenablage kopiert.", "OK");
+    }
+
+    private void OnTogglePasswordVisibilityTapped(object? sender, TappedEventArgs e)
+    {
+        if (e.Parameter is not PasswordVaultEntry entry)
+        {
+            return;
+        }
+
+        entry.IsPasswordVisible = !entry.IsPasswordVisible;
     }
 
     private void OnOpenMenuTapped(object? sender, TappedEventArgs e)


### PR DESCRIPTION
## Summary
- group vault entries by category and add search and category filter controls with updated header spacing
- add inline password visibility toggles, display local modified timestamps, and refresh vault layout styling
- surface existing category suggestions while editing entries for quicker data entry

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f67ce291e4832a888cf069cc4b0bee