### PR TITLE
Fix Windows vault actions flyout without ContextFlyout property

### DIFF
--- a/Password Phrase Producer/Views/VaultPage.xaml
+++ b/Password Phrase Producer/Views/VaultPage.xaml
@@ -158,15 +158,6 @@
                         <Border.GestureRecognizers>
                             <TapGestureRecognizer Tapped="OnVaultActionsTapped" />
                         </Border.GestureRecognizers>
-                        <Border.ContextFlyout>
-                            <MenuFlyout>
-                                <MenuFlyoutItem Text="Backup exportieren" Clicked="OnExportBackupClicked" />
-                                <MenuFlyoutItem Text="Backup importieren" Clicked="OnImportBackupClicked" />
-                                <MenuFlyoutItem Text="Verschlüsselten Tresor exportieren" Clicked="OnExportEncryptedClicked" />
-                                <MenuFlyoutItem Text="Verschlüsselten Tresor importieren" Clicked="OnImportEncryptedClicked" />
-                                <MenuFlyoutItem Text="Master-Passwort ändern" Clicked="OnChangePasswordMenuItemClicked" />
-                            </MenuFlyout>
-                        </Border.ContextFlyout>
                         <HorizontalStackLayout Spacing="10" VerticalOptions="Center">
                             <Label
                                 Text="☰"


### PR DESCRIPTION
## Summary
- remove the deprecated Border.ContextFlyout markup that caused XAML compilation to fail
- create the vault actions MenuFlyout programmatically on Windows so the existing handler can still open it

## Testing
- dotnet build *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f6b1c2aa98832aa80d05a96b648cd1