### PR TITLE
Adjust mode tiles to resize dynamically

### DIFF
--- a/Password Phrase Producer/StartPage.xaml
+++ b/Password Phrase Producer/StartPage.xaml
@@ -14,7 +14,8 @@
     </ContentPage.Background>
 
     <ScrollView>
-        <VerticalStackLayout Spacing="28"
+        <VerticalStackLayout x:Name="PageContentLayout"
+                             Spacing="28"
                              Padding="24,48,24,40">
             <Grid ColumnDefinitions="*,Auto"
                   RowDefinitions="Auto"
@@ -58,17 +59,11 @@
                             Margin="0,8,0,0"
                             ItemSizingStrategy="MeasureAllItems">
                 <CollectionView.ItemsLayout>
-                    <GridItemsLayout Orientation="Vertical"
+                    <GridItemsLayout x:Name="ModeGridLayout"
+                                     Orientation="Vertical"
                                      VerticalItemSpacing="22"
-                                     HorizontalItemSpacing="22">
-                        <GridItemsLayout.Span>
-                            <OnIdiom x:TypeArguments="x:Int32">
-                                <OnIdiom.Phone>1</OnIdiom.Phone>
-                                <OnIdiom.Tablet>2</OnIdiom.Tablet>
-                                <OnIdiom.Desktop>3</OnIdiom.Desktop>
-                            </OnIdiom>
-                        </GridItemsLayout.Span>
-                    </GridItemsLayout>
+                                     HorizontalItemSpacing="22"
+                                     Span="1" />
                 </CollectionView.ItemsLayout>
                 <CollectionView.ItemTemplate>
                     <DataTemplate x:DataType="local:PasswordModeOption">

--- a/Password Phrase Producer/StartPage.xaml.cs
+++ b/Password Phrase Producer/StartPage.xaml.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Maui.Controls;
 using Password_Phrase_Producer.ViewModels;
 
@@ -9,6 +10,8 @@ public partial class StartPage : ContentPage
     {
         InitializeComponent();
         BindingContext = new StartPageViewModel();
+        Loaded += OnPageLoaded;
+        SizeChanged += OnPageSizeChanged;
     }
 
     private void OnOpenMenuTapped(object? sender, TappedEventArgs e)
@@ -16,6 +19,48 @@ public partial class StartPage : ContentPage
         if (Shell.Current is not null)
         {
             Shell.Current.FlyoutIsPresented = true;
+        }
+    }
+
+    private void OnPageLoaded(object? sender, EventArgs e)
+    {
+        UpdateGridSpan();
+    }
+
+    private void OnPageSizeChanged(object? sender, EventArgs e)
+    {
+        UpdateGridSpan();
+    }
+
+    private void UpdateGridSpan()
+    {
+        if (ModeGridLayout is null)
+        {
+            return;
+        }
+
+        double availableWidth = Width;
+
+        if (double.IsNaN(availableWidth) || availableWidth <= 0)
+        {
+            return;
+        }
+
+        if (PageContentLayout is not null)
+        {
+            availableWidth -= PageContentLayout.Padding.HorizontalThickness;
+        }
+
+        availableWidth = Math.Max(0, availableWidth);
+
+        const double minTileWidth = 280;
+        double spacing = ModeGridLayout.HorizontalItemSpacing;
+
+        int columns = Math.Max(1, (int)Math.Floor((availableWidth + spacing) / (minTileWidth + spacing)));
+
+        if (ModeGridLayout.Span != columns)
+        {
+            ModeGridLayout.Span = columns;
         }
     }
 }


### PR DESCRIPTION
## Summary
- make the start page mode grid accessible from code-behind
- compute the mode tile span dynamically to better use the available window width

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_690354e482ac832a8f1f29d3926c9e50