### PR TITLE
Fix segment rotation segment creation return type

### DIFF
--- a/Password Phrase Producer/PasswordGenerationTechniques/SegmentRotationTechnique/SegmentRotationTechnique.cs
+++ b/Password Phrase Producer/PasswordGenerationTechniques/SegmentRotationTechnique/SegmentRotationTechnique.cs
@@ -33,7 +33,7 @@ namespace Password_Phrase_Producer.PasswordGenerationTechniques.SegmentRotationT
             return $"{string.Join("-", rotated)}#{checksum}";
         }
 
-        private static IList<string> CreateSegments(string cleaned, int segmentLength)
+        private static IReadOnlyList<string> CreateSegments(string cleaned, int segmentLength)
         {
             var segments = new List<string>();
 


### PR DESCRIPTION
## Summary
- update the segment rotation technique to expose an IReadOnlyList from CreateSegments so it can be consumed by RotateSegments

## Testing
- not run (dotnet CLI unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fc4b3d50c832aa173d52b9adf2a70)