### PR TITLE
Refine vault page layout with floating action button

### DIFF
--- a/Password Phrase Producer/Views/VaultPage.xaml
+++ b/Password Phrase Producer/Views/VaultPage.xaml
@@ -26,12 +26,12 @@
     <Grid>
         <Grid RowDefinitions="Auto,*">
             <Grid
-                Padding="24,48,24,20"
-                RowSpacing="18"
+                Padding="24,40,24,16"
+                RowSpacing="12"
                 RowDefinitions="Auto,Auto">
                 <Grid
-                    ColumnDefinitions="Auto,*,Auto"
-                    ColumnSpacing="20"
+                    ColumnDefinitions="Auto,*,Auto,Auto"
+                    ColumnSpacing="16"
                     VerticalOptions="Start">
                     <Border
                         WidthRequest="52"
@@ -56,20 +56,29 @@
                             TextColor="#CFD3FF" />
                     </Border>
 
-                    <VerticalStackLayout Grid.Column="1" Spacing="4">
+                    <VerticalStackLayout Grid.Column="1">
                         <Label
                             Text="Tresor"
                             FontSize="28"
                             FontAttributes="Bold"
                             TextColor="White" />
-                        <Label
-                            Text="Behalte deine Zugangsdaten im Blick und verwalte sie sicher."
-                            FontSize="14"
-                            TextColor="#AEB5DA" />
                     </VerticalStackLayout>
 
-                    <Border
+                    <Button
                         Grid.Column="2"
+                        Text="＋ Neuer Eintrag"
+                        Clicked="OnAddEntryClicked"
+                        HeightRequest="44"
+                        Padding="18,10"
+                        BackgroundColor="#3B4AD1"
+                        TextColor="White"
+                        FontAttributes="Bold"
+                        CornerRadius="16"
+                        IsVisible="{Binding IsUnlocked}"
+                        SemanticProperties.Hint="Neuen Tresor-Eintrag hinzufügen" />
+
+                    <Border
+                        Grid.Column="3"
                         WidthRequest="52"
                         HeightRequest="52"
                         BackgroundColor="#1F2338"
@@ -94,129 +103,83 @@
                     </Border>
                 </Grid>
 
-                <Grid Grid.Row="1" RowDefinitions="Auto,Auto" RowSpacing="16">
-                    <Grid Grid.Row="0" ColumnDefinitions="*,Auto" ColumnSpacing="14">
-                        <Border
-                            StrokeThickness="0"
-                            BackgroundColor="#3B4AD1"
-                            Padding="18,14"
-                            HorizontalOptions="Fill"
-                            VerticalOptions="Center">
-                            <Border.StrokeShape>
-                                <RoundRectangle CornerRadius="22" />
-                            </Border.StrokeShape>
-                            <Border.Shadow>
-                                <Shadow Brush="#30000000" Radius="18" Offset="0,10" />
-                            </Border.Shadow>
-                            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="16" VerticalOptions="Center">
-                                <Border
-                                    WidthRequest="48"
-                                    HeightRequest="48"
-                                    BackgroundColor="#5465FF"
-                                    StrokeThickness="0"
-                                    VerticalOptions="Center">
-                                    <Border.StrokeShape>
-                                        <RoundRectangle CornerRadius="18" />
-                                    </Border.StrokeShape>
-                                    <Label
-                                        Text="＋"
-                                        FontSize="24"
-                                        HorizontalOptions="Center"
-                                        VerticalOptions="Center"
-                                        TextColor="White" />
-                                </Border>
-                                <Label
-                                    Grid.Column="1"
-                                    Text="Neuer Eintrag"
-                                    FontSize="20"
-                                    FontAttributes="Bold"
-                                    VerticalOptions="Center"
-                                    TextColor="White" />
-                            </Grid>
-                            <Border.GestureRecognizers>
-                                <TapGestureRecognizer Tapped="OnAddEntryClicked" />
-                            </Border.GestureRecognizers>
-                        </Border>
-
-                        <Border
-                            Grid.Column="1"
-                            WidthRequest="52"
-                            HeightRequest="52"
-                            StrokeThickness="0"
-                            Padding="0"
-                            BackgroundColor="#1F2338"
-                            HorizontalOptions="End"
-                            VerticalOptions="Center">
-                            <Border.StrokeShape>
-                                <RoundRectangle CornerRadius="20" />
-                            </Border.StrokeShape>
-                            <Border.Shadow>
-                                <Shadow Brush="#1A000000" Radius="12" Offset="0,8" />
-                            </Border.Shadow>
-                            <Border.GestureRecognizers>
-                                <TapGestureRecognizer Tapped="OnVaultActionsTapped" />
-                            </Border.GestureRecognizers>
+                <Grid Grid.Row="1" ColumnDefinitions="*,Auto,Auto" ColumnSpacing="12">
+                    <Border
+                        BackgroundColor="#1F2338"
+                        StrokeThickness="0"
+                        Padding="14,10"
+                        HorizontalOptions="Fill"
+                        VerticalOptions="Center">
+                        <Border.StrokeShape>
+                            <RoundRectangle CornerRadius="20" />
+                        </Border.StrokeShape>
+                        <Border.Shadow>
+                            <Shadow Brush="#1A000000" Radius="12" Offset="0,8" />
+                        </Border.Shadow>
+                        <Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">
                             <Label
-                                Text="⚙"
-                                FontSize="20"
-                                HorizontalOptions="Center"
+                                Text="🔍"
+                                FontSize="16"
                                 VerticalOptions="Center"
                                 TextColor="#CFD3FF" />
-                        </Border>
-                    </Grid>
+                            <Entry
+                                Grid.Column="1"
+                                Text="{Binding SearchQuery}"
+                                Placeholder="Suche im Tresor"
+                                PlaceholderColor="#7F85B2"
+                                TextColor="White"
+                                BackgroundColor="Transparent"
+                                ClearButtonVisibility="WhileEditing" />
+                        </Grid>
+                    </Border>
 
-                    <Grid Grid.Row="1" ColumnDefinitions="*,Auto" ColumnSpacing="14">
-                        <Border
-                            BackgroundColor="#1F2338"
-                            StrokeThickness="0"
-                            Padding="16,12"
-                            HorizontalOptions="Fill"
-                            VerticalOptions="Center">
-                            <Border.StrokeShape>
-                                <RoundRectangle CornerRadius="20" />
-                            </Border.StrokeShape>
-                            <Border.Shadow>
-                                <Shadow Brush="#1A000000" Radius="12" Offset="0,8" />
-                            </Border.Shadow>
-                            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="12">
-                                <Label
-                                    Text="🔍"
-                                    FontSize="16"
-                                    VerticalOptions="Center"
-                                    TextColor="#CFD3FF" />
-                                <Entry
-                                    Grid.Column="1"
-                                    Text="{Binding SearchQuery}"
-                                    Placeholder="Suche im Tresor"
-                                    PlaceholderColor="#7F85B2"
-                                    TextColor="White"
-                                    BackgroundColor="Transparent"
-                                    ClearButtonVisibility="WhileEditing" />
-                            </Grid>
-                        </Border>
+                    <Border
+                        Grid.Column="1"
+                        BackgroundColor="#1F2338"
+                        StrokeThickness="0"
+                        Padding="12,8"
+                        HorizontalOptions="End"
+                        VerticalOptions="Center">
+                        <Border.StrokeShape>
+                            <RoundRectangle CornerRadius="20" />
+                        </Border.StrokeShape>
+                        <Border.Shadow>
+                            <Shadow Brush="#1A000000" Radius="12" Offset="0,8" />
+                        </Border.Shadow>
+                        <Picker
+                            ItemsSource="{Binding CategoryFilterOptions}"
+                            SelectedItem="{Binding SelectedCategory}"
+                            Title="Kategorie wählen"
+                            FontSize="14"
+                            TextColor="#E0E4FF"
+                            TitleColor="#7F85B2" />
+                    </Border>
 
-                        <Border
-                            Grid.Column="1"
-                            BackgroundColor="#1F2338"
-                            StrokeThickness="0"
-                            Padding="14,10"
-                            HorizontalOptions="End"
-                            VerticalOptions="Center">
-                            <Border.StrokeShape>
-                                <RoundRectangle CornerRadius="20" />
-                            </Border.StrokeShape>
-                            <Border.Shadow>
-                                <Shadow Brush="#1A000000" Radius="12" Offset="0,8" />
-                            </Border.Shadow>
-                            <Picker
-                                ItemsSource="{Binding CategoryFilterOptions}"
-                                SelectedItem="{Binding SelectedCategory}"
-                                Title="Kategorie wählen"
-                                FontSize="14"
-                                TextColor="#E0E4FF"
-                                TitleColor="#7F85B2" />
-                        </Border>
-                    </Grid>
+                    <Border
+                        Grid.Column="2"
+                        WidthRequest="48"
+                        HeightRequest="48"
+                        StrokeThickness="0"
+                        Padding="0"
+                        BackgroundColor="#1F2338"
+                        HorizontalOptions="End"
+                        VerticalOptions="Center">
+                        <Border.StrokeShape>
+                            <RoundRectangle CornerRadius="18" />
+                        </Border.StrokeShape>
+                        <Border.Shadow>
+                            <Shadow Brush="#1A000000" Radius="12" Offset="0,8" />
+                        </Border.Shadow>
+                        <Border.GestureRecognizers>
+                            <TapGestureRecognizer Tapped="OnVaultActionsTapped" />
+                        </Border.GestureRecognizers>
+                        <Label
+                            Text="⚙"
+                            FontSize="20"
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center"
+                            TextColor="#CFD3FF" />
+                    </Border>
                 </Grid>
             </Grid>
 
@@ -518,6 +481,27 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
             </CollectionView>
+        </Grid>
+
+        <Grid HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand">
+            <Button
+                HorizontalOptions="End"
+                VerticalOptions="End"
+                Margin="0,0,24,32"
+                WidthRequest="64"
+                HeightRequest="64"
+                CornerRadius="32"
+                BackgroundColor="#4A5CFF"
+                Text="＋"
+                FontSize="28"
+                TextColor="White"
+                Clicked="OnAddEntryClicked"
+                IsVisible="{Binding IsUnlocked}"
+                SemanticProperties.Hint="Neuen Tresor-Eintrag hinzufügen">
+                <Button.Shadow>
+                    <Shadow Brush="#55000000" Radius="24" Offset="0,12" />
+                </Button.Shadow>
+            </Button>
         </Grid>
 
         <Border


### PR DESCRIPTION
## Summary
- replace the wide "Neuer Eintrag" card with a compact header button and remove the vault description
- tighten header spacing while reorganizing the search/filter row to free up room for entries
- add a floating action button bound to OnAddEntryClicked that stays hidden while the vault is locked

## Testing
- `dotnet build 'Password Phrase Producer/PasswordPhraseProducer.csproj'` *(fails: dotnet not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_69039c7609c8832ab673bc7aeb0d78c3