### PR TITLE
Add vault quick action to password generators

### DIFF
--- a/Password Phrase Producer/Views/ModeHostPage.xaml.cs
+++ b/Password Phrase Producer/Views/ModeHostPage.xaml.cs
@@ -11,7 +11,8 @@ public partial class ModeHostPage : ContentPage
         InitializeComponent();
         BindingContext = option;
         Title = option.Title;
-        ContentHost.Content = option.CreateView();
+        var contentView = option.CreateView();
+        ContentHost.Content = new PasswordGeneratorHostView(contentView);
     }
 
     private async void OnBackTapped(object? sender, TappedEventArgs e)

--- a/Password Phrase Producer/Views/PasswordGeneratorHostView.cs
+++ b/Password Phrase Producer/Views/PasswordGeneratorHostView.cs
@@ -1,0 +1,313 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+using Password_Phrase_Producer.Models;
+using Password_Phrase_Producer.Services.Vault;
+using Password_Phrase_Producer.Windows.PasswordGenerationWindows;
+
+namespace Password_Phrase_Producer.Views;
+
+public class PasswordGeneratorHostView : ContentView
+{
+    private readonly Button _addToVaultButton;
+    private readonly IPasswordResultProvider? _resultProvider;
+    private PasswordVaultService? _vaultService;
+
+    public PasswordGeneratorHostView(View content)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+
+        _resultProvider = content as IPasswordResultProvider ?? FindResultProvider(content);
+        _vaultService = ResolveVaultService();
+
+        var layout = new Grid
+        {
+            RowSpacing = 24,
+            RowDefinitions =
+            {
+                new RowDefinition { Height = GridLength.Star },
+                new RowDefinition { Height = GridLength.Auto }
+            }
+        };
+
+        layout.Children.Add(content);
+        Grid.SetRow(content, 0);
+
+        var actionContainer = CreateActionContainer();
+        layout.Children.Add(actionContainer);
+        Grid.SetRow(actionContainer, 1);
+
+        Content = layout;
+
+        UpdateButtonState();
+
+        if (_resultProvider is not null)
+        {
+            _resultProvider.PasswordGenerated += OnPasswordGenerated;
+            _resultProvider.PasswordCleared += OnPasswordCleared;
+        }
+    }
+
+    protected override void OnParentSet()
+    {
+        base.OnParentSet();
+
+        if (Parent is null)
+        {
+            DetachEvents();
+        }
+    }
+
+    private View CreateActionContainer()
+    {
+        var border = new Border
+        {
+            StrokeThickness = 0,
+            BackgroundColor = Color.FromArgb("#1F2438"),
+            Padding = new Thickness(18, 16),
+            StrokeShape = new RoundRectangle { CornerRadius = 20 }
+        };
+
+        _addToVaultButton = new Button
+        {
+            Text = "Zum Tresor hinzufügen",
+            HorizontalOptions = LayoutOptions.Fill,
+            IsEnabled = false
+        };
+
+        if (Application.Current?.Resources.TryGetValue("PrimaryActionButtonStyle", out var styleObj) == true && styleObj is Style style)
+        {
+            _addToVaultButton.Style = style;
+        }
+
+        _addToVaultButton.Clicked += OnAddToVaultClicked;
+
+        border.Content = _addToVaultButton;
+        return border;
+    }
+
+    private void OnPasswordGenerated(object? sender, string password)
+    {
+        UpdateButtonState();
+    }
+
+    private void OnPasswordCleared(object? sender, EventArgs e)
+    {
+        UpdateButtonState();
+    }
+
+    private void UpdateButtonState()
+    {
+        var hasPassword = !string.IsNullOrWhiteSpace(_resultProvider?.LastGeneratedPassword);
+        var canUseVault = GetVaultService() is not null;
+        _addToVaultButton.IsEnabled = hasPassword && canUseVault;
+    }
+
+    private async void OnAddToVaultClicked(object? sender, EventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(_resultProvider?.LastGeneratedPassword))
+        {
+            return;
+        }
+
+        var vaultService = GetVaultService();
+
+        if (vaultService is null)
+        {
+            await ShowAlert("Tresor nicht verfügbar", "Der Tresor-Dienst konnte nicht geladen werden.");
+            return;
+        }
+
+        var password = _resultProvider.LastGeneratedPassword!;
+
+        if (!await vaultService.HasMasterPasswordAsync())
+        {
+            await PromptToCreateVault();
+            return;
+        }
+
+        if (!vaultService.IsUnlocked)
+        {
+            await PromptToUnlockVault();
+            return;
+        }
+
+        await AddPasswordToVaultAsync(password, vaultService);
+    }
+
+    private async Task AddPasswordToVaultAsync(string password, PasswordVaultService vaultService)
+    {
+        var navigation = Application.Current?.MainPage?.Navigation;
+        if (navigation is null)
+        {
+            await ShowAlert("Navigation nicht verfügbar", "Der Tresor-Editor konnte nicht geöffnet werden.");
+            return;
+        }
+
+        var entry = new PasswordVaultEntry
+        {
+            Password = password
+        };
+
+        var availableCategories = await LoadAvailableCategoriesAsync(vaultService);
+
+        var result = await VaultEntryEditorPage.ShowAsync(navigation, entry, "Passwort zum Tresor hinzufügen", availableCategories);
+
+        if (result is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await vaultService.AddOrUpdateEntryAsync(result);
+        }
+        catch (Exception ex)
+        {
+            await ShowAlert("Fehler", $"Der Eintrag konnte nicht gespeichert werden: {ex.Message}");
+            return;
+        }
+
+        await ShowAlert("Gespeichert", "Das Passwort wurde erfolgreich im Tresor abgelegt.");
+    }
+
+    private async Task PromptToCreateVault()
+    {
+        var mainPage = Application.Current?.MainPage;
+        if (mainPage is null)
+        {
+            return;
+        }
+
+        var createVault = await mainPage.DisplayAlert(
+            "Tresor benötigt",
+            "Du musst zuerst einen Tresor anlegen, bevor du Passwörter speichern kannst.",
+            "Tresor erstellen",
+            "Abbrechen");
+
+        if (createVault)
+        {
+            if (Shell.Current is not null)
+            {
+                await Shell.Current.GoToAsync("//vault");
+            }
+        }
+    }
+
+    private async Task PromptToUnlockVault()
+    {
+        var mainPage = Application.Current?.MainPage;
+        if (mainPage is null)
+        {
+            return;
+        }
+
+        var navigateToVault = await mainPage.DisplayAlert(
+            "Tresor gesperrt",
+            "Bitte entsperre deinen Tresor, um Passwörter speichern zu können.",
+            "Zum Tresor",
+            "Abbrechen");
+
+        if (navigateToVault)
+        {
+            if (Shell.Current is not null)
+            {
+                await Shell.Current.GoToAsync("//vault");
+            }
+        }
+    }
+
+    private async Task ShowAlert(string title, string message)
+    {
+        var mainPage = Application.Current?.MainPage;
+        if (mainPage is not null)
+        {
+            await mainPage.DisplayAlert(title, message, "OK");
+        }
+    }
+
+    private async Task<string[]> LoadAvailableCategoriesAsync(PasswordVaultService vaultService)
+    {
+        try
+        {
+            var entries = await vaultService.GetEntriesAsync();
+            return entries
+                .Select(entry => entry.Category)
+                .Where(category => !string.IsNullOrWhiteSpace(category))
+                .Distinct(StringComparer.CurrentCultureIgnoreCase)
+                .ToArray();
+        }
+        catch
+        {
+            return Array.Empty<string>();
+        }
+    }
+
+    private void DetachEvents()
+    {
+        if (_resultProvider is not null)
+        {
+            _resultProvider.PasswordGenerated -= OnPasswordGenerated;
+            _resultProvider.PasswordCleared -= OnPasswordCleared;
+        }
+
+        _addToVaultButton.Clicked -= OnAddToVaultClicked;
+    }
+
+    private static IPasswordResultProvider? FindResultProvider(object element)
+    {
+        if (element is IPasswordResultProvider provider)
+        {
+            return provider;
+        }
+
+        if (element is IElement view)
+        {
+            foreach (var child in view.FindDescendants())
+            {
+                if (child is IPasswordResultProvider childProvider)
+                {
+                    return childProvider;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private PasswordVaultService? GetVaultService()
+    {
+        if (_vaultService is not null)
+        {
+            return _vaultService;
+        }
+
+        _vaultService = ResolveVaultService();
+        return _vaultService;
+    }
+
+    private static PasswordVaultService? ResolveVaultService()
+    {
+        try
+        {
+            return Application.Current?.Handler?.MauiContext?.Services.GetService<PasswordVaultService>();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}
+
+public interface IPasswordResultProvider
+{
+    event EventHandler<string> PasswordGenerated;
+
+    event EventHandler PasswordCleared;
+
+    string? LastGeneratedPassword { get; }
+}

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/ConcatenationTechniquesUiPage.xaml
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/ConcatenationTechniquesUiPage.xaml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+<local:PasswordGeneratorContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:controls="clr-namespace:Password_Phrase_Producer.Windows.PasswordGenerationWindows.Controls"
+             xmlns:local="clr-namespace:Password_Phrase_Producer.Windows.PasswordGenerationWindows"
              x:Class="Password_Phrase_Producer.Windows.PasswordGenerationWindows.ConcatenationTechniquesUiPage">
     <VerticalStackLayout Spacing="24">
         <Border StrokeThickness="0"
@@ -68,4 +69,4 @@
             </VerticalStackLayout>
         </Border>
     </VerticalStackLayout>
-</ContentView>
+</local:PasswordGeneratorContentView>

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/ConcatenationTechniquesUiPage.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/ConcatenationTechniquesUiPage.xaml.cs
@@ -9,7 +9,7 @@ using Password_Phrase_Producer.Services.EntropyAnalyzer;
 
 namespace Password_Phrase_Producer.Windows.PasswordGenerationWindows;
 
-public partial class ConcatenationTechniquesUiPage : ContentView
+public partial class ConcatenationTechniquesUiPage : PasswordGeneratorContentView
 {
     private readonly IConcatenationTechnique concatenationTechnique;
     private readonly IPasswordEntropyAnalyzer entropyAnalyzer;
@@ -72,6 +72,7 @@ public partial class ConcatenationTechniquesUiPage : ContentView
             }
 
             analysisPanel?.Reset();
+            UpdateGeneratedPassword(null);
             return;
         }
 
@@ -79,6 +80,8 @@ public partial class ConcatenationTechniquesUiPage : ContentView
         {
             resultEntry.Text = result;
         }
+
+        UpdateGeneratedPassword(result);
 
         if (analysisPanel is not null)
         {

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/DicewareTechniqueUiPage.xaml
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/DicewareTechniqueUiPage.xaml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+<local:PasswordGeneratorContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:controls="clr-namespace:Password_Phrase_Producer.Windows.PasswordGenerationWindows.Controls"
+             xmlns:local="clr-namespace:Password_Phrase_Producer.Windows.PasswordGenerationWindows"
              x:Class="Password_Phrase_Producer.Windows.PasswordGenerationWindows.DicewareTechniqueUiPage">
     <VerticalStackLayout Spacing="24">
         <Border StrokeThickness="0"
@@ -64,4 +65,4 @@
             </VerticalStackLayout>
         </Border>
     </VerticalStackLayout>
-</ContentView>
+</local:PasswordGeneratorContentView>

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/DicewareTechniqueUiPage.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/DicewareTechniqueUiPage.xaml.cs
@@ -1,11 +1,10 @@
 using System;
-using Microsoft.Maui.Controls;
 using Password_Phrase_Producer.PasswordGenerationTechniques.DicewareTechnique;
 using Password_Phrase_Producer.Services.EntropyAnalyzer;
 
 namespace Password_Phrase_Producer.Windows.PasswordGenerationWindows;
 
-public partial class DicewareTechniqueUiPage : ContentView
+public partial class DicewareTechniqueUiPage : PasswordGeneratorContentView
 {
     private readonly IDicewareTechnique dicewareTechnique;
     private readonly IPasswordEntropyAnalyzer entropyAnalyzer;
@@ -52,6 +51,7 @@ public partial class DicewareTechniqueUiPage : ContentView
             }
 
             analysisPanel?.Reset();
+            UpdateGeneratedPassword(null);
             return;
         }
 
@@ -59,6 +59,8 @@ public partial class DicewareTechniqueUiPage : ContentView
         {
             resultEntry.Text = result;
         }
+
+        UpdateGeneratedPassword(result);
 
         if (analysisPanel is not null)
         {

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/HachBasedTechniquesUiPage.xaml
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/HachBasedTechniquesUiPage.xaml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+<local:PasswordGeneratorContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:controls="clr-namespace:Password_Phrase_Producer.Windows.PasswordGenerationWindows.Controls"
+             xmlns:local="clr-namespace:Password_Phrase_Producer.Windows.PasswordGenerationWindows"
              x:Class="Password_Phrase_Producer.Windows.PasswordGenerationWindows.HachBasedTechniquesUiPage">
     <VerticalStackLayout Spacing="24">
         <Border StrokeThickness="0"
@@ -55,4 +56,4 @@
             </VerticalStackLayout>
         </Border>
     </VerticalStackLayout>
-</ContentView>
+</local:PasswordGeneratorContentView>

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/HachBasedTechniquesUiPage.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/HachBasedTechniquesUiPage.xaml.cs
@@ -1,11 +1,10 @@
 using System;
-using Microsoft.Maui.Controls;
 using Password_Phrase_Producer.PasswordGenerationTechniques.HashBasedTechniques;
 using Password_Phrase_Producer.Services.EntropyAnalyzer;
 
 namespace Password_Phrase_Producer.Windows.PasswordGenerationWindows;
 
-public partial class HachBasedTechniquesUiPage : ContentView
+public partial class HachBasedTechniquesUiPage : PasswordGeneratorContentView
 {
     private readonly IHashBasedTechniques hashBasedTechnique;
     private readonly IPasswordEntropyAnalyzer entropyAnalyzer;
@@ -31,6 +30,8 @@ public partial class HachBasedTechniquesUiPage : ContentView
                 resultEntry.Text = result;
             }
 
+            UpdateGeneratedPassword(result);
+
             if (analysisPanel is not null)
             {
                 var analysis = entropyAnalyzer.Analyze(result);
@@ -45,6 +46,7 @@ public partial class HachBasedTechniquesUiPage : ContentView
             }
 
             analysisPanel?.Reset();
+            UpdateGeneratedPassword(null);
         }
     }
 

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/MirrorTechniqueUiPage.xaml
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/MirrorTechniqueUiPage.xaml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+<local:PasswordGeneratorContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:controls="clr-namespace:Password_Phrase_Producer.Windows.PasswordGenerationWindows.Controls"
+             xmlns:local="clr-namespace:Password_Phrase_Producer.Windows.PasswordGenerationWindows"
              x:Class="Password_Phrase_Producer.Windows.PasswordGenerationWindows.MirrorTechniqueUiPage">
     <VerticalStackLayout Spacing="24">
         <Border StrokeThickness="0"
@@ -55,4 +56,4 @@
             </VerticalStackLayout>
         </Border>
     </VerticalStackLayout>
-</ContentView>
+</local:PasswordGeneratorContentView>

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/MirrorTechniqueUiPage.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/MirrorTechniqueUiPage.xaml.cs
@@ -1,11 +1,10 @@
 using System;
-using Microsoft.Maui.Controls;
 using Password_Phrase_Producer.PasswordGenerationTechniques.MirrorLockTechnique;
 using Password_Phrase_Producer.Services.EntropyAnalyzer;
 
 namespace Password_Phrase_Producer.Windows.PasswordGenerationWindows;
 
-public partial class MirrorTechniqueUiPage : ContentView
+public partial class MirrorTechniqueUiPage : PasswordGeneratorContentView
 {
     private readonly IMirrorLockTechnique mirrorTechnique;
     private readonly IPasswordEntropyAnalyzer entropyAnalyzer;
@@ -32,6 +31,7 @@ public partial class MirrorTechniqueUiPage : ContentView
             }
 
             analysisPanel?.Reset();
+            UpdateGeneratedPassword(null);
             return;
         }
 
@@ -39,6 +39,8 @@ public partial class MirrorTechniqueUiPage : ContentView
         {
             resultEntry.Text = result;
         }
+
+        UpdateGeneratedPassword(result);
 
         if (analysisPanel is not null)
         {

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/PasswordGeneratorContentView.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/PasswordGeneratorContentView.cs
@@ -1,0 +1,36 @@
+using System;
+using Microsoft.Maui.Controls;
+using Password_Phrase_Producer.Views;
+
+namespace Password_Phrase_Producer.Windows.PasswordGenerationWindows;
+
+public abstract class PasswordGeneratorContentView : ContentView, IPasswordResultProvider
+{
+    private string? _lastGeneratedPassword;
+
+    public event EventHandler<string>? PasswordGenerated;
+
+    public event EventHandler? PasswordCleared;
+
+    public string? LastGeneratedPassword
+    {
+        get => _lastGeneratedPassword;
+        private set => _lastGeneratedPassword = value;
+    }
+
+    protected void UpdateGeneratedPassword(string? password)
+    {
+        var normalized = string.IsNullOrWhiteSpace(password) ? null : password;
+
+        LastGeneratedPassword = normalized;
+
+        if (normalized is not null)
+        {
+            PasswordGenerated?.Invoke(this, normalized);
+        }
+        else
+        {
+            PasswordCleared?.Invoke(this, EventArgs.Empty);
+        }
+    }
+}

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/PatternCascadeTechniqueUiPage.xaml
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/PatternCascadeTechniqueUiPage.xaml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+<local:PasswordGeneratorContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:controls="clr-namespace:Password_Phrase_Producer.Windows.PasswordGenerationWindows.Controls"
+             xmlns:local="clr-namespace:Password_Phrase_Producer.Windows.PasswordGenerationWindows"
              x:Class="Password_Phrase_Producer.Windows.PasswordGenerationWindows.PatternCascadeTechniqueUiPage">
     <VerticalStackLayout Spacing="24">
         <Border StrokeThickness="0"
@@ -62,4 +63,4 @@
             </VerticalStackLayout>
         </Border>
     </VerticalStackLayout>
-</ContentView>
+</local:PasswordGeneratorContentView>

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/PatternCascadeTechniqueUiPage.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/PatternCascadeTechniqueUiPage.xaml.cs
@@ -1,11 +1,10 @@
 using System;
-using Microsoft.Maui.Controls;
 using Password_Phrase_Producer.PasswordGenerationTechniques.PatternCascadeTechnique;
 using Password_Phrase_Producer.Services.EntropyAnalyzer;
 
 namespace Password_Phrase_Producer.Windows.PasswordGenerationWindows;
 
-public partial class PatternCascadeTechniqueUiPage : ContentView
+public partial class PatternCascadeTechniqueUiPage : PasswordGeneratorContentView
 {
     private readonly IPatternCascadeTechnique patternCascadeTechnique;
     private readonly IPasswordEntropyAnalyzer entropyAnalyzer;
@@ -35,6 +34,7 @@ public partial class PatternCascadeTechniqueUiPage : ContentView
             }
 
             analysisPanel?.Reset();
+            UpdateGeneratedPassword(null);
             return;
         }
 
@@ -42,6 +42,8 @@ public partial class PatternCascadeTechniqueUiPage : ContentView
         {
             resultEntry.Text = result;
         }
+
+        UpdateGeneratedPassword(result);
 
         if (analysisPanel is not null)
         {

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/SegmentRotationTechniqueUiPage.xaml
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/SegmentRotationTechniqueUiPage.xaml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+<local:PasswordGeneratorContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:controls="clr-namespace:Password_Phrase_Producer.Windows.PasswordGenerationWindows.Controls"
+             xmlns:local="clr-namespace:Password_Phrase_Producer.Windows.PasswordGenerationWindows"
              x:Class="Password_Phrase_Producer.Windows.PasswordGenerationWindows.SegmentRotationTechniqueUiPage">
     <VerticalStackLayout Spacing="24">
         <Border StrokeThickness="0"
@@ -64,4 +65,4 @@
             </VerticalStackLayout>
         </Border>
     </VerticalStackLayout>
-</ContentView>
+</local:PasswordGeneratorContentView>

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/SegmentRotationTechniqueUiPage.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/SegmentRotationTechniqueUiPage.xaml.cs
@@ -1,11 +1,10 @@
 using System;
-using Microsoft.Maui.Controls;
 using Password_Phrase_Producer.PasswordGenerationTechniques.SegmentRotationTechnique;
 using Password_Phrase_Producer.Services.EntropyAnalyzer;
 
 namespace Password_Phrase_Producer.Windows.PasswordGenerationWindows;
 
-public partial class SegmentRotationTechniqueUiPage : ContentView
+public partial class SegmentRotationTechniqueUiPage : PasswordGeneratorContentView
 {
     private readonly ISegmentRotationTechnique rotationTechnique;
     private readonly IPasswordEntropyAnalyzer entropyAnalyzer;
@@ -52,6 +51,7 @@ public partial class SegmentRotationTechniqueUiPage : ContentView
             }
 
             analysisPanel?.Reset();
+            UpdateGeneratedPassword(null);
             return;
         }
 
@@ -59,6 +59,8 @@ public partial class SegmentRotationTechniqueUiPage : ContentView
         {
             resultEntry.Text = result;
         }
+
+        UpdateGeneratedPassword(result);
 
         if (analysisPanel is not null)
         {

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/SymbolInjectionTechniqueUiPage.xaml
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/SymbolInjectionTechniqueUiPage.xaml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+<local:PasswordGeneratorContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:controls="clr-namespace:Password_Phrase_Producer.Windows.PasswordGenerationWindows.Controls"
+             xmlns:local="clr-namespace:Password_Phrase_Producer.Windows.PasswordGenerationWindows"
              x:Class="Password_Phrase_Producer.Windows.PasswordGenerationWindows.SymbolInjectionTechniqueUiPage">
     <VerticalStackLayout Spacing="24">
         <Border StrokeThickness="0"
@@ -75,4 +76,4 @@
             </VerticalStackLayout>
         </Border>
     </VerticalStackLayout>
-</ContentView>
+</local:PasswordGeneratorContentView>

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/SymbolInjectionTechniqueUiPage.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/SymbolInjectionTechniqueUiPage.xaml.cs
@@ -1,11 +1,10 @@
 using System;
-using Microsoft.Maui.Controls;
 using Password_Phrase_Producer.PasswordGenerationTechniques.SymbolInjectionTechnique;
 using Password_Phrase_Producer.Services.EntropyAnalyzer;
 
 namespace Password_Phrase_Producer.Windows.PasswordGenerationWindows;
 
-public partial class SymbolInjectionTechniqueUiPage : ContentView
+public partial class SymbolInjectionTechniqueUiPage : PasswordGeneratorContentView
 {
     private readonly ISymbolInjectionTechnique symbolInjectionTechnique;
     private readonly IPasswordEntropyAnalyzer entropyAnalyzer;
@@ -55,6 +54,7 @@ public partial class SymbolInjectionTechniqueUiPage : ContentView
             }
 
             analysisPanel?.Reset();
+            UpdateGeneratedPassword(null);
             return;
         }
 
@@ -62,6 +62,8 @@ public partial class SymbolInjectionTechniqueUiPage : ContentView
         {
             resultEntry.Text = result;
         }
+
+        UpdateGeneratedPassword(result);
 
         if (analysisPanel is not null)
         {

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/TbvUiPage.xaml
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/TbvUiPage.xaml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+<local:PasswordGeneratorContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:controls="clr-namespace:Password_Phrase_Producer.Windows.PasswordGenerationWindows.Controls"
+             xmlns:local="clr-namespace:Password_Phrase_Producer.Windows.PasswordGenerationWindows"
              x:Class="Password_Phrase_Producer.Windows.PasswordGenerationWindows.TbvUiPage">
     <VerticalStackLayout Spacing="24">
         <Border StrokeThickness="0"
@@ -73,4 +74,4 @@
             </VerticalStackLayout>
         </Border>
     </VerticalStackLayout>
-</ContentView>
+</local:PasswordGeneratorContentView>

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/TbvUiPage.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/TbvUiPage.xaml.cs
@@ -1,11 +1,10 @@
 using System;
-using Microsoft.Maui.Controls;
 using Password_Phrase_Producer.PasswordGenerationTechniques.TbvTechniques;
 using Password_Phrase_Producer.Services.EntropyAnalyzer;
 
 namespace Password_Phrase_Producer.Windows.PasswordGenerationWindows;
 
-public partial class TbvUiPage : ContentView
+public partial class TbvUiPage : PasswordGeneratorContentView
 {
     private readonly Itbv tbv;
     private readonly IPasswordEntropyAnalyzer entropyAnalyzer;
@@ -26,6 +25,7 @@ public partial class TbvUiPage : ContentView
         if (string.IsNullOrWhiteSpace(password))
         {
             resultEntry.Text = string.Empty;
+            UpdateGeneratedPassword(null);
             return;
         }
 
@@ -41,6 +41,8 @@ public partial class TbvUiPage : ContentView
                 resultEntry.Text = result;
             }
 
+            UpdateGeneratedPassword(result);
+
             if (analysisPanel is not null)
             {
                 var analysis = entropyAnalyzer.Analyze(result);
@@ -55,6 +57,7 @@ public partial class TbvUiPage : ContentView
             }
 
             analysisPanel?.Reset();
+            UpdateGeneratedPassword(null);
         }
     }
 


### PR DESCRIPTION
## Summary
- add a reusable PasswordGeneratorHostView wrapper that injects a "Zum Tresor hinzufügen" action into every password mode
- expose generated password data via a PasswordGeneratorContentView base class so quick actions can subscribe without duplicating code
- update all generator pages to publish password changes and reset signals for the new quick action workflow

## Testing
- Not run (dotnet CLI is not available in the execution environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910da65357c832aae64951c7e1e28e6)