### PR TITLE
Fix NullReferenceException when editing vault entry categories

### DIFF
--- a/Password Phrase Producer/Views/VaultEntryEditorPage.xaml.cs
+++ b/Password Phrase Producer/Views/VaultEntryEditorPage.xaml.cs
@@ -20,19 +20,12 @@ public partial class VaultEntryEditorPage : ContentPage
     {
         ArgumentNullException.ThrowIfNull(entry);
 
+        _availableCategories = NormalizeCategories(availableCategories);
+        CategorySuggestions = new ObservableCollection<string>();
+
         InitializeComponent();
         BindingContext = entry;
         Title = title;
-
-        _availableCategories = availableCategories?
-            .Where(category => !string.IsNullOrWhiteSpace(category))
-            .Select(category => category.Trim())
-            .Distinct(StringComparer.CurrentCultureIgnoreCase)
-            .OrderBy(category => category, StringComparer.CurrentCultureIgnoreCase)
-            .ToList()
-            ?? new List<string>();
-
-        CategorySuggestions = new ObservableCollection<string>();
         UpdateCategorySuggestions(entry.Category, false);
     }
 
@@ -73,6 +66,21 @@ public partial class VaultEntryEditorPage : ContentPage
         }
 
         return await page.Result.ConfigureAwait(false);
+    }
+
+    private static List<string> NormalizeCategories(IEnumerable<string>? availableCategories)
+    {
+        if (availableCategories is null)
+        {
+            return new List<string>();
+        }
+
+        return availableCategories
+            .Where(category => !string.IsNullOrWhiteSpace(category))
+            .Select(category => category.Trim())
+            .Distinct(StringComparer.CurrentCultureIgnoreCase)
+            .OrderBy(category => category, StringComparer.CurrentCultureIgnoreCase)
+            .ToList();
     }
 
     private async void OnSaveClicked(object? sender, EventArgs e)


### PR DESCRIPTION
## Summary
- initialize the vault editor's category suggestions and source list before XAML events fire
- normalize the incoming categories collection with a helper that tolerates null input

## Testing
- ⚠️ `dotnet build 'Password Phrase Producer/Password Phrase Producer.sln'` *(fails: dotnet CLI is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fa5b845708832a8bf1e552b841bd57