### PR TITLE
Adjust release versioning to roll minor and patch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,10 +53,15 @@ jobs:
         id: compute_versions
         shell: pwsh
         run: |
-          $majorMinor = "1.0"
-          $build = "${{ github.run_number }}"
-          $appVersion = "$majorMinor.$build"
-          $windowsVersion = "$majorMinor.$build.0"
+          $runNumber = [int]"${{ github.run_number }}"
+          $major = [math]::Floor($runNumber / 100) + 1
+          $minor = [math]::Floor(($runNumber % 100) / 10)
+          $patch = $runNumber % 10
+
+          $majorMinor = "$major.$minor"
+          $build = $runNumber.ToString()
+          $appVersion = "$major.$minor.$patch"
+          $windowsVersion = "$appVersion.0"
           $releaseDir = Join-Path $env:RUNNER_TEMP 'release'
 
           New-Item -ItemType Directory -Force -Path $releaseDir | Out-Null


### PR DESCRIPTION
## Summary
- compute the release version from the workflow run number by rolling the minor and patch digits after 9
- keep the build number and Windows-specific version variables aligned with the new semantic version string

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910fc8b3d48832a8c523ed9371b7410)