### PR TITLE
Add five new password generation modes

### DIFF
--- a/Password Phrase Producer/PasswordGenerationTechniques/DicewareTechnique/AdaptiveDicewareTechnique.cs
+++ b/Password Phrase Producer/PasswordGenerationTechniques/DicewareTechnique/AdaptiveDicewareTechnique.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Password_Phrase_Producer.PasswordGenerationTechniques.DicewareTechnique
+{
+    internal class AdaptiveDicewareTechnique : IDicewareTechnique
+    {
+        private static readonly string[] WordList =
+        {
+            "anker", "atlas", "biene", "blitz", "cloud", "delta", "ember", "falke", "gamma", "harfe",
+            "ionen", "jaguar", "komet", "laser", "magma", "nebel", "omega", "pixel", "quarz", "robot",
+            "silbe", "token", "ultra", "vital", "wolke", "xenon", "yukon", "zirbe", "fjord", "zenit"
+        };
+
+        public string Generate(int wordCount, string? seed)
+        {
+            if (wordCount <= 0)
+            {
+                return string.Empty;
+            }
+
+            Random random = CreateRandom(seed);
+            var words = new List<string>(capacity: wordCount);
+            for (int i = 0; i < wordCount; i++)
+            {
+                words.Add(WordList[random.Next(WordList.Length)]);
+            }
+
+            string marker = CalculateEntropyMarker(words);
+            return string.Join('-', words) + marker;
+        }
+
+        private static Random CreateRandom(string? seed)
+        {
+            if (string.IsNullOrWhiteSpace(seed))
+            {
+                return Random.Shared;
+            }
+
+            byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(seed));
+            int seedValue = BitConverter.ToInt32(hash, 0);
+            return new Random(seedValue);
+        }
+
+        private static string CalculateEntropyMarker(IEnumerable<string> words)
+        {
+            int letters = 0;
+            int vowels = 0;
+
+            foreach (string word in words)
+            {
+                foreach (char character in word)
+                {
+                    if (char.IsLetter(character))
+                    {
+                        letters++;
+                        if (IsVowel(character))
+                        {
+                            vowels++;
+                        }
+                    }
+                }
+            }
+
+            int consonants = letters - vowels;
+            int score = (consonants * 37 + vowels * 17 + letters) % 1000;
+            return $"!{score:D3}";
+        }
+
+        private static bool IsVowel(char character)
+        {
+            char normalized = char.ToLowerInvariant(character);
+            return normalized is 'a' or 'e' or 'i' or 'o' or 'u';
+        }
+    }
+}

--- a/Password Phrase Producer/PasswordGenerationTechniques/DicewareTechnique/IDicewareTechnique.cs
+++ b/Password Phrase Producer/PasswordGenerationTechniques/DicewareTechnique/IDicewareTechnique.cs
@@ -1,0 +1,7 @@
+namespace Password_Phrase_Producer.PasswordGenerationTechniques.DicewareTechnique
+{
+    public interface IDicewareTechnique
+    {
+        string Generate(int wordCount, string? seed);
+    }
+}

--- a/Password Phrase Producer/PasswordGenerationTechniques/MirrorLockTechnique/IMirrorLockTechnique.cs
+++ b/Password Phrase Producer/PasswordGenerationTechniques/MirrorLockTechnique/IMirrorLockTechnique.cs
@@ -1,0 +1,7 @@
+namespace Password_Phrase_Producer.PasswordGenerationTechniques.MirrorLockTechnique
+{
+    public interface IMirrorLockTechnique
+    {
+        string CreatePassword(string input);
+    }
+}

--- a/Password Phrase Producer/PasswordGenerationTechniques/MirrorLockTechnique/MirrorLockTechnique.cs
+++ b/Password Phrase Producer/PasswordGenerationTechniques/MirrorLockTechnique/MirrorLockTechnique.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace Password_Phrase_Producer.PasswordGenerationTechniques.MirrorLockTechnique
+{
+    internal class MirrorLockTechnique : IMirrorLockTechnique
+    {
+        public string CreatePassword(string input)
+        {
+            if (string.IsNullOrWhiteSpace(input))
+            {
+                return string.Empty;
+            }
+
+            string normalized = NormalizeSegment(input.Trim());
+            if (string.IsNullOrEmpty(normalized))
+            {
+                return string.Empty;
+            }
+
+            string reversed = new string(normalized.Reverse().ToArray());
+            string pivot = CalculatePivot(normalized);
+
+            return string.Concat(normalized, pivot, reversed);
+        }
+
+        private static string NormalizeSegment(string value)
+        {
+            var cleaned = new string(value.Where(char.IsLetterOrDigit).ToArray());
+            if (cleaned.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            var builder = new StringBuilder(cleaned.Length);
+            for (int i = 0; i < cleaned.Length; i++)
+            {
+                char current = cleaned[i];
+                builder.Append(i % 2 == 0
+                    ? char.ToUpperInvariant(current)
+                    : char.ToLowerInvariant(current));
+            }
+
+            return builder.ToString();
+        }
+
+        private static string CalculatePivot(string segment)
+        {
+            int asciiSum = 0;
+            foreach (char character in segment)
+            {
+                asciiSum += character;
+            }
+
+            return (asciiSum % 1000).ToString("D3", CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/Password Phrase Producer/PasswordGenerationTechniques/PatternCascadeTechnique/IPatternCascadeTechnique.cs
+++ b/Password Phrase Producer/PasswordGenerationTechniques/PatternCascadeTechnique/IPatternCascadeTechnique.cs
@@ -1,0 +1,7 @@
+namespace Password_Phrase_Producer.PasswordGenerationTechniques.PatternCascadeTechnique
+{
+    public interface IPatternCascadeTechnique
+    {
+        string CreatePassword(string primaryWord, string secondaryWord, string numericToken);
+    }
+}

--- a/Password Phrase Producer/PasswordGenerationTechniques/PatternCascadeTechnique/PatternCascadeTechnique.cs
+++ b/Password Phrase Producer/PasswordGenerationTechniques/PatternCascadeTechnique/PatternCascadeTechnique.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace Password_Phrase_Producer.PasswordGenerationTechniques.PatternCascadeTechnique
+{
+    internal class PatternCascadeTechnique : IPatternCascadeTechnique
+    {
+        public string CreatePassword(string primaryWord, string secondaryWord, string numericToken)
+        {
+            if (string.IsNullOrWhiteSpace(primaryWord) || string.IsNullOrWhiteSpace(secondaryWord))
+            {
+                return string.Empty;
+            }
+
+            string normalizedPrimary = Normalize(primaryWord);
+            string normalizedSecondary = Normalize(secondaryWord);
+            string digits = ExtractDigits(numericToken);
+
+            if (string.IsNullOrEmpty(normalizedPrimary) || string.IsNullOrEmpty(normalizedSecondary))
+            {
+                return string.Empty;
+            }
+
+            if (digits.Length == 0)
+            {
+                digits = (normalizedPrimary.Length + normalizedSecondary.Length).ToString("D2", CultureInfo.InvariantCulture);
+            }
+
+            string checksum = CalculateChecksum(normalizedPrimary, normalizedSecondary, digits);
+
+            return string.Concat(normalizedPrimary, digits, normalizedSecondary, checksum);
+        }
+
+        private static string Normalize(string value)
+        {
+            var filtered = new string(value.Where(char.IsLetter).ToArray());
+            if (filtered.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            var builder = new StringBuilder(filtered.Length);
+            for (int i = 0; i < filtered.Length; i++)
+            {
+                char character = filtered[i];
+                builder.Append(i % 2 == 0
+                    ? char.ToUpperInvariant(character)
+                    : char.ToLowerInvariant(character));
+            }
+
+            return builder.ToString();
+        }
+
+        private static string ExtractDigits(string numericToken)
+        {
+            var digits = new string(numericToken.Where(char.IsDigit).ToArray());
+            if (digits.Length >= 2)
+            {
+                return digits;
+            }
+
+            if (digits.Length == 1)
+            {
+                return digits + digits;
+            }
+
+            return string.Empty;
+        }
+
+        private static string CalculateChecksum(string primary, string secondary, string digits)
+        {
+            int value = 0;
+            int factor = 1;
+
+            foreach (char character in primary.Concat(secondary))
+            {
+                value += character * factor;
+                factor = (factor % 5) + 1;
+            }
+
+            foreach (char digit in digits)
+            {
+                value += (digit - '0') * 17;
+            }
+
+            int checksum = value % 4096;
+            return checksum.ToString("X3", CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/Password Phrase Producer/PasswordGenerationTechniques/SegmentRotationTechnique/ISegmentRotationTechnique.cs
+++ b/Password Phrase Producer/PasswordGenerationTechniques/SegmentRotationTechnique/ISegmentRotationTechnique.cs
@@ -1,0 +1,7 @@
+namespace Password_Phrase_Producer.PasswordGenerationTechniques.SegmentRotationTechnique
+{
+    public interface ISegmentRotationTechnique
+    {
+        string ShuffleSegments(string input, int segmentLength);
+    }
+}

--- a/Password Phrase Producer/PasswordGenerationTechniques/SegmentRotationTechnique/SegmentRotationTechnique.cs
+++ b/Password Phrase Producer/PasswordGenerationTechniques/SegmentRotationTechnique/SegmentRotationTechnique.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace Password_Phrase_Producer.PasswordGenerationTechniques.SegmentRotationTechnique
+{
+    internal class SegmentRotationTechnique : ISegmentRotationTechnique
+    {
+        public string ShuffleSegments(string input, int segmentLength)
+        {
+            if (string.IsNullOrWhiteSpace(input) || segmentLength <= 0)
+            {
+                return string.Empty;
+            }
+
+            var cleaned = new string(input.Where(char.IsLetterOrDigit).ToArray());
+            if (cleaned.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            var segments = CreateSegments(cleaned, segmentLength);
+            if (segments.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            int rotation = CalculateRotation(cleaned);
+            var rotated = RotateSegments(segments, rotation).ToList();
+            string checksum = CalculateChecksum(rotated);
+
+            return $"{string.Join("-", rotated)}#{checksum}";
+        }
+
+        private static IList<string> CreateSegments(string cleaned, int segmentLength)
+        {
+            var segments = new List<string>();
+
+            for (int i = 0; i < cleaned.Length; i += segmentLength)
+            {
+                int remaining = Math.Min(segmentLength, cleaned.Length - i);
+                string segment = cleaned.Substring(i, remaining);
+
+                if (segment.Length < segmentLength)
+                {
+                    char pad = cleaned[(i + segment.Length - 1 + cleaned.Length) % cleaned.Length];
+                    segment = segment.PadRight(segmentLength, pad);
+                }
+
+                segments.Add(segment);
+            }
+
+            return segments;
+        }
+
+        private static int CalculateRotation(string cleaned)
+        {
+            int sum = cleaned.Sum(static c => c);
+            return sum % Math.Max(cleaned.Length, 1);
+        }
+
+        private static IEnumerable<string> RotateSegments(IReadOnlyList<string> segments, int rotation)
+        {
+            if (segments.Count == 0)
+            {
+                return Array.Empty<string>();
+            }
+
+            int shift = rotation % segments.Count;
+            if (shift < 0)
+            {
+                shift += segments.Count;
+            }
+
+            return segments.Skip(shift).Concat(segments.Take(shift));
+        }
+
+        private static string CalculateChecksum(IEnumerable<string> segments)
+        {
+            int total = 0;
+            int index = 1;
+
+            foreach (string segment in segments)
+            {
+                foreach (char character in segment)
+                {
+                    total += character * index;
+                }
+
+                index++;
+            }
+
+            int mod = total % 997;
+            return mod.ToString("X3", CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/Password Phrase Producer/PasswordGenerationTechniques/SymbolInjectionTechnique/ISymbolInjectionTechnique.cs
+++ b/Password Phrase Producer/PasswordGenerationTechniques/SymbolInjectionTechnique/ISymbolInjectionTechnique.cs
@@ -1,0 +1,7 @@
+namespace Password_Phrase_Producer.PasswordGenerationTechniques.SymbolInjectionTechnique
+{
+    public interface ISymbolInjectionTechnique
+    {
+        string InjectSymbols(string input, int symbolCount, bool randomizeCase, string? seed);
+    }
+}

--- a/Password Phrase Producer/PasswordGenerationTechniques/SymbolInjectionTechnique/SymbolInterleavingTechnique.cs
+++ b/Password Phrase Producer/PasswordGenerationTechniques/SymbolInjectionTechnique/SymbolInterleavingTechnique.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Password_Phrase_Producer.PasswordGenerationTechniques.SymbolInjectionTechnique
+{
+    internal class SymbolInterleavingTechnique : ISymbolInjectionTechnique
+    {
+        private static readonly char[] Symbols = { '!', '?', '#', '$', '%', '&', '*', '+', '=', '-', '_' };
+
+        public string InjectSymbols(string input, int symbolCount, bool randomizeCase, string? seed)
+        {
+            if (string.IsNullOrWhiteSpace(input))
+            {
+                return string.Empty;
+            }
+
+            var random = CreateRandom(seed);
+            var builder = new StringBuilder(input.Length + Math.Max(symbolCount, 0));
+
+            foreach (char character in input.Trim())
+            {
+                if (randomizeCase && char.IsLetter(character))
+                {
+                    bool upper = random.Next(2) == 0;
+                    builder.Append(upper ? char.ToUpperInvariant(character) : char.ToLowerInvariant(character));
+                }
+                else
+                {
+                    builder.Append(character);
+                }
+            }
+
+            int inserts = Math.Max(symbolCount, 0);
+            for (int i = 0; i < inserts; i++)
+            {
+                char symbol = Symbols[random.Next(Symbols.Length)];
+                int insertIndex = random.Next(builder.Length + 1);
+                builder.Insert(insertIndex, symbol);
+            }
+
+            builder.Append(inserts.ToString("X", CultureInfo.InvariantCulture));
+
+            return builder.ToString();
+        }
+
+        private static Random CreateRandom(string? seed)
+        {
+            if (string.IsNullOrWhiteSpace(seed))
+            {
+                return Random.Shared;
+            }
+
+            byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(seed));
+            int seedValue = BitConverter.ToInt32(hash, 0);
+            return new Random(seedValue);
+        }
+    }
+}

--- a/Password Phrase Producer/Services/ModeCatalog.cs
+++ b/Password Phrase Producer/Services/ModeCatalog.cs
@@ -1,6 +1,11 @@
 using System.Collections.Generic;
 using Password_Phrase_Producer.PasswordGenerationTechniques.ConcatenationTechniques;
 using Password_Phrase_Producer.PasswordGenerationTechniques.HashBasedTechniques;
+using Password_Phrase_Producer.PasswordGenerationTechniques.DicewareTechnique;
+using Password_Phrase_Producer.PasswordGenerationTechniques.MirrorLockTechnique;
+using Password_Phrase_Producer.PasswordGenerationTechniques.PatternCascadeTechnique;
+using Password_Phrase_Producer.PasswordGenerationTechniques.SegmentRotationTechnique;
+using Password_Phrase_Producer.PasswordGenerationTechniques.SymbolInjectionTechnique;
 using Password_Phrase_Producer.Windows.PasswordGenerationWindows;
 using PasswordPhraseProducer.PasswordGenerationTechniques.TbvTechniques;
 using Password_Phrase_Producer.Services.EntropyAnalyzer;
@@ -54,6 +59,41 @@ public static class ModeCatalog
             "Modernes Verfahren mit erweiterten Prüfungen und Komfort.",
             () => new TbvUiPage(new TBV3(), EntropyAnalyzer),
             "mode-tbv3",
-            "🚀")
+            "🚀"),
+        new(
+            "mirror-lock",
+            "Mirror Lock",
+            "Spiegele eine Phrase und ergänze sie um eine dreistellige Prüfsumme.",
+            () => new MirrorTechniqueUiPage(new MirrorLockTechnique(), EntropyAnalyzer),
+            "mode-mirror-lock",
+            "🪞"),
+        new(
+            "segment-rotation",
+            "Segment Rotation",
+            "Zerlege Text in Segmente und rotiere sie für ein strukturiertes Passwort.",
+            () => new SegmentRotationTechniqueUiPage(new SegmentRotationTechnique(), EntropyAnalyzer),
+            "mode-segment-rotation",
+            "🔁"),
+        new(
+            "diceware-seed",
+            "Diceware Seeded",
+            "Erzeuge Diceware-Phrasen mit optional deterministischem Seed.",
+            () => new DicewareTechniqueUiPage(new AdaptiveDicewareTechnique(), EntropyAnalyzer),
+            "mode-diceware-seed",
+            "🎲"),
+        new(
+            "symbol-mixer",
+            "Symbol Mixer",
+            "Mische Symbole in ein Passwort und steuere die Groß-/Kleinschreibung.",
+            () => new SymbolInjectionTechniqueUiPage(new SymbolInterleavingTechnique(), EntropyAnalyzer),
+            "mode-symbol-mixer",
+            "✨"),
+        new(
+            "pattern-cascade",
+            "Pattern Cascade",
+            "Kaskadiere Wörter und Zahlen zu einer wiederholbaren Struktur.",
+            () => new PatternCascadeTechniqueUiPage(new PatternCascadeTechnique(), EntropyAnalyzer),
+            "mode-pattern-cascade",
+            "🧬")
     };
 }

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/DicewareTechniqueUiPage.xaml
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/DicewareTechniqueUiPage.xaml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:controls="clr-namespace:Password_Phrase_Producer.Windows.PasswordGenerationWindows.Controls"
+             x:Class="Password_Phrase_Producer.Windows.PasswordGenerationWindows.DicewareTechniqueUiPage">
+    <VerticalStackLayout Spacing="24">
+        <Border StrokeThickness="0"
+                Padding="18"
+                BackgroundColor="#1F2438">
+            <Border.StrokeShape>
+                <RoundRectangle CornerRadius="22" />
+            </Border.StrokeShape>
+            <VerticalStackLayout Spacing="14">
+                <Label Text="Diceware Generator"
+                       FontSize="18"
+                       FontAttributes="Bold"
+                       TextColor="White"/>
+                <Label Text="Erzeuge reproduzierbare Passphrasen mit einem optionalen Seed."
+                       TextColor="#BDC2E8"
+                       FontSize="14"
+                       LineBreakMode="WordWrap"/>
+                <Label x:Name="wordCountLabel"
+                       Text="Wörter: 5"
+                       TextColor="#8F95C6"
+                       FontSize="13" />
+                <Slider x:Name="wordCountSlider"
+                        Minimum="3"
+                        Maximum="8"
+                        Value="5"
+                        ValueChanged="OnWordCountChanged" />
+                <Entry x:Name="seedEntry"
+                       Placeholder="Optionaler Seed für deterministische Ergebnisse"
+                       Style="{StaticResource DarkEntryStyle}" />
+            </VerticalStackLayout>
+        </Border>
+
+        <Border StrokeThickness="0"
+                Padding="18"
+                BackgroundColor="#1F2438">
+            <Border.StrokeShape>
+                <RoundRectangle CornerRadius="22" />
+            </Border.StrokeShape>
+            <VerticalStackLayout Spacing="16">
+                <Label Text="Passphrase"
+                       FontSize="18"
+                       FontAttributes="Bold"
+                       TextColor="White"/>
+                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
+                    <Entry x:Name="resultEntry"
+                           Placeholder="Generierte Passphrase"
+                           Style="{StaticResource DarkEntryStyle}"
+                           IsReadOnly="True" />
+                    <Button Grid.Column="1"
+                            Text="Kopieren"
+                            Style="{StaticResource PrimaryActionButtonStyle}"
+                            Clicked="OnCopyClicked"
+                            HorizontalOptions="End" />
+                </Grid>
+                <Button Text="Passphrase erzeugen"
+                        Style="{StaticResource PrimaryActionButtonStyle}"
+                        Clicked="OnCreateClicked" />
+                <controls:PasswordAnalysisPanel x:Name="analysisPanel"
+                                                 IsVisible="False" />
+            </VerticalStackLayout>
+        </Border>
+    </VerticalStackLayout>
+</ContentView>

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/DicewareTechniqueUiPage.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/DicewareTechniqueUiPage.xaml.cs
@@ -1,0 +1,82 @@
+using System;
+using Microsoft.Maui.Controls;
+using Password_Phrase_Producer.PasswordGenerationTechniques.DicewareTechnique;
+using Password_Phrase_Producer.Services.EntropyAnalyzer;
+
+namespace Password_Phrase_Producer.Windows.PasswordGenerationWindows;
+
+public partial class DicewareTechniqueUiPage : ContentView
+{
+    private readonly IDicewareTechnique dicewareTechnique;
+    private readonly IPasswordEntropyAnalyzer entropyAnalyzer;
+
+    public DicewareTechniqueUiPage(IDicewareTechnique dicewareTechnique, IPasswordEntropyAnalyzer entropyAnalyzer)
+    {
+        InitializeComponent();
+        this.dicewareTechnique = dicewareTechnique;
+        this.entropyAnalyzer = entropyAnalyzer;
+
+        UpdateWordCountLabel();
+        analysisPanel?.Reset();
+    }
+
+    private void OnWordCountChanged(object? sender, ValueChangedEventArgs e)
+    {
+        UpdateWordCountLabel();
+    }
+
+    private void UpdateWordCountLabel()
+    {
+        if (wordCountLabel is not null)
+        {
+            wordCountLabel.Text = $"Wörter: {GetWordCount()}";
+        }
+    }
+
+    private int GetWordCount()
+    {
+        return wordCountSlider is null ? 5 : (int)Math.Round(wordCountSlider.Value);
+    }
+
+    private void OnCreateClicked(object sender, EventArgs e)
+    {
+        int wordCount = GetWordCount();
+        string seed = seedEntry?.Text ?? string.Empty;
+        string result = dicewareTechnique.Generate(wordCount, string.IsNullOrWhiteSpace(seed) ? null : seed);
+
+        if (string.IsNullOrEmpty(result))
+        {
+            if (resultEntry is not null)
+            {
+                resultEntry.Text = string.Empty;
+            }
+
+            analysisPanel?.Reset();
+            return;
+        }
+
+        if (resultEntry is not null)
+        {
+            resultEntry.Text = result;
+        }
+
+        if (analysisPanel is not null)
+        {
+            var analysis = entropyAnalyzer.Analyze(result);
+            analysisPanel.Update(analysis);
+        }
+    }
+
+    private async void OnCopyClicked(object sender, EventArgs e)
+    {
+        if (!string.IsNullOrWhiteSpace(resultEntry?.Text))
+        {
+            await Clipboard.Default.SetTextAsync(resultEntry!.Text);
+            var mainPage = Application.Current?.MainPage;
+            if (mainPage is not null)
+            {
+                await mainPage.DisplayAlert("Info", "Password copied to clipboard", "OK");
+            }
+        }
+    }
+}

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/MirrorTechniqueUiPage.xaml
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/MirrorTechniqueUiPage.xaml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:controls="clr-namespace:Password_Phrase_Producer.Windows.PasswordGenerationWindows.Controls"
+             x:Class="Password_Phrase_Producer.Windows.PasswordGenerationWindows.MirrorTechniqueUiPage">
+    <VerticalStackLayout Spacing="24">
+        <Border StrokeThickness="0"
+                Padding="18"
+                BackgroundColor="#1F2438">
+            <Border.StrokeShape>
+                <RoundRectangle CornerRadius="22" />
+            </Border.StrokeShape>
+            <VerticalStackLayout Spacing="14">
+                <Label Text="Grundphrase"
+                       FontSize="18"
+                       FontAttributes="Bold"
+                       TextColor="White"/>
+                <Label Text="Gib eine Phrase ein, die gespiegelt und mit einer Prüfsumme versehen wird."
+                       TextColor="#BDC2E8"
+                       FontSize="14"
+                       LineBreakMode="WordWrap"/>
+                <Entry x:Name="inputEntry"
+                       Placeholder="Ausgangsphrase"
+                       Style="{StaticResource DarkEntryStyle}" />
+            </VerticalStackLayout>
+        </Border>
+
+        <Border StrokeThickness="0"
+                Padding="18"
+                BackgroundColor="#1F2438">
+            <Border.StrokeShape>
+                <RoundRectangle CornerRadius="22" />
+            </Border.StrokeShape>
+            <VerticalStackLayout Spacing="16">
+                <Label Text="Spiegel-Passwort"
+                       FontSize="18"
+                       FontAttributes="Bold"
+                       TextColor="White"/>
+                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
+                    <Entry x:Name="resultEntry"
+                           Placeholder="Generiertes Passwort"
+                           Style="{StaticResource DarkEntryStyle}"
+                           IsReadOnly="True" />
+                    <Button Grid.Column="1"
+                            Text="Kopieren"
+                            Style="{StaticResource PrimaryActionButtonStyle}"
+                            Clicked="OnCopyClicked"
+                            HorizontalOptions="End" />
+                </Grid>
+                <Button Text="Passwort spiegeln"
+                        Style="{StaticResource PrimaryActionButtonStyle}"
+                        Clicked="OnCreateClicked" />
+                <controls:PasswordAnalysisPanel x:Name="analysisPanel"
+                                                 IsVisible="False" />
+            </VerticalStackLayout>
+        </Border>
+    </VerticalStackLayout>
+</ContentView>

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/MirrorTechniqueUiPage.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/MirrorTechniqueUiPage.xaml.cs
@@ -1,0 +1,62 @@
+using System;
+using Microsoft.Maui.Controls;
+using Password_Phrase_Producer.PasswordGenerationTechniques.MirrorLockTechnique;
+using Password_Phrase_Producer.Services.EntropyAnalyzer;
+
+namespace Password_Phrase_Producer.Windows.PasswordGenerationWindows;
+
+public partial class MirrorTechniqueUiPage : ContentView
+{
+    private readonly IMirrorLockTechnique mirrorTechnique;
+    private readonly IPasswordEntropyAnalyzer entropyAnalyzer;
+
+    public MirrorTechniqueUiPage(IMirrorLockTechnique mirrorTechnique, IPasswordEntropyAnalyzer entropyAnalyzer)
+    {
+        InitializeComponent();
+        this.mirrorTechnique = mirrorTechnique;
+        this.entropyAnalyzer = entropyAnalyzer;
+
+        analysisPanel?.Reset();
+    }
+
+    private void OnCreateClicked(object sender, EventArgs e)
+    {
+        string input = inputEntry?.Text ?? string.Empty;
+        string result = mirrorTechnique.CreatePassword(input);
+
+        if (string.IsNullOrEmpty(result))
+        {
+            if (resultEntry is not null)
+            {
+                resultEntry.Text = string.Empty;
+            }
+
+            analysisPanel?.Reset();
+            return;
+        }
+
+        if (resultEntry is not null)
+        {
+            resultEntry.Text = result;
+        }
+
+        if (analysisPanel is not null)
+        {
+            var analysis = entropyAnalyzer.Analyze(result);
+            analysisPanel.Update(analysis);
+        }
+    }
+
+    private async void OnCopyClicked(object sender, EventArgs e)
+    {
+        if (!string.IsNullOrWhiteSpace(resultEntry?.Text))
+        {
+            await Clipboard.Default.SetTextAsync(resultEntry!.Text);
+            var mainPage = Application.Current?.MainPage;
+            if (mainPage is not null)
+            {
+                await mainPage.DisplayAlert("Info", "Password copied to clipboard", "OK");
+            }
+        }
+    }
+}

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/PatternCascadeTechniqueUiPage.xaml
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/PatternCascadeTechniqueUiPage.xaml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:controls="clr-namespace:Password_Phrase_Producer.Windows.PasswordGenerationWindows.Controls"
+             x:Class="Password_Phrase_Producer.Windows.PasswordGenerationWindows.PatternCascadeTechniqueUiPage">
+    <VerticalStackLayout Spacing="24">
+        <Border StrokeThickness="0"
+                Padding="18"
+                BackgroundColor="#1F2438">
+            <Border.StrokeShape>
+                <RoundRectangle CornerRadius="22" />
+            </Border.StrokeShape>
+            <VerticalStackLayout Spacing="14">
+                <Label Text="Pattern Cascade"
+                       FontSize="18"
+                       FontAttributes="Bold"
+                       TextColor="White"/>
+                <Label Text="Kombiniere zwei Wörter und einen Zahlencode zu einem strukturierten Passwort."
+                       TextColor="#BDC2E8"
+                       FontSize="14"
+                       LineBreakMode="WordWrap"/>
+                <Entry x:Name="primaryEntry"
+                       Placeholder="Erstes Wort"
+                       Style="{StaticResource DarkEntryStyle}" />
+                <Entry x:Name="secondaryEntry"
+                       Placeholder="Zweites Wort"
+                       Style="{StaticResource DarkEntryStyle}" />
+                <Entry x:Name="numericEntry"
+                       Placeholder="Zahlencode (optional)"
+                       Keyboard="Numeric"
+                       Style="{StaticResource DarkEntryStyle}" />
+            </VerticalStackLayout>
+        </Border>
+
+        <Border StrokeThickness="0"
+                Padding="18"
+                BackgroundColor="#1F2438">
+            <Border.StrokeShape>
+                <RoundRectangle CornerRadius="22" />
+            </Border.StrokeShape>
+            <VerticalStackLayout Spacing="16">
+                <Label Text="Cascade-Passwort"
+                       FontSize="18"
+                       FontAttributes="Bold"
+                       TextColor="White"/>
+                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
+                    <Entry x:Name="resultEntry"
+                           Placeholder="Generiertes Passwort"
+                           Style="{StaticResource DarkEntryStyle}"
+                           IsReadOnly="True" />
+                    <Button Grid.Column="1"
+                            Text="Kopieren"
+                            Style="{StaticResource PrimaryActionButtonStyle}"
+                            Clicked="OnCopyClicked"
+                            HorizontalOptions="End" />
+                </Grid>
+                <Button Text="Passwort erzeugen"
+                        Style="{StaticResource PrimaryActionButtonStyle}"
+                        Clicked="OnCreateClicked" />
+                <controls:PasswordAnalysisPanel x:Name="analysisPanel"
+                                                 IsVisible="False" />
+            </VerticalStackLayout>
+        </Border>
+    </VerticalStackLayout>
+</ContentView>

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/PatternCascadeTechniqueUiPage.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/PatternCascadeTechniqueUiPage.xaml.cs
@@ -1,0 +1,65 @@
+using System;
+using Microsoft.Maui.Controls;
+using Password_Phrase_Producer.PasswordGenerationTechniques.PatternCascadeTechnique;
+using Password_Phrase_Producer.Services.EntropyAnalyzer;
+
+namespace Password_Phrase_Producer.Windows.PasswordGenerationWindows;
+
+public partial class PatternCascadeTechniqueUiPage : ContentView
+{
+    private readonly IPatternCascadeTechnique patternCascadeTechnique;
+    private readonly IPasswordEntropyAnalyzer entropyAnalyzer;
+
+    public PatternCascadeTechniqueUiPage(IPatternCascadeTechnique patternCascadeTechnique, IPasswordEntropyAnalyzer entropyAnalyzer)
+    {
+        InitializeComponent();
+        this.patternCascadeTechnique = patternCascadeTechnique;
+        this.entropyAnalyzer = entropyAnalyzer;
+
+        analysisPanel?.Reset();
+    }
+
+    private void OnCreateClicked(object sender, EventArgs e)
+    {
+        string primary = primaryEntry?.Text ?? string.Empty;
+        string secondary = secondaryEntry?.Text ?? string.Empty;
+        string numeric = numericEntry?.Text ?? string.Empty;
+
+        string result = patternCascadeTechnique.CreatePassword(primary, secondary, numeric);
+
+        if (string.IsNullOrEmpty(result))
+        {
+            if (resultEntry is not null)
+            {
+                resultEntry.Text = string.Empty;
+            }
+
+            analysisPanel?.Reset();
+            return;
+        }
+
+        if (resultEntry is not null)
+        {
+            resultEntry.Text = result;
+        }
+
+        if (analysisPanel is not null)
+        {
+            var analysis = entropyAnalyzer.Analyze(result);
+            analysisPanel.Update(analysis);
+        }
+    }
+
+    private async void OnCopyClicked(object sender, EventArgs e)
+    {
+        if (!string.IsNullOrWhiteSpace(resultEntry?.Text))
+        {
+            await Clipboard.Default.SetTextAsync(resultEntry!.Text);
+            var mainPage = Application.Current?.MainPage;
+            if (mainPage is not null)
+            {
+                await mainPage.DisplayAlert("Info", "Password copied to clipboard", "OK");
+            }
+        }
+    }
+}

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/SegmentRotationTechniqueUiPage.xaml
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/SegmentRotationTechniqueUiPage.xaml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:controls="clr-namespace:Password_Phrase_Producer.Windows.PasswordGenerationWindows.Controls"
+             x:Class="Password_Phrase_Producer.Windows.PasswordGenerationWindows.SegmentRotationTechniqueUiPage">
+    <VerticalStackLayout Spacing="24">
+        <Border StrokeThickness="0"
+                Padding="18"
+                BackgroundColor="#1F2438">
+            <Border.StrokeShape>
+                <RoundRectangle CornerRadius="22" />
+            </Border.StrokeShape>
+            <VerticalStackLayout Spacing="14">
+                <Label Text="Basistext"
+                       FontSize="18"
+                       FontAttributes="Bold"
+                       TextColor="White"/>
+                <Label Text="Teile den Text in Segmente auf und rotiere sie für ein deterministisches Muster."
+                       TextColor="#BDC2E8"
+                       FontSize="14"
+                       LineBreakMode="WordWrap"/>
+                <Entry x:Name="inputEntry"
+                       Placeholder="Basistext"
+                       Style="{StaticResource DarkEntryStyle}" />
+                <Label x:Name="segmentLabel"
+                       Text="Segmentlänge: 3"
+                       TextColor="#8F95C6"
+                       FontSize="13" />
+                <Slider x:Name="segmentSlider"
+                        Minimum="2"
+                        Maximum="6"
+                        Value="3"
+                        ValueChanged="OnSegmentLengthChanged" />
+            </VerticalStackLayout>
+        </Border>
+
+        <Border StrokeThickness="0"
+                Padding="18"
+                BackgroundColor="#1F2438">
+            <Border.StrokeShape>
+                <RoundRectangle CornerRadius="22" />
+            </Border.StrokeShape>
+            <VerticalStackLayout Spacing="16">
+                <Label Text="Rotations-Ergebnis"
+                       FontSize="18"
+                       FontAttributes="Bold"
+                       TextColor="White"/>
+                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
+                    <Entry x:Name="resultEntry"
+                           Placeholder="Segmentiertes Passwort"
+                           Style="{StaticResource DarkEntryStyle}"
+                           IsReadOnly="True" />
+                    <Button Grid.Column="1"
+                            Text="Kopieren"
+                            Style="{StaticResource PrimaryActionButtonStyle}"
+                            Clicked="OnCopyClicked"
+                            HorizontalOptions="End" />
+                </Grid>
+                <Button Text="Passwort erzeugen"
+                        Style="{StaticResource PrimaryActionButtonStyle}"
+                        Clicked="OnCreateClicked" />
+                <controls:PasswordAnalysisPanel x:Name="analysisPanel"
+                                                 IsVisible="False" />
+            </VerticalStackLayout>
+        </Border>
+    </VerticalStackLayout>
+</ContentView>

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/SegmentRotationTechniqueUiPage.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/SegmentRotationTechniqueUiPage.xaml.cs
@@ -1,0 +1,82 @@
+using System;
+using Microsoft.Maui.Controls;
+using Password_Phrase_Producer.PasswordGenerationTechniques.SegmentRotationTechnique;
+using Password_Phrase_Producer.Services.EntropyAnalyzer;
+
+namespace Password_Phrase_Producer.Windows.PasswordGenerationWindows;
+
+public partial class SegmentRotationTechniqueUiPage : ContentView
+{
+    private readonly ISegmentRotationTechnique rotationTechnique;
+    private readonly IPasswordEntropyAnalyzer entropyAnalyzer;
+
+    public SegmentRotationTechniqueUiPage(ISegmentRotationTechnique rotationTechnique, IPasswordEntropyAnalyzer entropyAnalyzer)
+    {
+        InitializeComponent();
+        this.rotationTechnique = rotationTechnique;
+        this.entropyAnalyzer = entropyAnalyzer;
+
+        UpdateSegmentLabel();
+        analysisPanel?.Reset();
+    }
+
+    private void OnSegmentLengthChanged(object? sender, ValueChangedEventArgs e)
+    {
+        UpdateSegmentLabel();
+    }
+
+    private void UpdateSegmentLabel()
+    {
+        if (segmentLabel is not null)
+        {
+            segmentLabel.Text = $"Segmentlänge: {GetSegmentLength()}";
+        }
+    }
+
+    private int GetSegmentLength()
+    {
+        return segmentSlider is null ? 3 : (int)Math.Round(segmentSlider.Value);
+    }
+
+    private void OnCreateClicked(object sender, EventArgs e)
+    {
+        string input = inputEntry?.Text ?? string.Empty;
+        int segmentLength = GetSegmentLength();
+        string result = rotationTechnique.ShuffleSegments(input, segmentLength);
+
+        if (string.IsNullOrEmpty(result))
+        {
+            if (resultEntry is not null)
+            {
+                resultEntry.Text = string.Empty;
+            }
+
+            analysisPanel?.Reset();
+            return;
+        }
+
+        if (resultEntry is not null)
+        {
+            resultEntry.Text = result;
+        }
+
+        if (analysisPanel is not null)
+        {
+            var analysis = entropyAnalyzer.Analyze(result);
+            analysisPanel.Update(analysis);
+        }
+    }
+
+    private async void OnCopyClicked(object sender, EventArgs e)
+    {
+        if (!string.IsNullOrWhiteSpace(resultEntry?.Text))
+        {
+            await Clipboard.Default.SetTextAsync(resultEntry!.Text);
+            var mainPage = Application.Current?.MainPage;
+            if (mainPage is not null)
+            {
+                await mainPage.DisplayAlert("Info", "Password copied to clipboard", "OK");
+            }
+        }
+    }
+}

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/SymbolInjectionTechniqueUiPage.xaml
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/SymbolInjectionTechniqueUiPage.xaml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:controls="clr-namespace:Password_Phrase_Producer.Windows.PasswordGenerationWindows.Controls"
+             x:Class="Password_Phrase_Producer.Windows.PasswordGenerationWindows.SymbolInjectionTechniqueUiPage">
+    <VerticalStackLayout Spacing="24">
+        <Border StrokeThickness="0"
+                Padding="18"
+                BackgroundColor="#1F2438">
+            <Border.StrokeShape>
+                <RoundRectangle CornerRadius="22" />
+            </Border.StrokeShape>
+            <VerticalStackLayout Spacing="14">
+                <Label Text="Symbol-Mixer"
+                       FontSize="18"
+                       FontAttributes="Bold"
+                       TextColor="White"/>
+                <Label Text="Injiziere Symbole an zufälligen Positionen und steuere die Groß-/Kleinschreibung."
+                       TextColor="#BDC2E8"
+                       FontSize="14"
+                       LineBreakMode="WordWrap"/>
+                <Entry x:Name="inputEntry"
+                       Placeholder="Basispasswort"
+                       Style="{StaticResource DarkEntryStyle}" />
+                <Label x:Name="symbolLabel"
+                       Text="Symbole: 2"
+                       TextColor="#8F95C6"
+                       FontSize="13" />
+                <Slider x:Name="symbolSlider"
+                        Minimum="0"
+                        Maximum="6"
+                        Value="2"
+                        ValueChanged="OnSymbolCountChanged" />
+                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+                    <Label Text="Groß-/Kleinschreibung variieren"
+                           TextColor="#BDC2E8"
+                           FontSize="14" />
+                    <Switch x:Name="caseSwitch"
+                            Grid.Column="1"
+                            OnColor="#FF7700" />
+                </Grid>
+                <Entry x:Name="seedEntry"
+                       Placeholder="Optionaler Seed für reproduzierbare Symbole"
+                       Style="{StaticResource DarkEntryStyle}" />
+            </VerticalStackLayout>
+        </Border>
+
+        <Border StrokeThickness="0"
+                Padding="18"
+                BackgroundColor="#1F2438">
+            <Border.StrokeShape>
+                <RoundRectangle CornerRadius="22" />
+            </Border.StrokeShape>
+            <VerticalStackLayout Spacing="16">
+                <Label Text="Symbolisiertes Passwort"
+                       FontSize="18"
+                       FontAttributes="Bold"
+                       TextColor="White"/>
+                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
+                    <Entry x:Name="resultEntry"
+                           Placeholder="Ergebnis"
+                           Style="{StaticResource DarkEntryStyle}"
+                           IsReadOnly="True" />
+                    <Button Grid.Column="1"
+                            Text="Kopieren"
+                            Style="{StaticResource PrimaryActionButtonStyle}"
+                            Clicked="OnCopyClicked"
+                            HorizontalOptions="End" />
+                </Grid>
+                <Button Text="Passwort erzeugen"
+                        Style="{StaticResource PrimaryActionButtonStyle}"
+                        Clicked="OnCreateClicked" />
+                <controls:PasswordAnalysisPanel x:Name="analysisPanel"
+                                                 IsVisible="False" />
+            </VerticalStackLayout>
+        </Border>
+    </VerticalStackLayout>
+</ContentView>

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/SymbolInjectionTechniqueUiPage.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/SymbolInjectionTechniqueUiPage.xaml.cs
@@ -1,0 +1,85 @@
+using System;
+using Microsoft.Maui.Controls;
+using Password_Phrase_Producer.PasswordGenerationTechniques.SymbolInjectionTechnique;
+using Password_Phrase_Producer.Services.EntropyAnalyzer;
+
+namespace Password_Phrase_Producer.Windows.PasswordGenerationWindows;
+
+public partial class SymbolInjectionTechniqueUiPage : ContentView
+{
+    private readonly ISymbolInjectionTechnique symbolInjectionTechnique;
+    private readonly IPasswordEntropyAnalyzer entropyAnalyzer;
+
+    public SymbolInjectionTechniqueUiPage(ISymbolInjectionTechnique symbolInjectionTechnique, IPasswordEntropyAnalyzer entropyAnalyzer)
+    {
+        InitializeComponent();
+        this.symbolInjectionTechnique = symbolInjectionTechnique;
+        this.entropyAnalyzer = entropyAnalyzer;
+
+        UpdateSymbolLabel();
+        analysisPanel?.Reset();
+    }
+
+    private void OnSymbolCountChanged(object? sender, ValueChangedEventArgs e)
+    {
+        UpdateSymbolLabel();
+    }
+
+    private void UpdateSymbolLabel()
+    {
+        if (symbolLabel is not null)
+        {
+            symbolLabel.Text = $"Symbole: {GetSymbolCount()}";
+        }
+    }
+
+    private int GetSymbolCount()
+    {
+        return symbolSlider is null ? 2 : (int)Math.Round(symbolSlider.Value);
+    }
+
+    private void OnCreateClicked(object sender, EventArgs e)
+    {
+        string input = inputEntry?.Text ?? string.Empty;
+        int symbolCount = GetSymbolCount();
+        bool randomizeCase = caseSwitch?.IsToggled ?? false;
+        string seed = seedEntry?.Text ?? string.Empty;
+
+        string result = symbolInjectionTechnique.InjectSymbols(input, symbolCount, randomizeCase, string.IsNullOrWhiteSpace(seed) ? null : seed);
+
+        if (string.IsNullOrEmpty(result))
+        {
+            if (resultEntry is not null)
+            {
+                resultEntry.Text = string.Empty;
+            }
+
+            analysisPanel?.Reset();
+            return;
+        }
+
+        if (resultEntry is not null)
+        {
+            resultEntry.Text = result;
+        }
+
+        if (analysisPanel is not null)
+        {
+            var analysis = entropyAnalyzer.Analyze(result);
+            analysisPanel.Update(analysis);
+        }
+    }
+
+    private async void OnCopyClicked(object sender, EventArgs e)
+    {
+        if (!string.IsNullOrWhiteSpace(resultEntry?.Text))
+        {
+            await Clipboard.Default.SetTextAsync(resultEntry!.Text);
+            var mainPage = Application.Current?.MainPage;
+            if (mainPage is not null)
+            {
+                await mainPage.DisplayAlert("Info", "Password copied to clipboard", "OK");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add five new password generation techniques with dedicated interfaces and deterministic logic where applicable
- create matching UI pages for each technique and connect them to entropy analysis and clipboard features
- register the new modes in the catalog so they appear in the app navigation

## Testing
- dotnet build *(fails: command not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fbee8a5b4832abc9626b238dbb1eb)