### PR TITLE
Remove obsolete light dismiss override

### DIFF
--- a/Password Phrase Producer/Views/Dialogs/ActionSheetPopup.cs
+++ b/Password Phrase Producer/Views/Dialogs/ActionSheetPopup.cs
@@ -189,13 +189,4 @@ public sealed class ActionSheetPopup : Popup
         return cancelBorder;
     }
 
-    protected override void OnLightDismissed()
-    {
-        base.OnLightDismissed();
-
-        if (_cancelText is not null)
-        {
-            Close(null);
-        }
-    }
 }


### PR DESCRIPTION
## Summary
- remove the OnLightDismissed override from ActionSheetPopup because the base method no longer exists
- rely on the popup's default light-dismiss behavior

## Testing
- `dotnet build 'Password Phrase Producer/Password Phrase Producer.sln' -c Release -f net9.0-android` *(fails: dotnet CLI not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691192a1e154832ab92e010daaecf2b7)