### PR TITLE
Revamp vault UI and integrate custom popups

### DIFF
--- a/Password Phrase Producer/Views/Dialogs/ActionSheetPopup.cs
+++ b/Password Phrase Producer/Views/Dialogs/ActionSheetPopup.cs
@@ -1,0 +1,201 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CommunityToolkit.Maui.Views;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+
+namespace Password_Phrase_Producer.Views.Dialogs;
+
+public sealed record ActionSheetPopupOption(string Id, string Title, string? Description = null, bool IsDestructive = false, bool IsSelected = false);
+
+public sealed class ActionSheetPopup : Popup
+{
+    private readonly string? _cancelText;
+
+    public ActionSheetPopup(string title, IEnumerable<ActionSheetPopupOption> options, string? message = null, string? cancelText = null)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var optionList = options.ToList();
+        if (optionList.Count == 0)
+        {
+            throw new ArgumentException("At least one option is required.", nameof(options));
+        }
+
+        _cancelText = cancelText;
+
+        BackgroundColor = Color.FromRgba(0, 0, 0, 0.65);
+        CanBeDismissedByTappingOutside = cancelText is not null;
+
+        var contentStack = new VerticalStackLayout
+        {
+            Spacing = 18
+        };
+
+        if (!string.IsNullOrWhiteSpace(title))
+        {
+            contentStack.Children.Add(new Label
+            {
+                Text = title,
+                FontSize = 18,
+                FontAttributes = FontAttributes.Bold,
+                TextColor = Colors.White
+            });
+        }
+
+        if (!string.IsNullOrWhiteSpace(message))
+        {
+            contentStack.Children.Add(new Label
+            {
+                Text = message,
+                FontSize = 14,
+                TextColor = Color.FromArgb("#B6BBE0"),
+                LineBreakMode = LineBreakMode.WordWrap
+            });
+        }
+
+        foreach (var option in optionList)
+        {
+            contentStack.Children.Add(CreateOptionView(option));
+        }
+
+        var card = new Border
+        {
+            BackgroundColor = Color.FromArgb("#1B2036"),
+            StrokeShape = new RoundRectangle { CornerRadius = 26 },
+            StrokeThickness = 0,
+            Padding = new Thickness(22, 22, 22, 24),
+            Content = contentStack
+        };
+
+        var rootStack = new VerticalStackLayout
+        {
+            Spacing = 18,
+            Margin = new Thickness(24, 0, 24, 36),
+            HorizontalOptions = LayoutOptions.Fill,
+            VerticalOptions = LayoutOptions.End
+        };
+
+        rootStack.Children.Add(card);
+
+        if (!string.IsNullOrWhiteSpace(cancelText))
+        {
+            rootStack.Children.Add(CreateCancelButton(cancelText));
+        }
+
+        Content = new Grid
+        {
+            HorizontalOptions = LayoutOptions.Fill,
+            VerticalOptions = LayoutOptions.Fill,
+            Children =
+            {
+                rootStack
+            }
+        };
+    }
+
+    private View CreateOptionView(ActionSheetPopupOption option)
+    {
+        var optionLayout = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = GridLength.Star },
+                new ColumnDefinition { Width = GridLength.Auto }
+            },
+            RowDefinitions =
+            {
+                new RowDefinition { Height = GridLength.Auto },
+                new RowDefinition { Height = GridLength.Auto }
+            },
+            ColumnSpacing = 12
+        };
+
+        var titleLabel = new Label
+        {
+            Text = option.Title,
+            FontSize = 16,
+            FontAttributes = FontAttributes.Bold,
+            TextColor = option.IsDestructive ? Color.FromArgb("#FF7474") : Colors.White
+        };
+        optionLayout.Children.Add(titleLabel);
+
+        if (!string.IsNullOrWhiteSpace(option.Description))
+        {
+            optionLayout.Children.Add(new Label
+            {
+                Text = option.Description,
+                FontSize = 13,
+                TextColor = Color.FromArgb("#9EA3C4"),
+                LineBreakMode = LineBreakMode.WordWrap
+            }, 0, 1);
+        }
+
+        if (option.IsSelected)
+        {
+            var checkLabel = new Label
+            {
+                Text = "✓",
+                FontSize = 16,
+                TextColor = Color.FromArgb("#63F5A8"),
+                HorizontalOptions = LayoutOptions.End,
+                VerticalOptions = LayoutOptions.Start
+            };
+            optionLayout.Children.Add(checkLabel, 1, 0);
+            Grid.SetRowSpan(checkLabel, string.IsNullOrWhiteSpace(option.Description) ? 1 : 2);
+        }
+
+        var optionBorder = new Border
+        {
+            BackgroundColor = option.IsSelected ? Color.FromArgb("#262D4A") : Color.FromArgb("#161B2F"),
+            StrokeShape = new RoundRectangle { CornerRadius = 20 },
+            StrokeThickness = 0,
+            Padding = new Thickness(18, 14),
+            Content = optionLayout
+        };
+
+        var capturedOption = option;
+        optionBorder.GestureRecognizers.Add(new TapGestureRecognizer
+        {
+            Command = new Command(() => Close(capturedOption.Id))
+        });
+
+        return optionBorder;
+    }
+
+    private View CreateCancelButton(string cancelText)
+    {
+        var cancelBorder = new Border
+        {
+            BackgroundColor = Color.FromArgb("#161B2F"),
+            StrokeShape = new RoundRectangle { CornerRadius = 20 },
+            StrokeThickness = 0,
+            Padding = new Thickness(18, 14),
+            Content = new Label
+            {
+                Text = cancelText,
+                FontSize = 16,
+                TextColor = Colors.White,
+                HorizontalTextAlignment = TextAlignment.Center
+            }
+        };
+
+        cancelBorder.GestureRecognizers.Add(new TapGestureRecognizer
+        {
+            Command = new Command(() => Close(null))
+        });
+
+        return cancelBorder;
+    }
+
+    protected override void OnLightDismissed()
+    {
+        base.OnLightDismissed();
+
+        if (_cancelText is not null)
+        {
+            Close(null);
+        }
+    }
+}

--- a/Password Phrase Producer/Views/Dialogs/ConfirmationPopup.cs
+++ b/Password Phrase Producer/Views/Dialogs/ConfirmationPopup.cs
@@ -1,0 +1,113 @@
+using System;
+using CommunityToolkit.Maui.Views;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+
+namespace Password_Phrase_Producer.Views.Dialogs;
+
+public sealed class ConfirmationPopup : Popup
+{
+    public ConfirmationPopup(string title, string message, string confirmText, string cancelText, bool confirmIsDestructive = false)
+    {
+        BackgroundColor = Color.FromRgba(0, 0, 0, 0.65);
+        CanBeDismissedByTappingOutside = false;
+
+        var titleLabel = new Label
+        {
+            Text = title,
+            FontSize = 18,
+            FontAttributes = FontAttributes.Bold,
+            TextColor = Colors.White
+        };
+
+        var messageLabel = new Label
+        {
+            Text = message,
+            FontSize = 14,
+            TextColor = Color.FromArgb("#B6BBE0"),
+            LineBreakMode = LineBreakMode.WordWrap
+        };
+
+        var buttonGrid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = GridLength.Star },
+                new ColumnDefinition { Width = GridLength.Star }
+            },
+            ColumnSpacing = 14
+        };
+
+        var cancelButton = CreateActionButton(cancelText, Color.FromArgb("#1A2038"), () => Close(false));
+        buttonGrid.Children.Add(cancelButton);
+
+        var confirmColor = confirmIsDestructive ? Color.FromArgb("#432028") : Color.FromArgb("#2C3A73");
+        var confirmButton = CreateActionButton(confirmText, confirmColor, () => Close(true));
+        buttonGrid.Children.Add(confirmButton, 1, 0);
+
+        var cardLayout = new VerticalStackLayout
+        {
+            Spacing = 18,
+            Children =
+            {
+                titleLabel,
+                messageLabel,
+                buttonGrid
+            }
+        };
+
+        var card = new Border
+        {
+            BackgroundColor = Color.FromArgb("#1B2036"),
+            StrokeShape = new RoundRectangle { CornerRadius = 28 },
+            StrokeThickness = 0,
+            Padding = new Thickness(24, 26),
+            Content = cardLayout
+        };
+
+        Content = new Grid
+        {
+            HorizontalOptions = LayoutOptions.Fill,
+            VerticalOptions = LayoutOptions.Fill,
+            Children =
+            {
+                new Grid
+                {
+                    Padding = new Thickness(24),
+                    HorizontalOptions = LayoutOptions.Fill,
+                    VerticalOptions = LayoutOptions.Center,
+                    Children = { card }
+                }
+            }
+        };
+    }
+
+    private static View CreateActionButton(string text, Color background, Action onClicked)
+    {
+        var label = new Label
+        {
+            Text = text,
+            FontSize = 15,
+            FontAttributes = FontAttributes.Bold,
+            TextColor = Colors.White,
+            HorizontalTextAlignment = TextAlignment.Center,
+            VerticalTextAlignment = TextAlignment.Center
+        };
+
+        var button = new Border
+        {
+            BackgroundColor = background,
+            StrokeThickness = 0,
+            StrokeShape = new RoundRectangle { CornerRadius = 18 },
+            Padding = new Thickness(16, 14),
+            Content = label
+        };
+
+        button.GestureRecognizers.Add(new TapGestureRecognizer
+        {
+            Command = new Command(onClicked)
+        });
+
+        return button;
+    }
+}

--- a/Password Phrase Producer/Views/IPasswordGeneratorActionHost.cs
+++ b/Password Phrase Producer/Views/IPasswordGeneratorActionHost.cs
@@ -1,0 +1,8 @@
+using Microsoft.Maui.Controls;
+
+namespace Password_Phrase_Producer.Views;
+
+public interface IPasswordGeneratorActionHost
+{
+    bool TrySetAddToVaultAction(View actionView);
+}

--- a/Password Phrase Producer/Views/PasswordGeneratorHostView.cs
+++ b/Password Phrase Producer/Views/PasswordGeneratorHostView.cs
@@ -41,8 +41,17 @@ public class PasswordGeneratorHostView : ContentView
         Grid.SetRow(content, 0);
 
         var actionContainer = CreateActionContainer(_addToVaultButton);
-        layout.Children.Add(actionContainer);
-        Grid.SetRow(actionContainer, 1);
+
+        if (content is IPasswordGeneratorActionHost actionHost && actionHost.TrySetAddToVaultAction(actionContainer))
+        {
+            layout.RowDefinitions.Clear();
+            layout.RowDefinitions.Add(new RowDefinition { Height = GridLength.Star });
+        }
+        else
+        {
+            layout.Children.Add(actionContainer);
+            Grid.SetRow(actionContainer, 1);
+        }
 
         Content = layout;
 

--- a/Password Phrase Producer/Views/VaultPage.xaml
+++ b/Password Phrase Producer/Views/VaultPage.xaml
@@ -30,7 +30,7 @@
                 RowSpacing="12"
                 RowDefinitions="Auto,Auto">
                 <Grid
-                    ColumnDefinitions="Auto,*,Auto,Auto"
+                    ColumnDefinitions="Auto,*,Auto,Auto,Auto"
                     ColumnSpacing="16"
                     VerticalOptions="Start">
                     <Border
@@ -66,19 +66,49 @@
 
                     <Button
                         Grid.Column="2"
-                        Text="＋ Neuer Eintrag"
+                        Text="＋"
                         Clicked="OnAddEntryClicked"
-                        HeightRequest="44"
-                        Padding="18,10"
+                        WidthRequest="52"
+                        HeightRequest="52"
+                        Padding="0"
                         BackgroundColor="#3B4AD1"
                         TextColor="White"
-                        FontAttributes="Bold"
-                        CornerRadius="16"
+                        FontSize="26"
+                        CornerRadius="18"
                         IsVisible="{Binding IsUnlocked}"
-                        SemanticProperties.Hint="Neuen Tresor-Eintrag hinzufügen" />
+                        SemanticProperties.Hint="Neuen Tresor-Eintrag hinzufügen">
+                        <Button.Shadow>
+                            <Shadow Brush="#25000000" Radius="12" Offset="0,8" />
+                        </Button.Shadow>
+                    </Button>
 
                     <Border
                         Grid.Column="3"
+                        WidthRequest="52"
+                        HeightRequest="52"
+                        BackgroundColor="#1F2338"
+                        StrokeThickness="0"
+                        HorizontalOptions="End"
+                        VerticalOptions="Center">
+                        <Border.StrokeShape>
+                            <RoundRectangle CornerRadius="18" />
+                        </Border.StrokeShape>
+                        <Border.Shadow>
+                            <Shadow Brush="#25000000" Radius="12" Offset="0,8" />
+                        </Border.Shadow>
+                        <Border.GestureRecognizers>
+                            <TapGestureRecognizer Tapped="OnVaultActionsTapped" />
+                        </Border.GestureRecognizers>
+                        <Label
+                            Text="⚙"
+                            FontSize="20"
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center"
+                            TextColor="#CFD3FF" />
+                    </Border>
+
+                    <Border
+                        Grid.Column="4"
                         WidthRequest="52"
                         HeightRequest="52"
                         BackgroundColor="#1F2338"
@@ -103,11 +133,11 @@
                     </Border>
                 </Grid>
 
-                <Grid Grid.Row="1" ColumnDefinitions="*,Auto,Auto" ColumnSpacing="12">
+                <Grid Grid.Row="1" ColumnDefinitions="*,Auto" ColumnSpacing="12">
                     <Border
                         BackgroundColor="#1F2338"
                         StrokeThickness="0"
-                        Padding="14,10"
+                        Padding="16,12"
                         HorizontalOptions="Fill"
                         VerticalOptions="Center">
                         <Border.StrokeShape>
@@ -135,35 +165,14 @@
 
                     <Border
                         Grid.Column="1"
-                        BackgroundColor="#1F2338"
+                        WidthRequest="52"
+                        HeightRequest="52"
                         StrokeThickness="0"
-                        Padding="12,8"
-                        HorizontalOptions="End"
-                        VerticalOptions="Center">
-                        <Border.StrokeShape>
-                            <RoundRectangle CornerRadius="20" />
-                        </Border.StrokeShape>
-                        <Border.Shadow>
-                            <Shadow Brush="#1A000000" Radius="12" Offset="0,8" />
-                        </Border.Shadow>
-                        <Picker
-                            ItemsSource="{Binding CategoryFilterOptions}"
-                            SelectedItem="{Binding SelectedCategory}"
-                            Title="Kategorie wählen"
-                            FontSize="14"
-                            TextColor="#E0E4FF"
-                            TitleColor="#7F85B2" />
-                    </Border>
-
-                    <Border
-                        Grid.Column="2"
-                        WidthRequest="48"
-                        HeightRequest="48"
-                        StrokeThickness="0"
-                        Padding="0"
                         BackgroundColor="#1F2338"
                         HorizontalOptions="End"
-                        VerticalOptions="Center">
+                        VerticalOptions="Center"
+                        SemanticProperties.Description="Kategorie auswählen"
+                        SemanticProperties.Hint="{Binding SelectedCategory, StringFormat='Aktive Kategorie: {0}'}">
                         <Border.StrokeShape>
                             <RoundRectangle CornerRadius="18" />
                         </Border.StrokeShape>
@@ -171,14 +180,35 @@
                             <Shadow Brush="#1A000000" Radius="12" Offset="0,8" />
                         </Border.Shadow>
                         <Border.GestureRecognizers>
-                            <TapGestureRecognizer Tapped="OnVaultActionsTapped" />
+                            <TapGestureRecognizer Tapped="OnCategoryFilterTapped" />
                         </Border.GestureRecognizers>
-                        <Label
-                            Text="⚙"
-                            FontSize="20"
-                            HorizontalOptions="Center"
-                            VerticalOptions="Center"
-                            TextColor="#CFD3FF" />
+                        <Grid>
+                            <Label
+                                Text="🗂"
+                                FontSize="22"
+                                HorizontalOptions="Center"
+                                VerticalOptions="Center"
+                                TextColor="#CFD3FF" />
+                            <Border
+                                WidthRequest="10"
+                                HeightRequest="10"
+                                BackgroundColor="#63F5A8"
+                                StrokeThickness="0"
+                                HorizontalOptions="End"
+                                VerticalOptions="Start"
+                                Margin="0,6,6,0">
+                                <Border.StrokeShape>
+                                    <Ellipse />
+                                </Border.StrokeShape>
+                                <Border.Triggers>
+                                    <DataTrigger TargetType="Border"
+                                                 Binding="{Binding SelectedCategory}"
+                                                 Value="Alle Kategorien">
+                                        <Setter Property="IsVisible" Value="False" />
+                                    </DataTrigger>
+                                </Border.Triggers>
+                            </Border>
+                        </Grid>
                     </Border>
                 </Grid>
             </Grid>
@@ -369,12 +399,14 @@
                                     </Label>
                                     <Border
                                         Grid.Column="1"
-                                        Padding="10,4"
+                                        WidthRequest="42"
+                                        HeightRequest="42"
                                         BackgroundColor="#2C3352"
                                         StrokeThickness="0"
-                                        VerticalOptions="Center">
+                                        VerticalOptions="Center"
+                                        SemanticProperties.Description="Passwort anzeigen oder verbergen">
                                         <Border.StrokeShape>
-                                            <RoundRectangle CornerRadius="14" />
+                                            <RoundRectangle CornerRadius="16" />
                                         </Border.StrokeShape>
                                         <Border.GestureRecognizers>
                                             <TapGestureRecognizer
@@ -382,24 +414,28 @@
                                                 CommandParameter="{Binding .}" />
                                         </Border.GestureRecognizers>
                                         <Label
-                                            FontSize="12"
+                                            FontSize="18"
                                             TextColor="#CED4FF"
-                                            Text="Anzeigen">
+                                            HorizontalOptions="Center"
+                                            VerticalOptions="Center"
+                                            Text="👁">
                                             <Label.Triggers>
                                                 <DataTrigger TargetType="Label" Binding="{Binding IsPasswordVisible}" Value="True">
-                                                    <Setter Property="Text" Value="Verbergen" />
+                                                    <Setter Property="Text" Value="🙈" />
                                                 </DataTrigger>
                                             </Label.Triggers>
                                         </Label>
                                     </Border>
                                     <Border
                                         Grid.Column="2"
-                                        Padding="10,4"
+                                        WidthRequest="42"
+                                        HeightRequest="42"
                                         BackgroundColor="#2C3352"
                                         StrokeThickness="0"
-                                        VerticalOptions="Center">
+                                        VerticalOptions="Center"
+                                        SemanticProperties.Description="Passwort kopieren">
                                         <Border.StrokeShape>
-                                            <RoundRectangle CornerRadius="14" />
+                                            <RoundRectangle CornerRadius="16" />
                                         </Border.StrokeShape>
                                         <Border.GestureRecognizers>
                                             <TapGestureRecognizer
@@ -407,9 +443,11 @@
                                                 CommandParameter="{Binding .}" />
                                         </Border.GestureRecognizers>
                                         <Label
-                                            Text="Kopieren"
-                                            FontSize="12"
-                                            TextColor="#CED4FF" />
+                                            Text="📋"
+                                            FontSize="18"
+                                            TextColor="#CED4FF"
+                                            HorizontalOptions="Center"
+                                            VerticalOptions="Center" />
                                     </Border>
                                 </Grid>
                             </Grid>

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/ConcatenationTechniquesUiPage.xaml
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/ConcatenationTechniquesUiPage.xaml
@@ -64,6 +64,8 @@
                 <Button Text="Passphrase erzeugen"
                         Style="{StaticResource PrimaryActionButtonStyle}"
                         Clicked="OnCreateClicked" />
+                <ContentView x:Name="addToVaultHost"
+                             IsVisible="False" />
                 <controls:PasswordAnalysisPanel x:Name="analysisPanel"
                                                  IsVisible="False" />
             </VerticalStackLayout>

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/ConcatenationTechniquesUiPage.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/ConcatenationTechniquesUiPage.xaml.cs
@@ -18,6 +18,7 @@ public partial class ConcatenationTechniquesUiPage : PasswordGeneratorContentVie
     public ConcatenationTechniquesUiPage(IConcatenationTechnique concatenationTechnique, IPasswordEntropyAnalyzer entropyAnalyzer)
     {
         InitializeComponent();
+        RegisterAddToVaultHost(addToVaultHost);
         this.concatenationTechnique = concatenationTechnique;
         this.entropyAnalyzer = entropyAnalyzer;
 

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/DicewareTechniqueUiPage.xaml
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/DicewareTechniqueUiPage.xaml
@@ -60,6 +60,8 @@
                 <Button Text="Passphrase erzeugen"
                         Style="{StaticResource PrimaryActionButtonStyle}"
                         Clicked="OnCreateClicked" />
+                <ContentView x:Name="addToVaultHost"
+                             IsVisible="False" />
                 <controls:PasswordAnalysisPanel x:Name="analysisPanel"
                                                  IsVisible="False" />
             </VerticalStackLayout>

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/DicewareTechniqueUiPage.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/DicewareTechniqueUiPage.xaml.cs
@@ -12,6 +12,7 @@ public partial class DicewareTechniqueUiPage : PasswordGeneratorContentView
     public DicewareTechniqueUiPage(IDicewareTechnique dicewareTechnique, IPasswordEntropyAnalyzer entropyAnalyzer)
     {
         InitializeComponent();
+        RegisterAddToVaultHost(addToVaultHost);
         this.dicewareTechnique = dicewareTechnique;
         this.entropyAnalyzer = entropyAnalyzer;
 

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/HachBasedTechniquesUiPage.xaml
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/HachBasedTechniquesUiPage.xaml
@@ -51,6 +51,8 @@
                 <Button Text="Hash erzeugen"
                         Style="{StaticResource PrimaryActionButtonStyle}"
                         Clicked="OnCreateClicked" />
+                <ContentView x:Name="addToVaultHost"
+                             IsVisible="False" />
                 <controls:PasswordAnalysisPanel x:Name="analysisPanel"
                                                  IsVisible="False" />
             </VerticalStackLayout>

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/HachBasedTechniquesUiPage.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/HachBasedTechniquesUiPage.xaml.cs
@@ -12,6 +12,7 @@ public partial class HachBasedTechniquesUiPage : PasswordGeneratorContentView
     public HachBasedTechniquesUiPage(IHashBasedTechniques hashBasedTechnique, IPasswordEntropyAnalyzer entropyAnalyzer)
     {
         InitializeComponent();
+        RegisterAddToVaultHost(addToVaultHost);
         this.hashBasedTechnique = hashBasedTechnique;
         this.entropyAnalyzer = entropyAnalyzer;
 

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/MirrorTechniqueUiPage.xaml
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/MirrorTechniqueUiPage.xaml
@@ -51,6 +51,8 @@
                 <Button Text="Passwort spiegeln"
                         Style="{StaticResource PrimaryActionButtonStyle}"
                         Clicked="OnCreateClicked" />
+                <ContentView x:Name="addToVaultHost"
+                             IsVisible="False" />
                 <controls:PasswordAnalysisPanel x:Name="analysisPanel"
                                                  IsVisible="False" />
             </VerticalStackLayout>

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/MirrorTechniqueUiPage.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/MirrorTechniqueUiPage.xaml.cs
@@ -12,6 +12,7 @@ public partial class MirrorTechniqueUiPage : PasswordGeneratorContentView
     public MirrorTechniqueUiPage(IMirrorLockTechnique mirrorTechnique, IPasswordEntropyAnalyzer entropyAnalyzer)
     {
         InitializeComponent();
+        RegisterAddToVaultHost(addToVaultHost);
         this.mirrorTechnique = mirrorTechnique;
         this.entropyAnalyzer = entropyAnalyzer;
 

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/PasswordGeneratorContentView.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/PasswordGeneratorContentView.cs
@@ -4,9 +4,10 @@ using Password_Phrase_Producer.Views;
 
 namespace Password_Phrase_Producer.Windows.PasswordGenerationWindows;
 
-public abstract class PasswordGeneratorContentView : ContentView, IPasswordResultProvider
+public abstract class PasswordGeneratorContentView : ContentView, IPasswordResultProvider, IPasswordGeneratorActionHost
 {
     private string? _lastGeneratedPassword;
+    private ContentView? _addToVaultHost;
 
     public event EventHandler<string>? PasswordGenerated;
 
@@ -16,6 +17,27 @@ public abstract class PasswordGeneratorContentView : ContentView, IPasswordResul
     {
         get => _lastGeneratedPassword;
         private set => _lastGeneratedPassword = value;
+    }
+
+    protected void RegisterAddToVaultHost(ContentView host)
+    {
+        _addToVaultHost = host;
+        _addToVaultHost.IsVisible = false;
+    }
+
+    bool IPasswordGeneratorActionHost.TrySetAddToVaultAction(View actionView)
+    {
+        if (_addToVaultHost is null)
+        {
+            return false;
+        }
+
+        actionView.HorizontalOptions = LayoutOptions.Fill;
+        actionView.VerticalOptions = LayoutOptions.Center;
+
+        _addToVaultHost.Content = actionView;
+        _addToVaultHost.IsVisible = true;
+        return true;
     }
 
     protected void UpdateGeneratedPassword(string? password)

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/PatternCascadeTechniqueUiPage.xaml
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/PatternCascadeTechniqueUiPage.xaml
@@ -58,6 +58,8 @@
                 <Button Text="Passwort erzeugen"
                         Style="{StaticResource PrimaryActionButtonStyle}"
                         Clicked="OnCreateClicked" />
+                <ContentView x:Name="addToVaultHost"
+                             IsVisible="False" />
                 <controls:PasswordAnalysisPanel x:Name="analysisPanel"
                                                  IsVisible="False" />
             </VerticalStackLayout>

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/PatternCascadeTechniqueUiPage.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/PatternCascadeTechniqueUiPage.xaml.cs
@@ -12,6 +12,7 @@ public partial class PatternCascadeTechniqueUiPage : PasswordGeneratorContentVie
     public PatternCascadeTechniqueUiPage(IPatternCascadeTechnique patternCascadeTechnique, IPasswordEntropyAnalyzer entropyAnalyzer)
     {
         InitializeComponent();
+        RegisterAddToVaultHost(addToVaultHost);
         this.patternCascadeTechnique = patternCascadeTechnique;
         this.entropyAnalyzer = entropyAnalyzer;
 

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/SegmentRotationTechniqueUiPage.xaml
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/SegmentRotationTechniqueUiPage.xaml
@@ -60,6 +60,8 @@
                 <Button Text="Passwort erzeugen"
                         Style="{StaticResource PrimaryActionButtonStyle}"
                         Clicked="OnCreateClicked" />
+                <ContentView x:Name="addToVaultHost"
+                             IsVisible="False" />
                 <controls:PasswordAnalysisPanel x:Name="analysisPanel"
                                                  IsVisible="False" />
             </VerticalStackLayout>

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/SegmentRotationTechniqueUiPage.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/SegmentRotationTechniqueUiPage.xaml.cs
@@ -12,6 +12,7 @@ public partial class SegmentRotationTechniqueUiPage : PasswordGeneratorContentVi
     public SegmentRotationTechniqueUiPage(ISegmentRotationTechnique rotationTechnique, IPasswordEntropyAnalyzer entropyAnalyzer)
     {
         InitializeComponent();
+        RegisterAddToVaultHost(addToVaultHost);
         this.rotationTechnique = rotationTechnique;
         this.entropyAnalyzer = entropyAnalyzer;
 

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/SymbolInjectionTechniqueUiPage.xaml
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/SymbolInjectionTechniqueUiPage.xaml
@@ -71,6 +71,8 @@
                 <Button Text="Passwort erzeugen"
                         Style="{StaticResource PrimaryActionButtonStyle}"
                         Clicked="OnCreateClicked" />
+                <ContentView x:Name="addToVaultHost"
+                             IsVisible="False" />
                 <controls:PasswordAnalysisPanel x:Name="analysisPanel"
                                                  IsVisible="False" />
             </VerticalStackLayout>

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/SymbolInjectionTechniqueUiPage.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/SymbolInjectionTechniqueUiPage.xaml.cs
@@ -12,6 +12,7 @@ public partial class SymbolInjectionTechniqueUiPage : PasswordGeneratorContentVi
     public SymbolInjectionTechniqueUiPage(ISymbolInjectionTechnique symbolInjectionTechnique, IPasswordEntropyAnalyzer entropyAnalyzer)
     {
         InitializeComponent();
+        RegisterAddToVaultHost(addToVaultHost);
         this.symbolInjectionTechnique = symbolInjectionTechnique;
         this.entropyAnalyzer = entropyAnalyzer;
 

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/TbvUiPage.xaml
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/TbvUiPage.xaml
@@ -69,6 +69,8 @@
                 <Button Text="TBV generieren"
                         Style="{StaticResource PrimaryActionButtonStyle}"
                         Clicked="OnCreateClicked" />
+                <ContentView x:Name="addToVaultHost"
+                             IsVisible="False" />
                 <controls:PasswordAnalysisPanel x:Name="analysisPanel"
                                                  IsVisible="False" />
             </VerticalStackLayout>

--- a/Password Phrase Producer/Windows/PasswordGenerationWindows/TbvUiPage.xaml.cs
+++ b/Password Phrase Producer/Windows/PasswordGenerationWindows/TbvUiPage.xaml.cs
@@ -12,6 +12,7 @@ public partial class TbvUiPage : PasswordGeneratorContentView
     public TbvUiPage(Itbv itbv, IPasswordEntropyAnalyzer entropyAnalyzer)
     {
         InitializeComponent();
+        RegisterAddToVaultHost(addToVaultHost);
         tbv = itbv;
         this.entropyAnalyzer = entropyAnalyzer;
 


### PR DESCRIPTION
## Summary
- embed the "add to vault" action inside password generator views through a reusable action-host interface and placeholders
- introduce styled popup components for action sheets and confirmations and switch vault actions, category picking, and deletions to them
- refresh the vault header and password cards with icon-sized controls to improve layout on small screens

## Testing
- ⚠️ `dotnet build` *(fails: `dotnet` CLI is not available in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69118df14030832aa657e734d8a3e5dd)