### PR TITLE
Handle vault action menu cross-platform

### DIFF
--- a/Password Phrase Producer/Views/VaultPage.xaml.cs
+++ b/Password Phrase Producer/Views/VaultPage.xaml.cs
@@ -168,12 +168,49 @@ public partial class VaultPage : ContentPage
         }
     }
 
-    private void OnVaultActionsTapped(object? sender, TappedEventArgs e)
+    private async void OnVaultActionsTapped(object? sender, TappedEventArgs e)
     {
-        if (sender is Element element)
+#if WINDOWS
+        if (sender is Element element && element.Handler?.PlatformView is Microsoft.UI.Xaml.FrameworkElement frameworkElement)
         {
-            FlyoutBase.ShowAttachedFlyout(element);
+            Microsoft.UI.Xaml.Controls.FlyoutBase.ShowAttachedFlyout(frameworkElement);
         }
+#else
+        const string exportBackup = "Backup exportieren";
+        const string importBackup = "Backup importieren";
+        const string exportEncrypted = "Verschlüsselten Tresor exportieren";
+        const string importEncrypted = "Verschlüsselten Tresor importieren";
+        const string changePassword = "Master-Passwort ändern";
+
+        var selection = await DisplayActionSheet(
+            "Aktionen",
+            "Abbrechen",
+            null,
+            exportBackup,
+            importBackup,
+            exportEncrypted,
+            importEncrypted,
+            changePassword);
+
+        switch (selection)
+        {
+            case exportBackup:
+                OnExportBackupClicked(sender, EventArgs.Empty);
+                break;
+            case importBackup:
+                OnImportBackupClicked(sender, EventArgs.Empty);
+                break;
+            case exportEncrypted:
+                OnExportEncryptedClicked(sender, EventArgs.Empty);
+                break;
+            case importEncrypted:
+                OnImportEncryptedClicked(sender, EventArgs.Empty);
+                break;
+            case changePassword:
+                OnChangePasswordMenuItemClicked(sender, EventArgs.Empty);
+                break;
+        }
+#endif
     }
 
     private async void OnExportBackupClicked(object? sender, EventArgs e)


### PR DESCRIPTION
## Summary
- add platform-specific handling for the vault actions menu so android builds no longer reference Windows-only APIs
- fallback to an action sheet on non-Windows platforms to keep the vault operations accessible

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f6abaf6f54832a9c4cc9c3eddaa38c