### PR TITLE
Fix modal host navigation lookup for MAUI

### DIFF
--- a/Password Phrase Producer/Views/VaultEntryEditorPage.xaml.cs
+++ b/Password Phrase Producer/Views/VaultEntryEditorPage.xaml.cs
@@ -193,7 +193,11 @@ public partial class VaultEntryEditorPage : ContentPage
 
             if (!navigationHost.ModalStack.Contains(target) && target is NavigationPage navigationPage)
             {
-                var containedPage = navigationPage.NavigationStack.FirstOrDefault();
+                var containedPage = navigationPage.Navigation?
+                    .NavigationStack
+                    .FirstOrDefault();
+
+                containedPage ??= navigationPage.CurrentPage;
                 if (containedPage == this && navigationHost.ModalStack.Contains(navigationPage))
                 {
                     target = navigationPage;


### PR DESCRIPTION
## Summary
- replace the deprecated NavigationPage.NavigationStack usage in VaultEntryEditorPage with the INavigation stack
- add a fallback to NavigationPage.CurrentPage when the stack has not been populated yet to keep the modal-closing logic intact

## Testing
- dotnet build *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f9e0ff7174832ab8055f1694689cb9