### PR TITLE
Fix VaultPage add entry handler signature

### DIFF
--- a/Password Phrase Producer/Views/VaultPage.xaml.cs
+++ b/Password Phrase Producer/Views/VaultPage.xaml.cs
@@ -62,7 +62,7 @@ public partial class VaultPage : ContentPage
         _viewModel.Deactivate();
     }
 
-    private async void OnAddEntryClicked(object? sender, TappedEventArgs e)
+    private async void OnAddEntryClicked(object? sender, EventArgs e)
     {
         if (!_viewModel.IsUnlocked)
         {


### PR DESCRIPTION
## Summary
- adjust VaultPage add entry handler to use the correct EventArgs signature for button clicks

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_6903d5f1e9f4832aafdcab9540de716a