### PR TITLE
Build Windows release as portable zip

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,51 +137,40 @@ jobs:
         run: |
           [IO.File]::WriteAllBytes($env:WINDOWS_CERTIFICATE_PATH, [Convert]::FromBase64String($env:WINDOWS_PFX_BASE64))
 
-      - name: Publish Windows MSIX package
+      - name: Publish Windows portable build
         shell: pwsh
-        env:
-          WINDOWS_PFX_PASSWORD: ${{ secrets.WINDOWS_PFX_PASSWORD }}
         run: |
-          $signingArgs = "-p:AppxPackageSigningEnabled=false"
-          if (Test-Path $env:WINDOWS_CERTIFICATE_PATH) {
-            $signingArgs = "-p:AppxPackageSigningEnabled=true -p:PackageCertificateFile=$env:WINDOWS_CERTIFICATE_PATH -p:PackageCertificatePassword=$env:WINDOWS_PFX_PASSWORD"
-          }
-          else {
-            Write-Host "::warning::Windows certificate not provided. MSIX package will be unsigned and require manual trust before installation or updates."
-          }
-
           dotnet publish "./Password Phrase Producer/Password Phrase Producer.sln" `
             -c Release `
             -f net9.0-windows10.0.19041.0 `
             -p:RuntimeIdentifier=win10-x64 `
-            -p:WindowsPackageType=MSIX `
+            -p:WindowsPackageType=None `
+            -p:SelfContained=true `
+            -p:PublishSingleFile=false `
             -p:ApplicationDisplayVersion=$env:APP_VERSION `
-            -p:ApplicationVersion=$env:APP_BUILD `
-            -p:PackageVersion=$env:APP_VERSION_WINDOWS `
-            $signingArgs
+            -p:ApplicationVersion=$env:APP_BUILD
 
       - name: Stage Windows artifact
         shell: pwsh
         run: |
           $workspace = "${{ github.workspace }}"
-          $packagesDir = Join-Path $workspace "Password Phrase Producer\bin\Release\net9.0-windows10.0.19041.0\win10-x64\AppPackages"
-          if (-not (Test-Path $packagesDir)) {
-            throw "Windows AppPackages directory not found."
+          $publishDir = Join-Path $workspace "Password Phrase Producer\bin\Release\net9.0-windows10.0.19041.0\win10-x64\publish"
+          if (-not (Test-Path $publishDir)) {
+            throw "Windows publish directory not found."
           }
 
-          $msix = Get-ChildItem -Path $packagesDir -Recurse -Filter "*.msix" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
-          if (-not $msix) {
-            throw "MSIX package was not produced."
+          $destination = Join-Path $env:RELEASE_DIRECTORY "Password-Phrase-Producer_$($env:APP_VERSION)_windows_x64_portable.zip"
+          if (Test-Path $destination) {
+            Remove-Item -Path $destination -Force
           }
 
-          $destination = Join-Path $env:RELEASE_DIRECTORY "Password-Phrase-Producer_$($env:APP_VERSION)_windows_x64.msix"
-          Copy-Item -Path $msix.FullName -Destination $destination -Force
+          Compress-Archive -Path (Join-Path $publishDir '*') -DestinationPath $destination
 
       - name: Upload Windows artifact
         uses: actions/upload-artifact@v4
         with:
-          name: windows-msix
-          path: '${{ env.RELEASE_DIRECTORY }}\\Password-Phrase-Producer_${{ env.APP_VERSION }}_windows_x64.msix'
+          name: windows-portable
+          path: '${{ env.RELEASE_DIRECTORY }}\\Password-Phrase-Producer_${{ env.APP_VERSION }}_windows_x64_portable.zip'
 
   release:
     name: Release artifacts
@@ -204,13 +193,13 @@ jobs:
       - name: Download Windows artifact
         uses: actions/download-artifact@v4
         with:
-          name: windows-msix
+          name: windows-portable
           path: release-assets
 
       - name: Generate SHA256 checksums
         working-directory: release-assets
         run: |
-          sha256sum "Password-Phrase-Producer_${VERSION}_android_signed.apk" "Password-Phrase-Producer_${VERSION}_windows_x64.msix" > "Password-Phrase-Producer_${VERSION}_SHA256.txt"
+          sha256sum "Password-Phrase-Producer_${VERSION}_android_signed.apk" "Password-Phrase-Producer_${VERSION}_windows_x64_portable.zip" > "Password-Phrase-Producer_${VERSION}_SHA256.txt"
 
       - name: Determine release metadata
         id: release_meta
@@ -235,5 +224,5 @@ jobs:
           prerelease: ${{ steps.release_meta.outputs.prerelease }}
           files: |
             release-assets/Password-Phrase-Producer_${{ env.VERSION }}_android_signed.apk
-            release-assets/Password-Phrase-Producer_${{ env.VERSION }}_windows_x64.msix
+            release-assets/Password-Phrase-Producer_${{ env.VERSION }}_windows_x64_portable.zip
             release-assets/Password-Phrase-Producer_${{ env.VERSION }}_SHA256.txt

--- a/README.md
+++ b/README.md
@@ -19,16 +19,9 @@ To receive an installable and updatable APK you must provide a persistent Androi
 
 The workflow restores the keystore, signs the APK during `dotnet publish`, and increments both the display and internal version numbers so that newer builds can be installed as updates on devices.
 
-### Windows (MSIX)
+### Windows (portable ZIP)
 
-Windows artifacts are now delivered as a single MSIX package that supports updating without manual uninstalling. Provide a code-signing certificate by configuring the following secrets:
-
-| Secret | Description |
-| --- | --- |
-| `WINDOWS_PFX_BASE64` | Base64 encoded `.pfx` certificate used to sign the MSIX. Ensure that the subject matches `CN=Password Phrase Producer` so that it aligns with the package manifest. |
-| `WINDOWS_PFX_PASSWORD` | Password that protects the certificate. |
-
-If the certificate is absent the workflow still produces an unsigned MSIX, which Windows will require you to trust manually before installing.
+Windows builds are published as self-contained, portable bundles. The workflow zips the published output (`Password Phrase Producer.exe` plus all required dependencies) into a single archive named `Password-Phrase-Producer_<version>_windows_x64_portable.zip`. Users simply extract the ZIP and launch the executable—no installer or code-signing certificate is required.
 
 ### Versioning
 


### PR DESCRIPTION
## Summary
- publish the Windows build as an unpackaged, self-contained MAUI app and zip the output
- upload and release the zipped bundle instead of the MSIX installer
- document the new portable Windows artifact in the README

## Testing
- dotnet build 'Password Phrase Producer/Password Phrase Producer.sln' *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_6903340ae978832a943f45dbac76467e