### PR TITLE
Fix WinUI flyout invocation for Vault actions

### DIFF
--- a/Password Phrase Producer/Views/VaultPage.xaml.cs
+++ b/Password Phrase Producer/Views/VaultPage.xaml.cs
@@ -183,8 +183,8 @@ public partial class VaultPage : ContentPage
 #if WINDOWS
         if (sender is Element element && element.Handler?.PlatformView is Microsoft.UI.Xaml.FrameworkElement frameworkElement)
         {
-            FlyoutBase.SetAttachedFlyout(frameworkElement, _vaultActionsFlyout);
-            FlyoutBase.ShowAttachedFlyout(frameworkElement);
+            Microsoft.UI.Xaml.Controls.FlyoutBase.SetAttachedFlyout(frameworkElement, _vaultActionsFlyout);
+            Microsoft.UI.Xaml.Controls.FlyoutBase.ShowAttachedFlyout(frameworkElement);
         }
 #else
         const string exportBackup = "Backup exportieren";
@@ -384,7 +384,7 @@ public partial class VaultPage : ContentPage
 
     private async Task<string?> DisplayPasswordPromptAsync(string title, string message, string accept, string cancel)
     {
-        var navigation = Navigation ?? Application.Current?.MainPage?.Navigation;
+        var navigation = Navigation ?? Microsoft.Maui.Controls.Application.Current?.MainPage?.Navigation;
         if (navigation is null)
         {
             throw new InvalidOperationException("Keine Navigationsinstanz verfügbar, um den Passwortdialog zu öffnen.");


### PR DESCRIPTION
## Summary
- qualify the WinUI flyout helper calls so the MSIX build can locate the correct API
- resolve the ambiguous Application reference when opening the password prompt navigation

## Testing
- ⚠️ `dotnet build "Password Phrase Producer/Password Phrase Producer.sln"` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f7191ee150832a96eccfb8816877a4