### PR TITLE
Improve vault entry button layout and handle editor errors

### DIFF
--- a/Password Phrase Producer/Views/VaultPage.xaml
+++ b/Password Phrase Producer/Views/VaultPage.xaml
@@ -125,7 +125,7 @@
                                         VerticalOptions="Center"
                                         TextColor="White" />
                                 </Border>
-                                <VerticalStackLayout Spacing="2" VerticalOptions="Center">
+                                <VerticalStackLayout Grid.Column="1" Spacing="2" VerticalOptions="Center">
                                     <Label
                                         Text="Neuer Eintrag"
                                         FontSize="18"

--- a/Password Phrase Producer/Views/VaultPage.xaml.cs
+++ b/Password Phrase Producer/Views/VaultPage.xaml.cs
@@ -62,6 +62,12 @@ public partial class VaultPage : ContentPage
 
     private async void OnAddEntryClicked(object? sender, TappedEventArgs e)
     {
+        if (!_viewModel.IsUnlocked)
+        {
+            await DisplayAlert("Tresor gesperrt", "Bitte entsperre den Tresor, bevor du neue Einträge hinzufügst.", "OK");
+            return;
+        }
+
         var entry = new PasswordVaultEntry();
         await ShowEditorAsync(entry, "Neuer Tresor-Eintrag");
     }
@@ -131,13 +137,30 @@ public partial class VaultPage : ContentPage
         BeginModalInteraction();
         try
         {
-            var result = await VaultEntryEditorPage.ShowAsync(Navigation, entry, title, _viewModel.AvailableCategories);
+            PasswordVaultEntry? result;
+            try
+            {
+                result = await VaultEntryEditorPage.ShowAsync(Navigation, entry, title, _viewModel.AvailableCategories);
+            }
+            catch (Exception ex)
+            {
+                await DisplayAlert("Fehler", $"Der Editor konnte nicht geöffnet werden: {ex.Message}", "OK");
+                return;
+            }
+
             if (result is null)
             {
                 return;
             }
 
-            await _viewModel.SaveEntryAsync(result);
+            try
+            {
+                await _viewModel.SaveEntryAsync(result);
+            }
+            catch (Exception ex)
+            {
+                await DisplayAlert("Fehler", $"Der Eintrag konnte nicht gespeichert werden: {ex.Message}", "OK");
+            }
         }
         finally
         {


### PR DESCRIPTION
## Summary
- ensure the "Neuer Eintrag" card positions its text beside the + icon instead of underneath it
- prevent crashes when opening or saving the entry editor by guarding against a locked vault and surfacing errors to the user

## Testing
- `dotnet build 'Password Phrase Producer/Password Phrase Producer.sln'` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f7c9c313f4832abe83e70a88f56338