### PR TITLE
Fix null-safe category initialization in editor

### DIFF
--- a/Password Phrase Producer/Views/VaultEntryEditorPage.xaml.cs
+++ b/Password Phrase Producer/Views/VaultEntryEditorPage.xaml.cs
@@ -24,13 +24,12 @@ public partial class VaultEntryEditorPage : ContentPage
         BindingContext = entry;
         Title = title;
 
-        _availableCategories = availableCategories?
+        _availableCategories = (availableCategories ?? Array.Empty<string>())
             .Where(category => !string.IsNullOrWhiteSpace(category))
             .Select(category => category.Trim())
             .Distinct(StringComparer.CurrentCultureIgnoreCase)
             .OrderBy(category => category, StringComparer.CurrentCultureIgnoreCase)
-            .ToList()
-            ?? new List<string>();
+            .ToList();
 
         CategorySuggestions = new ObservableCollection<string>();
         UpdateCategorySuggestions(entry.Category, false);


### PR DESCRIPTION
## Summary
- ensure the vault entry editor normalizes category inputs against an empty list when none are provided

## Testing
- dotnet build Password Phrase Producer/PasswordPhraseProducer.csproj *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68fa5b845708832a8bf1e552b841bd57