### PR TITLE
Open vault entry editor after unlocking from generator

### DIFF
--- a/Password Phrase Producer/Services/Vault/VaultNavigationCoordinator.cs
+++ b/Password Phrase Producer/Services/Vault/VaultNavigationCoordinator.cs
@@ -1,0 +1,53 @@
+using System;
+
+namespace Password_Phrase_Producer.Services.Vault;
+
+public sealed class PendingVaultEntryRequest
+{
+    public PendingVaultEntryRequest(string password)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(password);
+
+        Id = Guid.NewGuid();
+        Password = password;
+    }
+
+    public Guid Id { get; }
+
+    public string Password { get; }
+}
+
+public static class VaultNavigationCoordinator
+{
+    private static readonly object SyncRoot = new();
+    private static PendingVaultEntryRequest? _pendingRequest;
+
+    public static PendingVaultEntryRequest? GetPendingRequest()
+    {
+        lock (SyncRoot)
+        {
+            return _pendingRequest;
+        }
+    }
+
+    public static PendingVaultEntryRequest SetPendingPassword(string password)
+    {
+        lock (SyncRoot)
+        {
+            var request = new PendingVaultEntryRequest(password);
+            _pendingRequest = request;
+            return request;
+        }
+    }
+
+    public static void ClearPendingRequest(Guid requestId)
+    {
+        lock (SyncRoot)
+        {
+            if (_pendingRequest?.Id == requestId)
+            {
+                _pendingRequest = null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a vault navigation coordinator to keep pending password additions during navigation
- navigate directly to the vault when the generated password should be saved and the vault is locked
- trigger the vault entry editor with the generated password once the vault has been unlocked

## Testing
- Not run (dotnet CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910ebf53c14832aae9761913a94aea2)