### PR TITLE
Fix navigation candidate tuple declaration

### DIFF
--- a/Password Phrase Producer/Views/VaultEntryEditorPage.xaml.cs
+++ b/Password Phrase Producer/Views/VaultEntryEditorPage.xaml.cs
@@ -299,7 +299,7 @@ public partial class VaultEntryEditorPage : ContentPage
         return (resolved, finalDiagnostics);
     }
 
-    private static IEnumerable<(string Description, Func<INavigation?>> GetNavigationCandidates(INavigation? navigation)
+    private static IEnumerable<(string Description, Func<INavigation?> Resolver)> GetNavigationCandidates(INavigation? navigation)
     {
         yield return ("Shell.Current.CurrentPage.Navigation", () => Shell.Current?.CurrentPage?.Navigation);
         yield return ("Shell.Current.Navigation", () => Shell.Current?.Navigation);


### PR DESCRIPTION
## Summary
- fix the tuple signature for the navigation candidate helper so it compiles

## Testing
- dotnet build (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68f9d5beec90832a9cf07b1995a83581