### PR TITLE
Fix vault entry modal navigation and streamline vault header UI

### DIFF
--- a/Password Phrase Producer/Views/VaultEntryEditorPage.xaml.cs
+++ b/Password Phrase Producer/Views/VaultEntryEditorPage.xaml.cs
@@ -34,10 +34,16 @@ public partial class VaultEntryEditorPage : ContentPage
 
     public ObservableCollection<string> CategorySuggestions { get; }
 
-    public static async Task<PasswordVaultEntry?> ShowAsync(INavigation navigation, PasswordVaultEntry entry, string title, IEnumerable<string> availableCategories)
+    public static async Task<PasswordVaultEntry?> ShowAsync(INavigation? navigation, PasswordVaultEntry entry, string title, IEnumerable<string> availableCategories)
     {
         var page = new VaultEntryEditorPage(entry, title, availableCategories);
-        await navigation.PushModalAsync(page);
+        var navigationHost = navigation ?? Application.Current?.MainPage?.Navigation;
+        if (navigationHost is null)
+        {
+            throw new InvalidOperationException("Kein Navigationsstack verfügbar.");
+        }
+
+        await navigationHost.PushModalAsync(page);
         return await page.Result.ConfigureAwait(false);
     }
 

--- a/Password Phrase Producer/Views/VaultPage.xaml
+++ b/Password Phrase Producer/Views/VaultPage.xaml
@@ -99,7 +99,7 @@
                         <Border
                             StrokeThickness="0"
                             BackgroundColor="#3B4AD1"
-                            Padding="16,14"
+                            Padding="18,14"
                             HorizontalOptions="Fill"
                             VerticalOptions="Center">
                             <Border.StrokeShape>
@@ -108,75 +108,61 @@
                             <Border.Shadow>
                                 <Shadow Brush="#30000000" Radius="18" Offset="0,10" />
                             </Border.Shadow>
-                            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="14" VerticalOptions="Center">
+                            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="16" VerticalOptions="Center">
                                 <Border
-                                    WidthRequest="44"
-                                    HeightRequest="44"
+                                    WidthRequest="48"
+                                    HeightRequest="48"
                                     BackgroundColor="#5465FF"
                                     StrokeThickness="0"
                                     VerticalOptions="Center">
                                     <Border.StrokeShape>
-                                        <RoundRectangle CornerRadius="16" />
+                                        <RoundRectangle CornerRadius="18" />
                                     </Border.StrokeShape>
                                     <Label
                                         Text="＋"
-                                        FontSize="22"
+                                        FontSize="24"
                                         HorizontalOptions="Center"
                                         VerticalOptions="Center"
                                         TextColor="White" />
                                 </Border>
-                                <VerticalStackLayout Grid.Column="1" Spacing="2" VerticalOptions="Center">
-                                    <Label
-                                        Text="Neuer Eintrag"
-                                        FontSize="18"
-                                        FontAttributes="Bold"
-                                        TextColor="White" />
-                                    <Label
-                                        Text="Manuell hinzufügen"
-                                        FontSize="13"
-                                        TextColor="#E3E6FF" />
-                                </VerticalStackLayout>
+                                <Label
+                                    Grid.Column="1"
+                                    Text="Neuer Eintrag"
+                                    FontSize="20"
+                                    FontAttributes="Bold"
+                                    VerticalOptions="Center"
+                                    TextColor="White" />
                             </Grid>
                             <Border.GestureRecognizers>
                                 <TapGestureRecognizer Tapped="OnAddEntryClicked" />
                             </Border.GestureRecognizers>
                         </Border>
 
-                    <Border
-                        Grid.Column="1"
-                        Padding="18,12"
-                        StrokeThickness="0"
-                        BackgroundColor="#1F2338"
-                        HorizontalOptions="End"
-                        VerticalOptions="Center">
-                        <Border.StrokeShape>
-                            <RoundRectangle CornerRadius="20" />
-                        </Border.StrokeShape>
-                        <Border.Shadow>
-                            <Shadow Brush="#1A000000" Radius="12" Offset="0,8" />
-                        </Border.Shadow>
-                        <Border.GestureRecognizers>
-                            <TapGestureRecognizer Tapped="OnVaultActionsTapped" />
-                        </Border.GestureRecognizers>
-                        <HorizontalStackLayout Spacing="10" VerticalOptions="Center">
+                        <Border
+                            Grid.Column="1"
+                            WidthRequest="52"
+                            HeightRequest="52"
+                            StrokeThickness="0"
+                            Padding="0"
+                            BackgroundColor="#1F2338"
+                            HorizontalOptions="End"
+                            VerticalOptions="Center">
+                            <Border.StrokeShape>
+                                <RoundRectangle CornerRadius="20" />
+                            </Border.StrokeShape>
+                            <Border.Shadow>
+                                <Shadow Brush="#1A000000" Radius="12" Offset="0,8" />
+                            </Border.Shadow>
+                            <Border.GestureRecognizers>
+                                <TapGestureRecognizer Tapped="OnVaultActionsTapped" />
+                            </Border.GestureRecognizers>
                             <Label
-                                Text="☰"
-                                FontSize="18"
+                                Text="⚙"
+                                FontSize="20"
+                                HorizontalOptions="Center"
                                 VerticalOptions="Center"
                                 TextColor="#CFD3FF" />
-                            <Label
-                                Text="Aktionen"
-                                FontSize="16"
-                                FontAttributes="Bold"
-                                VerticalOptions="Center"
-                                TextColor="#E0E4FF" />
-                            <Label
-                                Text="▾"
-                                FontSize="14"
-                                VerticalOptions="Center"
-                                TextColor="#727AA7" />
-                        </HorizontalStackLayout>
-                    </Border>
+                        </Border>
                     </Grid>
 
                     <Grid Grid.Row="1" ColumnDefinitions="*,Auto" ColumnSpacing="14">


### PR DESCRIPTION
## Summary
- add a navigation fallback when opening the vault entry editor to prevent null reference failures
- simplify the "Neuer Eintrag" card layout and shrink the actions control to improve available space and readability

## Testing
- not run (dotnet CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68f7e71a3d44832a99223fd32096bc9b