### PR TITLE
Handle null UI references in vault entry editor suggestions

### DIFF
--- a/Password Phrase Producer/Views/VaultEntryEditorPage.xaml.cs
+++ b/Password Phrase Producer/Views/VaultEntryEditorPage.xaml.cs
@@ -68,14 +68,20 @@ public partial class VaultEntryEditorPage : ContentPage
         => OnCancelClicked(sender, EventArgs.Empty);
 
     private void OnCategoryTextChanged(object? sender, TextChangedEventArgs e)
-        => UpdateCategorySuggestions(e.NewTextValue, CategoryEntry.IsFocused);
+    {
+        var isFocused = CategoryEntry?.IsFocused ?? false;
+        UpdateCategorySuggestions(e.NewTextValue, isFocused);
+    }
 
     private void OnCategoryEntryFocused(object? sender, FocusEventArgs e)
-        => UpdateCategorySuggestions(CategoryEntry.Text, true);
+        => UpdateCategorySuggestions(CategoryEntry?.Text, true);
 
     private void OnCategoryEntryUnfocused(object? sender, FocusEventArgs e)
     {
-        CategorySuggestionsView.IsVisible = false;
+        if (CategorySuggestionsView is not null)
+        {
+            CategorySuggestionsView.IsVisible = false;
+        }
     }
 
     private void OnCategorySuggestionTapped(object? sender, TappedEventArgs e)
@@ -95,7 +101,10 @@ public partial class VaultEntryEditorPage : ContentPage
         if (_availableCategories.Count == 0)
         {
             CategorySuggestions.Clear();
-            CategorySuggestionsView.IsVisible = false;
+            if (CategorySuggestionsView is not null)
+            {
+                CategorySuggestionsView.IsVisible = false;
+            }
             return;
         }
 
@@ -116,7 +125,10 @@ public partial class VaultEntryEditorPage : ContentPage
             CategorySuggestions.Add(suggestion);
         }
 
-        CategorySuggestionsView.IsVisible = showSuggestions && CategorySuggestions.Count > 0;
+        if (CategorySuggestionsView is not null)
+        {
+            CategorySuggestionsView.IsVisible = showSuggestions && CategorySuggestions.Count > 0;
+        }
     }
 
     protected override bool OnBackButtonPressed()


### PR DESCRIPTION
## Summary
- guard category suggestion handlers against null UI elements when the editor opens without categories
- ensure category suggestion visibility checks account for the control not being initialized yet

## Testing
- `dotnet build 'Password Phrase Producer/Password Phrase Producer.sln'` *(fails: dotnet command unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f7fd06854c832a951038a542947629