### PR TITLE
Update popups for .NET 9 compatibility

### DIFF
--- a/Password Phrase Producer/Views/Dialogs/ActionSheetPopup.cs
+++ b/Password Phrase Producer/Views/Dialogs/ActionSheetPopup.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using CommunityToolkit.Maui.Views;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Shapes;
 using Microsoft.Maui.Graphics;
 
 namespace Password_Phrase_Producer.Views.Dialogs;
@@ -25,8 +26,8 @@ public sealed class ActionSheetPopup : Popup
 
         _cancelText = cancelText;
 
-        BackgroundColor = Color.FromRgba(0, 0, 0, 0.65);
-        CanBeDismissedByTappingOutside = cancelText is not null;
+        Color = Color.FromRgba(0, 0, 0, 0.65);
+        CanBeDismissedByTappingOutsideOfPopup = cancelText is not null;
 
         var contentStack = new VerticalStackLayout
         {
@@ -123,13 +124,16 @@ public sealed class ActionSheetPopup : Popup
 
         if (!string.IsNullOrWhiteSpace(option.Description))
         {
-            optionLayout.Children.Add(new Label
+            var descriptionLabel = new Label
             {
                 Text = option.Description,
                 FontSize = 13,
                 TextColor = Color.FromArgb("#9EA3C4"),
                 LineBreakMode = LineBreakMode.WordWrap
-            }, 0, 1);
+            };
+            Grid.SetColumn(descriptionLabel, 0);
+            Grid.SetRow(descriptionLabel, 1);
+            optionLayout.Children.Add(descriptionLabel);
         }
 
         if (option.IsSelected)
@@ -142,7 +146,9 @@ public sealed class ActionSheetPopup : Popup
                 HorizontalOptions = LayoutOptions.End,
                 VerticalOptions = LayoutOptions.Start
             };
-            optionLayout.Children.Add(checkLabel, 1, 0);
+            Grid.SetColumn(checkLabel, 1);
+            Grid.SetRow(checkLabel, 0);
+            optionLayout.Children.Add(checkLabel);
             Grid.SetRowSpan(checkLabel, string.IsNullOrWhiteSpace(option.Description) ? 1 : 2);
         }
 

--- a/Password Phrase Producer/Views/Dialogs/ConfirmationPopup.cs
+++ b/Password Phrase Producer/Views/Dialogs/ConfirmationPopup.cs
@@ -1,6 +1,7 @@
 using System;
 using CommunityToolkit.Maui.Views;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Shapes;
 using Microsoft.Maui.Graphics;
 
 namespace Password_Phrase_Producer.Views.Dialogs;
@@ -9,8 +10,8 @@ public sealed class ConfirmationPopup : Popup
 {
     public ConfirmationPopup(string title, string message, string confirmText, string cancelText, bool confirmIsDestructive = false)
     {
-        BackgroundColor = Color.FromRgba(0, 0, 0, 0.65);
-        CanBeDismissedByTappingOutside = false;
+        Color = Color.FromRgba(0, 0, 0, 0.65);
+        CanBeDismissedByTappingOutsideOfPopup = false;
 
         var titleLabel = new Label
         {
@@ -43,7 +44,9 @@ public sealed class ConfirmationPopup : Popup
 
         var confirmColor = confirmIsDestructive ? Color.FromArgb("#432028") : Color.FromArgb("#2C3A73");
         var confirmButton = CreateActionButton(confirmText, confirmColor, () => Close(true));
-        buttonGrid.Children.Add(confirmButton, 1, 0);
+        Grid.SetColumn(confirmButton, 1);
+        Grid.SetRow(confirmButton, 0);
+        buttonGrid.Children.Add(confirmButton);
 
         var cardLayout = new VerticalStackLayout
         {

--- a/Password Phrase Producer/Views/VaultPage.xaml.cs
+++ b/Password Phrase Producer/Views/VaultPage.xaml.cs
@@ -425,7 +425,7 @@ public partial class VaultPage : ContentPage
         foreach (var category in _viewModel.CategoryFilterOptions)
         {
             var isSelected = string.Equals(category, _viewModel.SelectedCategory, StringComparison.CurrentCultureIgnoreCase);
-            options.Add(new ActionSheetPopupOption(category, category, isSelected: isSelected));
+            options.Add(new ActionSheetPopupOption(category, category, IsSelected: isSelected));
         }
 
         var popup = new ActionSheetPopup("Kategorie wählen", options, cancelText: "Abbrechen");


### PR DESCRIPTION
## Summary
- replace deprecated popup properties with their .NET 9 equivalents
- adjust grid population to avoid removed overloads and add required shape namespace
- fix ActionSheetPopupOption invocation to match constructor parameter casing

## Testing
- not run (dotnet CLI not available in container)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911958e4ee8832a88ac6f0436ba04f8)