### PR TITLE
Fix vault editor navigation host resolution

### DIFF
--- a/Password Phrase Producer/Views/VaultEntryEditorPage.xaml.cs
+++ b/Password Phrase Producer/Views/VaultEntryEditorPage.xaml.cs
@@ -37,7 +37,9 @@ public partial class VaultEntryEditorPage : ContentPage
     public static async Task<PasswordVaultEntry?> ShowAsync(INavigation? navigation, PasswordVaultEntry entry, string title, IEnumerable<string> availableCategories)
     {
         var page = new VaultEntryEditorPage(entry, title, availableCategories);
-        var navigationHost = navigation ?? Application.Current?.MainPage?.Navigation;
+        var navigationHost = Shell.Current?.Navigation
+            ?? navigation
+            ?? Application.Current?.MainPage?.Navigation;
         if (navigationHost is null)
         {
             throw new InvalidOperationException("Kein Navigationsstack verfügbar.");
@@ -143,9 +145,18 @@ public partial class VaultEntryEditorPage : ContentPage
 
     private async Task CloseAsync()
     {
-        if (Navigation.ModalStack.Contains(this))
+        var navigationHost = Shell.Current?.Navigation
+            ?? Navigation
+            ?? Application.Current?.MainPage?.Navigation;
+
+        if (navigationHost is null)
         {
-            await Navigation.PopModalAsync().ConfigureAwait(false);
+            return;
+        }
+
+        if (navigationHost.ModalStack.Contains(this))
+        {
+            await navigationHost.PopModalAsync().ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure the vault entry editor resolves navigation using Shell when opening the modal
- guard modal closing logic with the same navigation fallback to avoid null-reference crashes

## Testing
- not run (environment lacks dotnet CLI)

------
https://chatgpt.com/codex/tasks/task_e_68f802945b70832ab149349e5c6049a4