### PR TITLE
Fix WinUI flyout usage on Windows build

### DIFF
--- a/Password Phrase Producer/Views/VaultPage.xaml.cs
+++ b/Password Phrase Producer/Views/VaultPage.xaml.cs
@@ -10,6 +10,7 @@ using Microsoft.Maui.Storage;
 #if WINDOWS
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
 #endif
 using Password_Phrase_Producer.Models;
 using Password_Phrase_Producer.ViewModels;
@@ -183,8 +184,8 @@ public partial class VaultPage : ContentPage
 #if WINDOWS
         if (sender is Element element && element.Handler?.PlatformView is Microsoft.UI.Xaml.FrameworkElement frameworkElement)
         {
-            Microsoft.UI.Xaml.Controls.FlyoutBase.SetAttachedFlyout(frameworkElement, _vaultActionsFlyout);
-            Microsoft.UI.Xaml.Controls.FlyoutBase.ShowAttachedFlyout(frameworkElement);
+            FlyoutBase.SetAttachedFlyout(frameworkElement, _vaultActionsFlyout);
+            FlyoutBase.ShowAttachedFlyout(frameworkElement);
         }
 #else
         const string exportBackup = "Backup exportieren";


### PR DESCRIPTION
## Summary
- add the WinUI primitives namespace when building for Windows
- call FlyoutBase helper methods without fully qualifying the namespace to avoid missing type errors

## Testing
- N/A (not run)

------
https://chatgpt.com/codex/tasks/task_e_68f760039480832a8ab6fa015d70c0ed