### PR TITLE
Fix FlyoutBase ambiguity on Windows

### DIFF
--- a/Password Phrase Producer/Views/VaultPage.xaml.cs
+++ b/Password Phrase Producer/Views/VaultPage.xaml.cs
@@ -10,7 +10,7 @@ using Microsoft.Maui.Storage;
 #if WINDOWS
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
+using WinUIFlyoutBase = Microsoft.UI.Xaml.Controls.Primitives.FlyoutBase;
 #endif
 using Password_Phrase_Producer.Models;
 using Password_Phrase_Producer.ViewModels;
@@ -184,8 +184,8 @@ public partial class VaultPage : ContentPage
 #if WINDOWS
         if (sender is Element element && element.Handler?.PlatformView is Microsoft.UI.Xaml.FrameworkElement frameworkElement)
         {
-            FlyoutBase.SetAttachedFlyout(frameworkElement, _vaultActionsFlyout);
-            FlyoutBase.ShowAttachedFlyout(frameworkElement);
+            WinUIFlyoutBase.SetAttachedFlyout(frameworkElement, _vaultActionsFlyout);
+            WinUIFlyoutBase.ShowAttachedFlyout(frameworkElement);
         }
 #else
         const string exportBackup = "Backup exportieren";


### PR DESCRIPTION
## Summary
- add a WinUI alias for FlyoutBase so that Windows-specific code uses the correct type
- call the WinUI FlyoutBase APIs explicitly to avoid the namespace clash during Windows builds

## Testing
- `dotnet build 'Password Phrase Producer/PasswordPhraseProducer.csproj' -c Release -f net9.0-windows10.0.19041.0` *(fails: dotnet CLI is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68f7c073fd90832a80d145f2986fa162