### PR TITLE
Add Google Drive vault sync provider

### DIFF
--- a/Password Phrase Producer/MauiProgram.cs
+++ b/Password Phrase Producer/MauiProgram.cs
@@ -2,6 +2,7 @@ using CommunityToolkit.Maui;
 using Microsoft.Extensions.Logging;
 using Password_Phrase_Producer.Services.Security;
 using Password_Phrase_Producer.Services.Vault;
+using Password_Phrase_Producer.Services.Vault.Sync;
 using Password_Phrase_Producer.ViewModels;
 using Password_Phrase_Producer.Views;
 
@@ -25,6 +26,16 @@ public static class MauiProgram
         builder.Logging.AddDebug();
 #endif
 
+        builder.Services.AddSingleton<IVaultSyncProvider, FileSystemVaultSyncProvider>();
+        builder.Services.AddSingleton<IVaultSyncProvider, S3VaultSyncProvider>();
+        builder.Services.AddSingleton<IVaultSyncProvider, GoogleDriveVaultSyncProvider>();
+#if ANDROID
+        builder.Services.AddSingleton<IVaultSyncScheduler, Password_Phrase_Producer.Platforms.Android.VaultSyncScheduler>();
+#elif WINDOWS
+        builder.Services.AddSingleton<IVaultSyncScheduler, Password_Phrase_Producer.Platforms.Windows.VaultSyncScheduler>();
+#else
+        builder.Services.AddSingleton<IVaultSyncScheduler, NoOpVaultSyncScheduler>();
+#endif
         builder.Services.AddSingleton<PasswordVaultService>();
         builder.Services.AddSingleton<IBiometricAuthenticationService, BiometricAuthenticationService>();
         builder.Services.AddTransient<VaultPageViewModel>();

--- a/Password Phrase Producer/PasswordPhraseProducer.csproj
+++ b/Password Phrase Producer/PasswordPhraseProducer.csproj
@@ -80,6 +80,7 @@
                 <PackageReference Include="CommunityToolkit.Maui" Version="8.0.0" />
                 <PackageReference Include="Plugin.Maui.Biometric" Version="0.0.7" />
                 <PackageReference Include="Xamarin.AndroidX.Biometric" Version="1.1.0.28" Condition="'$(TargetFramework)' == 'net9.0-android'" />
+                <PackageReference Include="AWSSDK.S3" Version="3.7.200.6" />
         </ItemGroup>
 
 	<ItemGroup>

--- a/Password Phrase Producer/Platforms/Android/VaultSyncScheduler.cs
+++ b/Password Phrase Producer/Platforms/Android/VaultSyncScheduler.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Password_Phrase_Producer.Services.Vault.Sync;
+
+namespace Password_Phrase_Producer.Platforms.Android;
+
+public sealed class VaultSyncScheduler : IVaultSyncScheduler, IDisposable
+{
+    private readonly ILogger<VaultSyncScheduler> _logger;
+    private Timer? _timer;
+    private Func<CancellationToken, Task>? _callback;
+    private int _isRunning;
+
+    public VaultSyncScheduler(ILogger<VaultSyncScheduler> logger)
+    {
+        _logger = logger;
+    }
+
+    public void Schedule(TimeSpan interval, Func<CancellationToken, Task> callback)
+    {
+        Cancel();
+        _callback = callback ?? throw new ArgumentNullException(nameof(callback));
+        _timer = new Timer(OnTimerTick, null, TimeSpan.Zero, interval);
+    }
+
+    public void Cancel()
+    {
+        Interlocked.Exchange(ref _isRunning, 0);
+        _timer?.Dispose();
+        _timer = null;
+        _callback = null;
+    }
+
+    public void Dispose()
+        => Cancel();
+
+    private void OnTimerTick(object? state)
+    {
+        if (_callback is null)
+        {
+            return;
+        }
+
+        if (Interlocked.Exchange(ref _isRunning, 1) == 1)
+        {
+            return;
+        }
+
+        _ = ExecuteAsync();
+    }
+
+    private async Task ExecuteAsync()
+    {
+        try
+        {
+            var callback = _callback;
+            if (callback is null)
+            {
+                return;
+            }
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+            await callback(cts.Token).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Fehler beim Ausführen der Hintergrundsynchronisation.");
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _isRunning, 0);
+        }
+    }
+}

--- a/Password Phrase Producer/Platforms/Windows/VaultSyncScheduler.cs
+++ b/Password Phrase Producer/Platforms/Windows/VaultSyncScheduler.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.UI.Dispatching;
+using Password_Phrase_Producer.Services.Vault.Sync;
+
+namespace Password_Phrase_Producer.Platforms.Windows;
+
+public sealed class VaultSyncScheduler : IVaultSyncScheduler
+{
+    private readonly DispatcherQueue _dispatcherQueue;
+    private readonly ILogger<VaultSyncScheduler> _logger;
+    private DispatcherQueueTimer? _timer;
+    private Func<CancellationToken, Task>? _callback;
+    private bool _isRunning;
+
+    public VaultSyncScheduler(ILogger<VaultSyncScheduler> logger)
+    {
+        _dispatcherQueue = DispatcherQueue.GetForCurrentThread() ?? throw new InvalidOperationException("Es konnte keine DispatcherQueue initialisiert werden.");
+        _logger = logger;
+    }
+
+    public void Schedule(TimeSpan interval, Func<CancellationToken, Task> callback)
+    {
+        Cancel();
+        _callback = callback ?? throw new ArgumentNullException(nameof(callback));
+        _timer = _dispatcherQueue.CreateTimer();
+        _timer.Interval = interval;
+        _timer.IsRepeating = true;
+        _timer.Tick += OnTimerTick;
+        _timer.Start();
+    }
+
+    public void Cancel()
+    {
+        if (_timer is null)
+        {
+            _callback = null;
+            _isRunning = false;
+            return;
+        }
+
+        _timer.Tick -= OnTimerTick;
+        _timer.Stop();
+        _timer = null;
+        _callback = null;
+        _isRunning = false;
+    }
+
+    private void OnTimerTick(DispatcherQueueTimer sender, object args)
+    {
+        if (_callback is null || _isRunning)
+        {
+            return;
+        }
+
+        _isRunning = true;
+        _ = ExecuteAsync();
+    }
+
+    private async Task ExecuteAsync()
+    {
+        try
+        {
+            var callback = _callback;
+            if (callback is null)
+            {
+                return;
+            }
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+            await callback(cts.Token).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Fehler beim Ausführen der Hintergrundsynchronisation.");
+        }
+        finally
+        {
+            _isRunning = false;
+        }
+    }
+}

--- a/Password Phrase Producer/Services/Vault/Sync/FileSystemVaultSyncProvider.cs
+++ b/Password Phrase Producer/Services/Vault/Sync/FileSystemVaultSyncProvider.cs
@@ -1,0 +1,106 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Password_Phrase_Producer.Services.Vault.Sync;
+
+public sealed class FileSystemVaultSyncProvider : IVaultSyncProvider
+{
+    public const string ProviderKey = "FileSystem";
+    public const string PathParameterKey = "path";
+
+    public string Key => ProviderKey;
+
+    public string DisplayName => "Gemeinsames Laufwerk / Ordner";
+
+    public bool SupportsAutomaticSync => true;
+
+    public Task<bool> IsConfiguredAsync(VaultSyncConfiguration configuration, CancellationToken cancellationToken = default)
+    {
+        if (configuration.Parameters.TryGetValue(PathParameterKey, out var path) && !string.IsNullOrWhiteSpace(path))
+        {
+            return Task.FromResult(true);
+        }
+
+        return Task.FromResult(false);
+    }
+
+    public async Task<VaultSyncRemoteState?> GetRemoteStateAsync(VaultSyncConfiguration configuration, CancellationToken cancellationToken = default)
+    {
+        var path = GetTargetPath(configuration);
+        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+        {
+            return null;
+        }
+
+        var info = new FileInfo(path);
+        var payload = await File.ReadAllBytesAsync(path, cancellationToken).ConfigureAwait(false);
+        return new VaultSyncRemoteState
+        {
+            LastModifiedUtc = info.LastWriteTimeUtc,
+            ContentLength = payload.LongLength,
+            MerkleHash = PasswordVaultService.ComputeMerkleRoot(payload),
+            EntityTag = info.LastWriteTimeUtc.ToFileTimeUtc().ToString()
+        };
+    }
+
+    public async Task<VaultSyncDownloadResult?> DownloadAsync(VaultSyncConfiguration configuration, CancellationToken cancellationToken = default)
+    {
+        var path = GetTargetPath(configuration);
+        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+        {
+            return null;
+        }
+
+        var payload = await File.ReadAllBytesAsync(path, cancellationToken).ConfigureAwait(false);
+        var info = new FileInfo(path);
+
+        return new VaultSyncDownloadResult
+        {
+            Payload = payload,
+            RemoteState = new VaultSyncRemoteState
+            {
+                LastModifiedUtc = info.LastWriteTimeUtc,
+                ContentLength = payload.LongLength,
+                MerkleHash = PasswordVaultService.ComputeMerkleRoot(payload),
+                EntityTag = info.LastWriteTimeUtc.ToFileTimeUtc().ToString()
+            }
+        };
+    }
+
+    public async Task UploadAsync(VaultSyncUploadRequest request, VaultSyncConfiguration configuration, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var path = GetTargetPath(configuration);
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            throw new InvalidOperationException("Es wurde kein Zielpfad für die Dateisynchronisation angegeben.");
+        }
+
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+
+        if (File.Exists(path) && request.RemoteStateBeforeUpload is not null)
+        {
+            var existingPayload = await File.ReadAllBytesAsync(path, cancellationToken).ConfigureAwait(false);
+            var existingHash = PasswordVaultService.ComputeMerkleRoot(existingPayload);
+            if (!string.Equals(existingHash, request.RemoteStateBeforeUpload.MerkleHash, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException("Der entfernte Tresor wurde seit der letzten Prüfung geändert.");
+            }
+        }
+
+        await File.WriteAllBytesAsync(path, request.Payload, cancellationToken).ConfigureAwait(false);
+        File.SetLastWriteTimeUtc(path, request.LocalState.LastModifiedUtc.UtcDateTime);
+    }
+
+    private static string? GetTargetPath(VaultSyncConfiguration configuration)
+    {
+        if (configuration.Parameters.TryGetValue(PathParameterKey, out var path))
+        {
+            return path?.Trim();
+        }
+
+        return null;
+    }
+}

--- a/Password Phrase Producer/Services/Vault/Sync/GoogleDriveVaultSyncProvider.cs
+++ b/Password Phrase Producer/Services/Vault/Sync/GoogleDriveVaultSyncProvider.cs
@@ -1,0 +1,419 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Password_Phrase_Producer.Services.Vault.Sync;
+
+public sealed class GoogleDriveVaultSyncProvider : IVaultSyncProvider
+{
+    public const string ProviderKey = "GoogleDrive";
+    public const string ClientIdParameterKey = "clientId";
+    public const string ClientSecretParameterKey = "clientSecret";
+    public const string RefreshTokenParameterKey = "refreshToken";
+    public const string FileIdParameterKey = "fileId";
+    public const string FileNameParameterKey = "fileName";
+    public const string FolderIdParameterKey = "folderId";
+
+    private const string MerklePropertyKey = "vaultMerkleHash";
+    private const string DefaultFileName = "vault.json.enc";
+    private static readonly Uri TokenEndpoint = new("https://oauth2.googleapis.com/token");
+    private static readonly Uri DriveApiBaseUri = new("https://www.googleapis.com/drive/v3/");
+    private static readonly Uri DriveUploadBaseUri = new("https://www.googleapis.com/upload/drive/v3/");
+    private static readonly HttpClient SharedHttpClient = new()
+    {
+        Timeout = TimeSpan.FromSeconds(100)
+    };
+
+    private readonly HttpClient _httpClient;
+    private readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    public GoogleDriveVaultSyncProvider(HttpClient? httpClient = null)
+    {
+        _httpClient = httpClient ?? SharedHttpClient;
+    }
+
+    public string Key => ProviderKey;
+
+    public string DisplayName => "Google Drive";
+
+    public bool SupportsAutomaticSync => true;
+
+    public Task<bool> IsConfiguredAsync(VaultSyncConfiguration configuration, CancellationToken cancellationToken = default)
+    {
+        var hasCoreParameters = configuration.Parameters.TryGetValue(ClientIdParameterKey, out var clientId) && !string.IsNullOrWhiteSpace(clientId)
+            && configuration.Parameters.TryGetValue(ClientSecretParameterKey, out var clientSecret) && !string.IsNullOrWhiteSpace(clientSecret)
+            && configuration.Parameters.TryGetValue(RefreshTokenParameterKey, out var refreshToken) && !string.IsNullOrWhiteSpace(refreshToken);
+
+        if (!hasCoreParameters)
+        {
+            return Task.FromResult(false);
+        }
+
+        if (configuration.Parameters.TryGetValue(FileIdParameterKey, out var fileId) && !string.IsNullOrWhiteSpace(fileId))
+        {
+            return Task.FromResult(true);
+        }
+
+        if (configuration.Parameters.TryGetValue(FileNameParameterKey, out var fileName) && !string.IsNullOrWhiteSpace(fileName))
+        {
+            return Task.FromResult(true);
+        }
+
+        return Task.FromResult(false);
+    }
+
+    public async Task<VaultSyncRemoteState?> GetRemoteStateAsync(VaultSyncConfiguration configuration, CancellationToken cancellationToken = default)
+    {
+        if (!await IsConfiguredAsync(configuration, cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        var accessToken = await AcquireAccessTokenAsync(configuration, cancellationToken).ConfigureAwait(false);
+        var file = await ResolveFileAsync(configuration, accessToken, cancellationToken).ConfigureAwait(false);
+        if (file is null)
+        {
+            return null;
+        }
+
+        return CreateRemoteState(file);
+    }
+
+    public async Task<VaultSyncDownloadResult?> DownloadAsync(VaultSyncConfiguration configuration, CancellationToken cancellationToken = default)
+    {
+        if (!await IsConfiguredAsync(configuration, cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        var accessToken = await AcquireAccessTokenAsync(configuration, cancellationToken).ConfigureAwait(false);
+        var file = await ResolveFileAsync(configuration, accessToken, cancellationToken).ConfigureAwait(false);
+        if (file is null || string.IsNullOrWhiteSpace(file.Id))
+        {
+            return null;
+        }
+
+        var payload = await DownloadFileAsync(file.Id, accessToken, cancellationToken).ConfigureAwait(false);
+        return new VaultSyncDownloadResult
+        {
+            Payload = payload,
+            RemoteState = CreateRemoteState(file)
+        };
+    }
+
+    public async Task UploadAsync(VaultSyncUploadRequest request, VaultSyncConfiguration configuration, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (!await IsConfiguredAsync(configuration, cancellationToken).ConfigureAwait(false))
+        {
+            throw new InvalidOperationException("Die Google-Drive-Synchronisation ist nicht vollständig konfiguriert.");
+        }
+
+        var accessToken = await AcquireAccessTokenAsync(configuration, cancellationToken).ConfigureAwait(false);
+        var file = await ResolveFileAsync(configuration, accessToken, cancellationToken).ConfigureAwait(false);
+
+        if (file is not null && request.RemoteStateBeforeUpload is not null)
+        {
+            var remoteHash = file.AppProperties is not null && file.AppProperties.TryGetValue(MerklePropertyKey, out var merkle)
+                ? merkle
+                : string.Empty;
+            if (!string.Equals(remoteHash, request.RemoteStateBeforeUpload.MerkleHash, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException("Der entfernte Tresor wurde seit der letzten Synchronisation verändert.");
+            }
+        }
+
+        if (file is null || string.IsNullOrWhiteSpace(file.Id))
+        {
+            await CreateFileAsync(request, configuration, accessToken, cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            await UpdateFileAsync(file.Id, request, configuration, accessToken, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static VaultSyncRemoteState CreateRemoteState(DriveFileMetadata file)
+    {
+        var lastModified = file.ModifiedTimeRaw is null
+            ? DateTimeOffset.UtcNow
+            : DateTimeOffset.Parse(file.ModifiedTimeRaw, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
+
+        var merkleHash = file.AppProperties is not null && file.AppProperties.TryGetValue(MerklePropertyKey, out var merkle)
+            ? merkle
+            : string.Empty;
+
+        var contentLength = 0L;
+        if (file.SizeRaw is not null && long.TryParse(file.SizeRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedSize))
+        {
+            contentLength = parsedSize;
+        }
+
+        return new VaultSyncRemoteState
+        {
+            LastModifiedUtc = lastModified,
+            MerkleHash = merkleHash,
+            ContentLength = contentLength,
+            EntityTag = file.HeadRevisionId
+        };
+    }
+
+    private async Task<string> AcquireAccessTokenAsync(VaultSyncConfiguration configuration, CancellationToken cancellationToken)
+    {
+        var parameters = new Dictionary<string, string>
+        {
+            ["client_id"] = configuration.Parameters[ClientIdParameterKey],
+            ["client_secret"] = configuration.Parameters[ClientSecretParameterKey],
+            ["refresh_token"] = configuration.Parameters[RefreshTokenParameterKey],
+            ["grant_type"] = "refresh_token"
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, TokenEndpoint)
+        {
+            Content = new FormUrlEncodedContent(parameters)
+        };
+
+        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            var error = JsonSerializer.Deserialize<TokenErrorResponse>(content, _jsonOptions);
+            var message = error?.ErrorDescription ?? error?.Error ?? response.ReasonPhrase ?? "Unbekannter Fehler beim Abrufen des Tokens.";
+            throw new InvalidOperationException($"Google Drive Zugriffstoken konnte nicht aktualisiert werden: {message}");
+        }
+
+        var token = JsonSerializer.Deserialize<TokenSuccessResponse>(content, _jsonOptions);
+        if (token is null || string.IsNullOrWhiteSpace(token.AccessToken))
+        {
+            throw new InvalidOperationException("Google Drive hat kein gültiges Zugriffstoken zurückgegeben.");
+        }
+
+        return token.AccessToken;
+    }
+
+    private async Task<DriveFileMetadata?> ResolveFileAsync(VaultSyncConfiguration configuration, string accessToken, CancellationToken cancellationToken)
+    {
+        var fileId = GetOptionalParameter(configuration, FileIdParameterKey);
+        if (!string.IsNullOrWhiteSpace(fileId))
+        {
+            var metadata = await GetFileByIdAsync(fileId!, accessToken, cancellationToken).ConfigureAwait(false);
+            if (metadata is not null)
+            {
+                return metadata;
+            }
+        }
+
+        var fileName = GetFileName(configuration);
+        var folderId = GetOptionalParameter(configuration, FolderIdParameterKey);
+        return await FindFileByNameAsync(fileName, folderId, accessToken, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<DriveFileMetadata?> GetFileByIdAsync(string fileId, string accessToken, CancellationToken cancellationToken)
+    {
+        var requestUri = new Uri(DriveApiBaseUri, $"files/{Uri.EscapeDataString(fileId)}?fields=id,name,modifiedTime,size,headRevisionId,appProperties&supportsAllDrives=true");
+        using var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+
+        response.EnsureSuccessStatusCode();
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        var metadata = await JsonSerializer.DeserializeAsync<DriveFileMetadata>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+        return metadata;
+    }
+
+    private async Task<DriveFileMetadata?> FindFileByNameAsync(string fileName, string? folderId, string accessToken, CancellationToken cancellationToken)
+    {
+        var sanitizedName = fileName.Replace("'", "\\'");
+        var queryBuilder = new StringBuilder();
+        queryBuilder.Append($"name = '{sanitizedName}' and trashed = false");
+        if (!string.IsNullOrWhiteSpace(folderId))
+        {
+            var sanitizedFolderId = folderId.Replace("'", "\\'");
+            queryBuilder.Append($" and '{sanitizedFolderId}' in parents");
+        }
+
+        var requestUri = new Uri(DriveApiBaseUri, $"files?q={Uri.EscapeDataString(queryBuilder.ToString())}&fields=files(id,name,modifiedTime,size,headRevisionId,appProperties)&pageSize=1&supportsAllDrives=true&includeItemsFromAllDrives=true");
+        using var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        var list = await JsonSerializer.DeserializeAsync<DriveFileListResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+        return list?.Files is { Count: > 0 } ? list.Files[0] : null;
+    }
+
+    private async Task<byte[]> DownloadFileAsync(string fileId, string accessToken, CancellationToken cancellationToken)
+    {
+        var requestUri = new Uri(DriveApiBaseUri, $"files/{Uri.EscapeDataString(fileId)}?alt=media&supportsAllDrives=true");
+        using var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+        using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task CreateFileAsync(VaultSyncUploadRequest request, VaultSyncConfiguration configuration, string accessToken, CancellationToken cancellationToken)
+    {
+        var metadata = BuildMetadata(configuration, request.LocalState.MerkleHash, includeParents: true);
+        var uriBuilder = new StringBuilder("files?uploadType=multipart&supportsAllDrives=true");
+        var requestUri = new Uri(DriveUploadBaseUri, uriBuilder.ToString());
+
+        using var content = CreateMultipartContent(metadata, request.Payload);
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Post, requestUri)
+        {
+            Content = content
+        };
+        httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+        using var response = await _httpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+    }
+
+    private async Task UpdateFileAsync(string fileId, VaultSyncUploadRequest request, VaultSyncConfiguration configuration, string accessToken, CancellationToken cancellationToken)
+    {
+        var metadata = BuildMetadata(configuration, request.LocalState.MerkleHash, includeParents: false);
+        var requestUri = new Uri(DriveUploadBaseUri, $"files/{Uri.EscapeDataString(fileId)}?uploadType=multipart&supportsAllDrives=true");
+
+        using var content = CreateMultipartContent(metadata, request.Payload);
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Patch, requestUri)
+        {
+            Content = content
+        };
+        httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+        using var response = await _httpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+    }
+
+    private static MultipartContent CreateMultipartContent(GoogleDriveFileMetadata metadata, byte[] payload)
+    {
+        var multipart = new MultipartContent("related");
+        var metadataJson = JsonSerializer.Serialize(metadata);
+        var metadataContent = new StringContent(metadataJson, Encoding.UTF8, "application/json");
+        multipart.Add(metadataContent);
+
+        var fileContent = new ByteArrayContent(payload);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        multipart.Add(fileContent);
+
+        return multipart;
+    }
+
+    private static GoogleDriveFileMetadata BuildMetadata(VaultSyncConfiguration configuration, string merkleHash, bool includeParents)
+    {
+        var metadata = new GoogleDriveFileMetadata
+        {
+            Name = GetFileName(configuration),
+            AppProperties = new Dictionary<string, string>
+            {
+                [MerklePropertyKey] = merkleHash
+            }
+        };
+
+        if (includeParents)
+        {
+            var folderId = GetOptionalParameter(configuration, FolderIdParameterKey);
+            if (!string.IsNullOrWhiteSpace(folderId))
+            {
+                metadata.Parents = new List<string> { folderId! };
+            }
+        }
+
+        return metadata;
+    }
+
+    private static string GetFileName(VaultSyncConfiguration configuration)
+    {
+        if (configuration.Parameters.TryGetValue(FileNameParameterKey, out var fileName) && !string.IsNullOrWhiteSpace(fileName))
+        {
+            return fileName.Trim();
+        }
+
+        return DefaultFileName;
+    }
+
+    private static string? GetOptionalParameter(VaultSyncConfiguration configuration, string key)
+    {
+        if (configuration.Parameters.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value))
+        {
+            return value.Trim();
+        }
+
+        return null;
+    }
+
+    private sealed class TokenSuccessResponse
+    {
+        [JsonPropertyName("access_token")]
+        public string AccessToken { get; set; } = string.Empty;
+    }
+
+    private sealed class TokenErrorResponse
+    {
+        [JsonPropertyName("error")]
+        public string? Error { get; set; }
+
+        [JsonPropertyName("error_description")]
+        public string? ErrorDescription { get; set; }
+    }
+
+    private sealed class DriveFileMetadata
+    {
+        [JsonPropertyName("id")]
+        public string? Id { get; set; }
+
+        [JsonPropertyName("name")]
+        public string? Name { get; set; }
+
+        [JsonPropertyName("modifiedTime")]
+        public string? ModifiedTimeRaw { get; set; }
+
+        [JsonPropertyName("size")]
+        public string? SizeRaw { get; set; }
+
+        [JsonPropertyName("headRevisionId")]
+        public string? HeadRevisionId { get; set; }
+
+        [JsonPropertyName("appProperties")]
+        public Dictionary<string, string>? AppProperties { get; set; }
+
+        [JsonPropertyName("parents")]
+        public List<string>? Parents { get; set; }
+    }
+
+    private sealed class DriveFileListResponse
+    {
+        [JsonPropertyName("files")]
+        public List<DriveFileMetadata> Files { get; set; } = new();
+    }
+
+    private sealed class GoogleDriveFileMetadata
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = DefaultFileName;
+
+        [JsonPropertyName("appProperties")]
+        public Dictionary<string, string> AppProperties { get; set; } = new();
+
+        [JsonPropertyName("parents")]
+        public List<string>? Parents { get; set; }
+    }
+}

--- a/Password Phrase Producer/Services/Vault/Sync/IVaultSyncProvider.cs
+++ b/Password Phrase Producer/Services/Vault/Sync/IVaultSyncProvider.cs
@@ -1,0 +1,21 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Password_Phrase_Producer.Services.Vault.Sync;
+
+public interface IVaultSyncProvider
+{
+    string Key { get; }
+
+    string DisplayName { get; }
+
+    bool SupportsAutomaticSync { get; }
+
+    Task<bool> IsConfiguredAsync(VaultSyncConfiguration configuration, CancellationToken cancellationToken = default);
+
+    Task<VaultSyncRemoteState?> GetRemoteStateAsync(VaultSyncConfiguration configuration, CancellationToken cancellationToken = default);
+
+    Task<VaultSyncDownloadResult?> DownloadAsync(VaultSyncConfiguration configuration, CancellationToken cancellationToken = default);
+
+    Task UploadAsync(VaultSyncUploadRequest request, VaultSyncConfiguration configuration, CancellationToken cancellationToken = default);
+}

--- a/Password Phrase Producer/Services/Vault/Sync/IVaultSyncScheduler.cs
+++ b/Password Phrase Producer/Services/Vault/Sync/IVaultSyncScheduler.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Password_Phrase_Producer.Services.Vault.Sync;
+
+public interface IVaultSyncScheduler
+{
+    void Schedule(TimeSpan interval, Func<CancellationToken, Task> callback);
+
+    void Cancel();
+}
+
+public sealed class NoOpVaultSyncScheduler : IVaultSyncScheduler
+{
+    public void Schedule(TimeSpan interval, Func<CancellationToken, Task> callback)
+    {
+    }
+
+    public void Cancel()
+    {
+    }
+}

--- a/Password Phrase Producer/Services/Vault/Sync/S3VaultSyncProvider.cs
+++ b/Password Phrase Producer/Services/Vault/Sync/S3VaultSyncProvider.cs
@@ -1,0 +1,163 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon;
+using Amazon.Runtime;
+using Amazon.S3;
+using Amazon.S3.Model;
+
+namespace Password_Phrase_Producer.Services.Vault.Sync;
+
+public sealed class S3VaultSyncProvider : IVaultSyncProvider
+{
+    public const string ProviderKey = "S3";
+    public const string BucketParameterKey = "bucket";
+    public const string ObjectKeyParameterKey = "objectKey";
+    public const string RegionParameterKey = "region";
+    public const string AccessKeyIdParameterKey = "accessKeyId";
+    public const string SecretAccessKeyParameterKey = "secretAccessKey";
+    private const string MerkleMetadataKey = "vault-merkle-hash";
+
+    public string Key => ProviderKey;
+
+    public string DisplayName => "Amazon S3";
+
+    public bool SupportsAutomaticSync => true;
+
+    public Task<bool> IsConfiguredAsync(VaultSyncConfiguration configuration, CancellationToken cancellationToken = default)
+    {
+        var isConfigured = configuration.Parameters.TryGetValue(BucketParameterKey, out var bucket) && !string.IsNullOrWhiteSpace(bucket)
+            && configuration.Parameters.TryGetValue(ObjectKeyParameterKey, out var objectKey) && !string.IsNullOrWhiteSpace(objectKey)
+            && configuration.Parameters.TryGetValue(RegionParameterKey, out var region) && !string.IsNullOrWhiteSpace(region)
+            && configuration.Parameters.TryGetValue(AccessKeyIdParameterKey, out var accessKeyId) && !string.IsNullOrWhiteSpace(accessKeyId)
+            && configuration.Parameters.TryGetValue(SecretAccessKeyParameterKey, out var secret) && !string.IsNullOrWhiteSpace(secret);
+
+        return Task.FromResult(isConfigured);
+    }
+
+    public async Task<VaultSyncRemoteState?> GetRemoteStateAsync(VaultSyncConfiguration configuration, CancellationToken cancellationToken = default)
+    {
+        if (!await IsConfiguredAsync(configuration, cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        using var client = CreateClient(configuration);
+        var request = new GetObjectMetadataRequest
+        {
+            BucketName = configuration.Parameters[BucketParameterKey],
+            Key = configuration.Parameters[ObjectKeyParameterKey]
+        };
+
+        try
+        {
+            var response = await client.GetObjectMetadataAsync(request, cancellationToken).ConfigureAwait(false);
+            return new VaultSyncRemoteState
+            {
+                LastModifiedUtc = response.LastModified.ToUniversalTime(),
+                ContentLength = response.Headers.ContentLength,
+                MerkleHash = response.Metadata[$"x-amz-meta-{MerkleMetadataKey}"] ?? string.Empty,
+                EntityTag = response.ETag
+            };
+        }
+        catch (AmazonS3Exception ex) when (string.Equals(ex.ErrorCode, "NotFound", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+    }
+
+    public async Task<VaultSyncDownloadResult?> DownloadAsync(VaultSyncConfiguration configuration, CancellationToken cancellationToken = default)
+    {
+        if (!await IsConfiguredAsync(configuration, cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        using var client = CreateClient(configuration);
+        var request = new GetObjectRequest
+        {
+            BucketName = configuration.Parameters[BucketParameterKey],
+            Key = configuration.Parameters[ObjectKeyParameterKey]
+        };
+
+        try
+        {
+            using var response = await client.GetObjectAsync(request, cancellationToken).ConfigureAwait(false);
+            await using var memoryStream = new MemoryStream();
+            await response.ResponseStream.CopyToAsync(memoryStream, cancellationToken).ConfigureAwait(false);
+            var payload = memoryStream.ToArray();
+            return new VaultSyncDownloadResult
+            {
+                Payload = payload,
+                RemoteState = new VaultSyncRemoteState
+                {
+                    LastModifiedUtc = response.LastModified.ToUniversalTime(),
+                    ContentLength = payload.LongLength,
+                    MerkleHash = response.Metadata[$"x-amz-meta-{MerkleMetadataKey}"] ?? string.Empty,
+                    EntityTag = response.ETag
+                }
+            };
+        }
+        catch (AmazonS3Exception ex) when (string.Equals(ex.ErrorCode, "NotFound", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+    }
+
+    public async Task UploadAsync(VaultSyncUploadRequest request, VaultSyncConfiguration configuration, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        if (!await IsConfiguredAsync(configuration, cancellationToken).ConfigureAwait(false))
+        {
+            throw new InvalidOperationException("Die S3-Synchronisation ist nicht vollständig konfiguriert.");
+        }
+
+        using var client = CreateClient(configuration);
+        var bucketName = configuration.Parameters[BucketParameterKey];
+        var objectKey = configuration.Parameters[ObjectKeyParameterKey];
+
+        if (request.RemoteStateBeforeUpload is not null)
+        {
+            var metadataRequest = new GetObjectMetadataRequest
+            {
+                BucketName = bucketName,
+                Key = objectKey
+            };
+
+            try
+            {
+                var metadataResponse = await client.GetObjectMetadataAsync(metadataRequest, cancellationToken).ConfigureAwait(false);
+                var currentHash = metadataResponse.Metadata[$"x-amz-meta-{MerkleMetadataKey}"] ?? string.Empty;
+                if (!string.Equals(currentHash, request.RemoteStateBeforeUpload.MerkleHash, StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException("Der entfernte Tresor wurde seit der letzten Synchronisation verändert.");
+                }
+            }
+            catch (AmazonS3Exception ex) when (string.Equals(ex.ErrorCode, "NotFound", StringComparison.OrdinalIgnoreCase))
+            {
+                // Objekt existiert nicht mehr, Upload kann fortgesetzt werden.
+            }
+        }
+
+        using var payloadStream = new MemoryStream(request.Payload, writable: false);
+        var putRequest = new PutObjectRequest
+        {
+            BucketName = bucketName,
+            Key = objectKey,
+            InputStream = payloadStream,
+            AutoCloseStream = false
+        };
+        putRequest.Metadata.Add(MerkleMetadataKey, request.LocalState.MerkleHash);
+        putRequest.Headers.ContentType = "application/octet-stream";
+
+        await client.PutObjectAsync(putRequest, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static IAmazonS3 CreateClient(VaultSyncConfiguration configuration)
+    {
+        var region = RegionEndpoint.GetBySystemName(configuration.Parameters[RegionParameterKey]);
+        var credentials = new BasicAWSCredentials(configuration.Parameters[AccessKeyIdParameterKey], configuration.Parameters[SecretAccessKeyParameterKey]);
+        return new AmazonS3Client(credentials, region);
+    }
+}

--- a/Password Phrase Producer/Services/Vault/Sync/VaultSyncModels.cs
+++ b/Password Phrase Producer/Services/Vault/Sync/VaultSyncModels.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Password_Phrase_Producer.Services.Vault.Sync;
+
+public enum VaultSyncOperation
+{
+    None,
+    Disabled,
+    NoProvider,
+    UpToDate,
+    Uploaded,
+    Downloaded,
+    Conflict,
+    Error
+}
+
+public sealed class VaultSyncRemoteState
+{
+    public DateTimeOffset LastModifiedUtc { get; set; }
+
+    public string MerkleHash { get; set; } = string.Empty;
+
+    public long ContentLength { get; set; }
+
+    public string? EntityTag { get; set; }
+}
+
+public sealed class VaultSyncUploadRequest
+{
+    public required byte[] Payload { get; init; }
+
+    public required VaultSyncRemoteState LocalState { get; init; }
+
+    public VaultSyncRemoteState? RemoteStateBeforeUpload { get; init; }
+}
+
+public sealed class VaultSyncDownloadResult
+{
+    public required byte[] Payload { get; init; }
+
+    public required VaultSyncRemoteState RemoteState { get; init; }
+}
+
+public sealed class VaultSyncResult
+{
+    public VaultSyncOperation Operation { get; init; }
+
+    public VaultSyncRemoteState? LocalState { get; init; }
+
+    public VaultSyncRemoteState? RemoteState { get; init; }
+
+    public string? ErrorMessage { get; init; }
+
+    [JsonIgnore]
+    public bool Success => Operation is not VaultSyncOperation.Error;
+}
+
+public sealed class VaultSyncConfiguration
+{
+    public bool IsEnabled { get; set; }
+
+    public bool AutoSyncEnabled { get; set; }
+
+    public string? ProviderKey { get; set; }
+
+    public Dictionary<string, string> Parameters { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+    public VaultSyncConfiguration Clone()
+        => new()
+        {
+            IsEnabled = IsEnabled,
+            AutoSyncEnabled = AutoSyncEnabled,
+            ProviderKey = ProviderKey,
+            Parameters = new Dictionary<string, string>(Parameters, StringComparer.OrdinalIgnoreCase)
+        };
+}
+
+public sealed class VaultSyncStatus
+{
+    public bool IsEnabled { get; set; }
+
+    public bool AutoSyncEnabled { get; set; }
+
+    public string? ProviderKey { get; set; }
+
+    public VaultSyncOperation LastOperation { get; set; }
+
+    public DateTimeOffset? LastSyncUtc { get; set; }
+
+    public string? LastError { get; set; }
+
+    public VaultSyncRemoteState? RemoteState { get; set; }
+}

--- a/Password Phrase Producer/Services/Vault/Sync/VaultSyncProviderDescriptor.cs
+++ b/Password Phrase Producer/Services/Vault/Sync/VaultSyncProviderDescriptor.cs
@@ -1,0 +1,3 @@
+namespace Password_Phrase_Producer.Services.Vault.Sync;
+
+public sealed record VaultSyncProviderDescriptor(string Key, string DisplayName, bool SupportsAutomaticSync);

--- a/Password Phrase Producer/ViewModels/VaultPageViewModel.cs
+++ b/Password Phrase Producer/ViewModels/VaultPageViewModel.cs
@@ -12,7 +12,9 @@ using Microsoft.Maui.Controls;
 using Password_Phrase_Producer.Models;
 using Password_Phrase_Producer.Services.Security;
 using Password_Phrase_Producer.Services.Vault;
+using Password_Phrase_Producer.Services.Vault.Sync;
 using System.Linq;
+using System.Text;
 
 namespace Password_Phrase_Producer.ViewModels;
 
@@ -35,6 +37,31 @@ public class VaultPageViewModel : INotifyPropertyChanged
     private string _selectedCategory = AllCategoriesFilter;
     private readonly List<PasswordVaultEntry> _allEntries = new();
     private readonly List<string> _availableCategories = new();
+    private readonly ObservableCollection<VaultSyncProviderDescriptor> _syncProviders = new();
+    private VaultSyncProviderDescriptor? _selectedSyncProvider;
+    private bool _isSyncEnabled;
+    private bool _isAutoSyncEnabled;
+    private bool _isSyncBusy;
+    private bool _isSyncSettingsDirty;
+    private bool _isLoadingSyncSettings;
+    private string _syncStatusMessage = "Synchronisation inaktiv.";
+    private string _fileSyncPath = string.Empty;
+    private string _s3BucketName = string.Empty;
+    private string _s3ObjectKey = "vault.json.enc";
+    private string _s3Region = string.Empty;
+    private string _s3AccessKeyId = string.Empty;
+    private string _s3SecretAccessKey = string.Empty;
+    private string _googleDriveClientId = string.Empty;
+    private string _googleDriveClientSecret = string.Empty;
+    private string _googleDriveRefreshToken = string.Empty;
+    private string _googleDriveFileId = string.Empty;
+    private string _googleDriveFileName = "vault.json.enc";
+    private string _googleDriveFolderId = string.Empty;
+    private string? _currentS3Secret;
+    private bool _hasS3Secret;
+    private DateTimeOffset? _lastSyncUtc;
+    private VaultSyncOperation _lastSyncOperation = VaultSyncOperation.None;
+    private string? _lastSyncError;
 
     private const string AllCategoriesFilter = "Alle Kategorien";
 
@@ -44,9 +71,12 @@ public class VaultPageViewModel : INotifyPropertyChanged
         _biometricAuthenticationService = biometricAuthenticationService;
         EntryGroups = new ObservableCollection<VaultEntryGroup>();
         CategoryFilterOptions = new ObservableCollection<string> { AllCategoriesFilter };
+        SyncProviders = _syncProviders;
 
         UnlockCommand = new Command(async () => await UnlockAsync(), () => !IsBusy);
         UnlockWithBiometricCommand = new Command(async () => await UnlockWithBiometricAsync(), () => !IsBusy && CanUseBiometric && IsBiometricConfigured);
+        SaveSyncSettingsCommand = new Command(async () => await SaveSyncSettingsAsync(), () => IsSyncSettingsDirty && !IsSyncBusy);
+        SyncNowCommand = new Command(async () => await SyncNowAsync(), () => !IsSyncBusy && IsSyncEnabled);
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;
@@ -54,6 +84,246 @@ public class VaultPageViewModel : INotifyPropertyChanged
     public ObservableCollection<VaultEntryGroup> EntryGroups { get; }
 
     public ObservableCollection<string> CategoryFilterOptions { get; }
+
+    public ObservableCollection<VaultSyncProviderDescriptor> SyncProviders { get; }
+
+    public bool IsSyncEnabled
+    {
+        get => _isSyncEnabled;
+        set
+        {
+            if (SetProperty(ref _isSyncEnabled, value) && !_isLoadingSyncSettings)
+            {
+                MarkSyncSettingsDirty();
+                UpdateSyncCommandStates();
+            }
+        }
+    }
+
+    public bool IsAutoSyncEnabled
+    {
+        get => _isAutoSyncEnabled;
+        set
+        {
+            if (SetProperty(ref _isAutoSyncEnabled, value) && !_isLoadingSyncSettings)
+            {
+                MarkSyncSettingsDirty();
+                UpdateSyncCommandStates();
+            }
+        }
+    }
+
+    public bool IsSyncBusy
+    {
+        get => _isSyncBusy;
+        private set
+        {
+            if (SetProperty(ref _isSyncBusy, value))
+            {
+                UpdateSyncCommandStates();
+            }
+        }
+    }
+
+    public bool IsSyncSettingsDirty
+    {
+        get => _isSyncSettingsDirty;
+        private set
+        {
+            if (SetProperty(ref _isSyncSettingsDirty, value))
+            {
+                UpdateSyncCommandStates();
+            }
+        }
+    }
+
+    public VaultSyncProviderDescriptor? SelectedSyncProvider
+    {
+        get => _selectedSyncProvider;
+        set
+        {
+            if (SetProperty(ref _selectedSyncProvider, value) && !_isLoadingSyncSettings)
+            {
+                MarkSyncSettingsDirty();
+                OnPropertyChanged(nameof(IsS3ProviderSelected));
+                OnPropertyChanged(nameof(IsFileProviderSelected));
+                OnPropertyChanged(nameof(IsGoogleDriveProviderSelected));
+                UpdateSyncCommandStates();
+            }
+        }
+    }
+
+    public bool IsS3ProviderSelected => string.Equals(SelectedSyncProvider?.Key, S3VaultSyncProvider.ProviderKey, StringComparison.OrdinalIgnoreCase);
+
+    public bool IsFileProviderSelected => string.Equals(SelectedSyncProvider?.Key, FileSystemVaultSyncProvider.ProviderKey, StringComparison.OrdinalIgnoreCase);
+
+    public bool IsGoogleDriveProviderSelected => string.Equals(SelectedSyncProvider?.Key, GoogleDriveVaultSyncProvider.ProviderKey, StringComparison.OrdinalIgnoreCase);
+
+    public string FileSyncPath
+    {
+        get => _fileSyncPath;
+        set
+        {
+            if (SetProperty(ref _fileSyncPath, value) && !_isLoadingSyncSettings)
+            {
+                MarkSyncSettingsDirty();
+            }
+        }
+    }
+
+    public string S3BucketName
+    {
+        get => _s3BucketName;
+        set
+        {
+            if (SetProperty(ref _s3BucketName, value) && !_isLoadingSyncSettings)
+            {
+                MarkSyncSettingsDirty();
+            }
+        }
+    }
+
+    public string S3ObjectKey
+    {
+        get => _s3ObjectKey;
+        set
+        {
+            if (SetProperty(ref _s3ObjectKey, value) && !_isLoadingSyncSettings)
+            {
+                MarkSyncSettingsDirty();
+            }
+        }
+    }
+
+    public string S3Region
+    {
+        get => _s3Region;
+        set
+        {
+            if (SetProperty(ref _s3Region, value) && !_isLoadingSyncSettings)
+            {
+                MarkSyncSettingsDirty();
+            }
+        }
+    }
+
+    public string S3AccessKeyId
+    {
+        get => _s3AccessKeyId;
+        set
+        {
+            if (SetProperty(ref _s3AccessKeyId, value) && !_isLoadingSyncSettings)
+            {
+                MarkSyncSettingsDirty();
+            }
+        }
+    }
+
+    public string S3SecretAccessKey
+    {
+        get => _s3SecretAccessKey;
+        set
+        {
+            if (SetProperty(ref _s3SecretAccessKey, value) && !_isLoadingSyncSettings)
+            {
+                MarkSyncSettingsDirty();
+            }
+        }
+    }
+
+    public string GoogleDriveClientId
+    {
+        get => _googleDriveClientId;
+        set
+        {
+            if (SetProperty(ref _googleDriveClientId, value) && !_isLoadingSyncSettings)
+            {
+                MarkSyncSettingsDirty();
+            }
+        }
+    }
+
+    public string GoogleDriveClientSecret
+    {
+        get => _googleDriveClientSecret;
+        set
+        {
+            if (SetProperty(ref _googleDriveClientSecret, value) && !_isLoadingSyncSettings)
+            {
+                MarkSyncSettingsDirty();
+            }
+        }
+    }
+
+    public string GoogleDriveRefreshToken
+    {
+        get => _googleDriveRefreshToken;
+        set
+        {
+            if (SetProperty(ref _googleDriveRefreshToken, value) && !_isLoadingSyncSettings)
+            {
+                MarkSyncSettingsDirty();
+            }
+        }
+    }
+
+    public string GoogleDriveFileId
+    {
+        get => _googleDriveFileId;
+        set
+        {
+            if (SetProperty(ref _googleDriveFileId, value) && !_isLoadingSyncSettings)
+            {
+                MarkSyncSettingsDirty();
+            }
+        }
+    }
+
+    public string GoogleDriveFileName
+    {
+        get => _googleDriveFileName;
+        set
+        {
+            if (SetProperty(ref _googleDriveFileName, value) && !_isLoadingSyncSettings)
+            {
+                MarkSyncSettingsDirty();
+            }
+        }
+    }
+
+    public string GoogleDriveFolderId
+    {
+        get => _googleDriveFolderId;
+        set
+        {
+            if (SetProperty(ref _googleDriveFolderId, value) && !_isLoadingSyncSettings)
+            {
+                MarkSyncSettingsDirty();
+            }
+        }
+    }
+
+    public bool HasS3Secret
+    {
+        get => _hasS3Secret;
+        private set => SetProperty(ref _hasS3Secret, value);
+    }
+
+    public DateTimeOffset? LastSyncUtc
+    {
+        get => _lastSyncUtc;
+        private set => SetProperty(ref _lastSyncUtc, value);
+    }
+
+    public string SyncStatusMessage
+    {
+        get => _syncStatusMessage;
+        private set => SetProperty(ref _syncStatusMessage, value);
+    }
+
+    public ICommand SaveSyncSettingsCommand { get; }
+
+    public ICommand SyncNowCommand { get; }
 
     public IReadOnlyList<string> AvailableCategories => _availableCategories;
 
@@ -190,6 +460,7 @@ public class VaultPageViewModel : INotifyPropertyChanged
         }
 
         MessagingCenter.Subscribe<PasswordVaultService>(this, VaultMessages.EntriesChanged, OnVaultEntriesChanged);
+        MessagingCenter.Subscribe<PasswordVaultService, VaultSyncResult>(this, VaultMessages.SyncStatusChanged, OnSyncStatusChanged);
         _isListening = true;
     }
 
@@ -198,6 +469,7 @@ public class VaultPageViewModel : INotifyPropertyChanged
         if (_isListening)
         {
             MessagingCenter.Unsubscribe<PasswordVaultService>(this, VaultMessages.EntriesChanged);
+            MessagingCenter.Unsubscribe<PasswordVaultService, VaultSyncResult>(this, VaultMessages.SyncStatusChanged);
             _isListening = false;
         }
 
@@ -218,6 +490,7 @@ public class VaultPageViewModel : INotifyPropertyChanged
 
     public async Task InitializeAsync(CancellationToken cancellationToken = default)
     {
+        await LoadSyncConfigurationAsync(cancellationToken).ConfigureAwait(false);
         await EnsureAccessStateAsync(cancellationToken);
 
         if (IsUnlocked)
@@ -243,6 +516,204 @@ public class VaultPageViewModel : INotifyPropertyChanged
         {
             IsBusy = false;
         }
+    }
+
+    private async Task LoadSyncConfigurationAsync(CancellationToken cancellationToken = default)
+    {
+        _isLoadingSyncSettings = true;
+        try
+        {
+            var providers = _vaultService.GetAvailableSyncProviders().ToList();
+            await MainThread.InvokeOnMainThreadAsync(() =>
+            {
+                _syncProviders.Clear();
+                foreach (var provider in providers)
+                {
+                    _syncProviders.Add(provider);
+                }
+            }).ConfigureAwait(false);
+
+            var configuration = await _vaultService.GetSyncConfigurationAsync(cancellationToken).ConfigureAwait(false);
+            var status = await _vaultService.GetSyncStatusAsync(cancellationToken).ConfigureAwait(false);
+
+            configuration.Parameters.TryGetValue(FileSystemVaultSyncProvider.PathParameterKey, out var path);
+            configuration.Parameters.TryGetValue(S3VaultSyncProvider.BucketParameterKey, out var bucket);
+            configuration.Parameters.TryGetValue(S3VaultSyncProvider.ObjectKeyParameterKey, out var objectKey);
+            configuration.Parameters.TryGetValue(S3VaultSyncProvider.RegionParameterKey, out var region);
+            configuration.Parameters.TryGetValue(S3VaultSyncProvider.AccessKeyIdParameterKey, out var accessKeyId);
+            configuration.Parameters.TryGetValue(S3VaultSyncProvider.SecretAccessKeyParameterKey, out var secret);
+            configuration.Parameters.TryGetValue(GoogleDriveVaultSyncProvider.ClientIdParameterKey, out var googleClientId);
+            configuration.Parameters.TryGetValue(GoogleDriveVaultSyncProvider.ClientSecretParameterKey, out var googleClientSecret);
+            configuration.Parameters.TryGetValue(GoogleDriveVaultSyncProvider.RefreshTokenParameterKey, out var googleRefreshToken);
+            configuration.Parameters.TryGetValue(GoogleDriveVaultSyncProvider.FileIdParameterKey, out var googleFileId);
+            configuration.Parameters.TryGetValue(GoogleDriveVaultSyncProvider.FileNameParameterKey, out var googleFileName);
+            configuration.Parameters.TryGetValue(GoogleDriveVaultSyncProvider.FolderIdParameterKey, out var googleFolderId);
+
+            await MainThread.InvokeOnMainThreadAsync(() =>
+            {
+                SelectedSyncProvider = providers.FirstOrDefault(p => string.Equals(p.Key, configuration.ProviderKey, StringComparison.OrdinalIgnoreCase));
+                IsSyncEnabled = configuration.IsEnabled;
+                IsAutoSyncEnabled = configuration.AutoSyncEnabled;
+                FileSyncPath = path ?? string.Empty;
+                S3BucketName = bucket ?? string.Empty;
+                S3ObjectKey = string.IsNullOrWhiteSpace(objectKey) ? "vault.json.enc" : objectKey;
+                S3Region = region ?? string.Empty;
+                S3AccessKeyId = accessKeyId ?? string.Empty;
+                _currentS3Secret = secret;
+                HasS3Secret = !string.IsNullOrWhiteSpace(_currentS3Secret);
+                S3SecretAccessKey = string.Empty;
+                GoogleDriveClientId = googleClientId ?? string.Empty;
+                GoogleDriveClientSecret = googleClientSecret ?? string.Empty;
+                GoogleDriveRefreshToken = googleRefreshToken ?? string.Empty;
+                GoogleDriveFileId = googleFileId ?? string.Empty;
+                GoogleDriveFileName = string.IsNullOrWhiteSpace(googleFileName) ? "vault.json.enc" : googleFileName;
+                GoogleDriveFolderId = googleFolderId ?? string.Empty;
+                UpdateSyncStatusMessage(status, null);
+                IsSyncSettingsDirty = false;
+            }).ConfigureAwait(false);
+        }
+        finally
+        {
+            _isLoadingSyncSettings = false;
+        }
+    }
+
+    private async Task RefreshSyncStatusAsync(VaultSyncResult? result = null, CancellationToken cancellationToken = default)
+    {
+        var status = await _vaultService.GetSyncStatusAsync(cancellationToken).ConfigureAwait(false);
+        await MainThread.InvokeOnMainThreadAsync(() => UpdateSyncStatusMessage(status, result)).ConfigureAwait(false);
+    }
+
+    private async Task SaveSyncSettingsAsync()
+    {
+        try
+        {
+            var configuration = BuildSyncConfiguration();
+            await _vaultService.UpdateSyncConfigurationAsync(configuration).ConfigureAwait(false);
+            await MainThread.InvokeOnMainThreadAsync(() =>
+            {
+                _currentS3Secret = configuration.Parameters.TryGetValue(S3VaultSyncProvider.SecretAccessKeyParameterKey, out var secret)
+                    ? secret
+                    : null;
+                HasS3Secret = !string.IsNullOrWhiteSpace(_currentS3Secret);
+                S3SecretAccessKey = string.Empty;
+                IsSyncSettingsDirty = false;
+            }).ConfigureAwait(false);
+            await RefreshSyncStatusAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            await MainThread.InvokeOnMainThreadAsync(() =>
+            {
+                SyncStatusMessage = $"Fehler beim Speichern der Synchronisation: {ex.Message}";
+            }).ConfigureAwait(false);
+        }
+    }
+
+    private async Task SyncNowAsync()
+    {
+        if (IsSyncBusy)
+        {
+            return;
+        }
+
+        try
+        {
+            await MainThread.InvokeOnMainThreadAsync(() => IsSyncBusy = true).ConfigureAwait(false);
+            var result = await _vaultService.SynchronizeAsync().ConfigureAwait(false);
+            await RefreshSyncStatusAsync(result).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            await MainThread.InvokeOnMainThreadAsync(() =>
+            {
+                SyncStatusMessage = $"Fehler bei der Synchronisation: {ex.Message}";
+            }).ConfigureAwait(false);
+        }
+        finally
+        {
+            await MainThread.InvokeOnMainThreadAsync(() => IsSyncBusy = false).ConfigureAwait(false);
+        }
+    }
+
+    private VaultSyncConfiguration BuildSyncConfiguration()
+    {
+        var configuration = new VaultSyncConfiguration
+        {
+            IsEnabled = IsSyncEnabled,
+            AutoSyncEnabled = IsAutoSyncEnabled,
+            ProviderKey = SelectedSyncProvider?.Key
+        };
+
+        if (IsFileProviderSelected && !string.IsNullOrWhiteSpace(FileSyncPath))
+        {
+            configuration.Parameters[FileSystemVaultSyncProvider.PathParameterKey] = FileSyncPath.Trim();
+        }
+
+        if (IsS3ProviderSelected)
+        {
+            if (!string.IsNullOrWhiteSpace(S3BucketName))
+            {
+                configuration.Parameters[S3VaultSyncProvider.BucketParameterKey] = S3BucketName.Trim();
+            }
+
+            configuration.Parameters[S3VaultSyncProvider.ObjectKeyParameterKey] = string.IsNullOrWhiteSpace(S3ObjectKey)
+                ? "vault.json.enc"
+                : S3ObjectKey.Trim();
+
+            if (!string.IsNullOrWhiteSpace(S3Region))
+            {
+                configuration.Parameters[S3VaultSyncProvider.RegionParameterKey] = S3Region.Trim();
+            }
+
+            if (!string.IsNullOrWhiteSpace(S3AccessKeyId))
+            {
+                configuration.Parameters[S3VaultSyncProvider.AccessKeyIdParameterKey] = S3AccessKeyId.Trim();
+            }
+
+            if (!string.IsNullOrWhiteSpace(S3SecretAccessKey))
+            {
+                configuration.Parameters[S3VaultSyncProvider.SecretAccessKeyParameterKey] = S3SecretAccessKey;
+            }
+            else if (!string.IsNullOrWhiteSpace(_currentS3Secret))
+            {
+                configuration.Parameters[S3VaultSyncProvider.SecretAccessKeyParameterKey] = _currentS3Secret!;
+            }
+        }
+
+        if (IsGoogleDriveProviderSelected)
+        {
+            if (!string.IsNullOrWhiteSpace(GoogleDriveClientId))
+            {
+                configuration.Parameters[GoogleDriveVaultSyncProvider.ClientIdParameterKey] = GoogleDriveClientId.Trim();
+            }
+
+            if (!string.IsNullOrWhiteSpace(GoogleDriveClientSecret))
+            {
+                configuration.Parameters[GoogleDriveVaultSyncProvider.ClientSecretParameterKey] = GoogleDriveClientSecret.Trim();
+            }
+
+            if (!string.IsNullOrWhiteSpace(GoogleDriveRefreshToken))
+            {
+                configuration.Parameters[GoogleDriveVaultSyncProvider.RefreshTokenParameterKey] = GoogleDriveRefreshToken.Trim();
+            }
+
+            if (!string.IsNullOrWhiteSpace(GoogleDriveFileId))
+            {
+                configuration.Parameters[GoogleDriveVaultSyncProvider.FileIdParameterKey] = GoogleDriveFileId.Trim();
+            }
+
+            configuration.Parameters[GoogleDriveVaultSyncProvider.FileNameParameterKey] = string.IsNullOrWhiteSpace(GoogleDriveFileName)
+                ? "vault.json.enc"
+                : GoogleDriveFileName.Trim();
+
+            if (!string.IsNullOrWhiteSpace(GoogleDriveFolderId))
+            {
+                configuration.Parameters[GoogleDriveVaultSyncProvider.FolderIdParameterKey] = GoogleDriveFolderId.Trim();
+            }
+        }
+
+        return configuration;
     }
 
     public async Task SaveEntryAsync(PasswordVaultEntry entry, CancellationToken cancellationToken = default)
@@ -454,6 +925,68 @@ public class VaultPageViewModel : INotifyPropertyChanged
         }
     }
 
+    private void OnSyncStatusChanged(PasswordVaultService sender, VaultSyncResult result)
+    {
+        _ = RefreshSyncStatusAsync(result).ContinueWith(task =>
+        {
+            if (task.Exception is not null)
+            {
+                Debug.WriteLine($"Fehler beim Aktualisieren des Sync-Status: {task.Exception}");
+            }
+        }, TaskScheduler.Default);
+    }
+
+    private void UpdateSyncStatusMessage(VaultSyncStatus status, VaultSyncResult? result)
+    {
+        LastSyncUtc = status.LastSyncUtc;
+        _lastSyncOperation = status.LastOperation;
+        _lastSyncError = result?.ErrorMessage ?? status.LastError;
+
+        var builder = new StringBuilder();
+        builder.Append("Status: ").Append(DescribeSyncOperation(status.LastOperation));
+
+        if (status.LastSyncUtc is DateTimeOffset lastSync)
+        {
+            builder.Append(" • Letzte Synchronisation: ").Append(lastSync.ToLocalTime().ToString("g"));
+        }
+
+        var error = result?.ErrorMessage ?? status.LastError;
+        if (!string.IsNullOrWhiteSpace(error))
+        {
+            builder.Append(" • Fehler: ").Append(error);
+        }
+        else if (status.RemoteState is { } remote)
+        {
+            builder.Append(" • Remote-Stand: ").Append(remote.LastModifiedUtc.ToLocalTime().ToString("g"));
+        }
+
+        SyncStatusMessage = builder.ToString();
+    }
+
+    private static string DescribeSyncOperation(VaultSyncOperation operation)
+        => operation switch
+        {
+            VaultSyncOperation.None => "Keine Synchronisation",
+            VaultSyncOperation.Disabled => "Deaktiviert",
+            VaultSyncOperation.NoProvider => "Kein Anbieter",
+            VaultSyncOperation.UpToDate => "Aktuell",
+            VaultSyncOperation.Uploaded => "Hochgeladen",
+            VaultSyncOperation.Downloaded => "Heruntergeladen",
+            VaultSyncOperation.Conflict => "Konflikt",
+            VaultSyncOperation.Error => "Fehler",
+            _ => "Unbekannt"
+        };
+
+    private void MarkSyncSettingsDirty()
+    {
+        if (_isLoadingSyncSettings)
+        {
+            return;
+        }
+
+        IsSyncSettingsDirty = true;
+    }
+
     private void UpdateCommandStates()
     {
         if (UnlockCommand is Command unlockCommand)
@@ -464,6 +997,21 @@ public class VaultPageViewModel : INotifyPropertyChanged
         if (UnlockWithBiometricCommand is Command biometricCommand)
         {
             MainThread.BeginInvokeOnMainThread(biometricCommand.ChangeCanExecute);
+        }
+
+        UpdateSyncCommandStates();
+    }
+
+    private void UpdateSyncCommandStates()
+    {
+        if (SaveSyncSettingsCommand is Command saveCommand)
+        {
+            MainThread.BeginInvokeOnMainThread(saveCommand.ChangeCanExecute);
+        }
+
+        if (SyncNowCommand is Command syncCommand)
+        {
+            MainThread.BeginInvokeOnMainThread(syncCommand.ChangeCanExecute);
         }
     }
 

--- a/Password Phrase Producer/Views/VaultPage.xaml
+++ b/Password Phrase Producer/Views/VaultPage.xaml
@@ -28,7 +28,7 @@
             <Grid
                 Padding="24,40,24,16"
                 RowSpacing="12"
-                RowDefinitions="Auto,Auto">
+                RowDefinitions="Auto,Auto,Auto">
                 <Grid
                     ColumnDefinitions="Auto,*,Auto,Auto,Auto"
                     ColumnSpacing="16"
@@ -211,6 +211,162 @@
                         </Grid>
                     </Border>
                 </Grid>
+                <Border
+                    Grid.Row="2"
+                    BackgroundColor="#1F2338"
+                    StrokeThickness="0"
+                    Padding="16"
+                    HorizontalOptions="Fill"
+                    VerticalOptions="Start">
+                    <Border.StrokeShape>
+                        <RoundRectangle CornerRadius="20" />
+                    </Border.StrokeShape>
+                    <Border.Shadow>
+                        <Shadow Brush="#1A000000" Radius="12" Offset="0,8" />
+                    </Border.Shadow>
+                    <VerticalStackLayout Spacing="12">
+                        <Label
+                            Text="{Binding SyncStatusMessage}"
+                            TextColor="#CFD3FF"
+                            FontAttributes="Bold"
+                            FontSize="14" />
+
+                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+                            <HorizontalStackLayout Spacing="8" VerticalOptions="Center">
+                                <Label Text="Sync aktiv" TextColor="#CFD3FF" />
+                                <Switch IsToggled="{Binding IsSyncEnabled}" />
+                            </HorizontalStackLayout>
+                            <HorizontalStackLayout Grid.Column="1" Spacing="8" VerticalOptions="Center">
+                                <Label Text="Auto-Sync" TextColor="#CFD3FF" />
+                                <Switch IsToggled="{Binding IsAutoSyncEnabled}" />
+                            </HorizontalStackLayout>
+                        </Grid>
+
+                        <Picker
+                            Title="Synchronisationsanbieter"
+                            ItemsSource="{Binding SyncProviders}"
+                            ItemDisplayBinding="{Binding DisplayName}"
+                            SelectedItem="{Binding SelectedSyncProvider}"
+                            TextColor="#CFD3FF"
+                            BackgroundColor="#242846" />
+
+                        <VerticalStackLayout IsVisible="{Binding IsFileProviderSelected}" Spacing="6">
+                            <Label Text="Zielpfad (z. B. Netzlaufwerk)" TextColor="#7F85B2" />
+                            <Entry
+                                Text="{Binding FileSyncPath}"
+                                Placeholder="\\\\Server\\Freigabe\\vault.json.enc"
+                                PlaceholderColor="#7F85B2"
+                                TextColor="#CFD3FF"
+                                BackgroundColor="#1B2036" />
+                        </VerticalStackLayout>
+
+                        <VerticalStackLayout IsVisible="{Binding IsS3ProviderSelected}" Spacing="6">
+                            <Label Text="Amazon S3 Konfiguration" TextColor="#7F85B2" />
+                            <Entry
+                                Text="{Binding S3BucketName}"
+                                Placeholder="Bucket"
+                                PlaceholderColor="#7F85B2"
+                                TextColor="#CFD3FF"
+                                BackgroundColor="#1B2036" />
+                            <Entry
+                                Text="{Binding S3ObjectKey}"
+                                Placeholder="Objektschlüssel"
+                                PlaceholderColor="#7F85B2"
+                                TextColor="#CFD3FF"
+                                BackgroundColor="#1B2036" />
+                            <Entry
+                                Text="{Binding S3Region}"
+                                Placeholder="Region (z. B. eu-central-1)"
+                                PlaceholderColor="#7F85B2"
+                                TextColor="#CFD3FF"
+                                BackgroundColor="#1B2036" />
+                            <Entry
+                                Text="{Binding S3AccessKeyId}"
+                                Placeholder="Access Key ID"
+                                PlaceholderColor="#7F85B2"
+                                TextColor="#CFD3FF"
+                                BackgroundColor="#1B2036" />
+                            <Entry
+                                Text="{Binding S3SecretAccessKey}"
+                                Placeholder="Secret Access Key"
+                                PlaceholderColor="#7F85B2"
+                                TextColor="#CFD3FF"
+                                IsPassword="True"
+                                BackgroundColor="#1B2036" />
+                            <Label
+                                IsVisible="{Binding HasS3Secret}"
+                                Text="Ein geheimes Zugriffstoken ist gespeichert."
+                                FontSize="12"
+                                TextColor="#63F5A8" />
+                        </VerticalStackLayout>
+
+                        <VerticalStackLayout IsVisible="{Binding IsGoogleDriveProviderSelected}" Spacing="6">
+                            <Label Text="Google Drive Konfiguration" TextColor="#7F85B2" />
+                            <Entry
+                                Text="{Binding GoogleDriveClientId}"
+                                Placeholder="OAuth Client ID"
+                                PlaceholderColor="#7F85B2"
+                                TextColor="#CFD3FF"
+                                BackgroundColor="#1B2036" />
+                            <Entry
+                                Text="{Binding GoogleDriveClientSecret}"
+                                Placeholder="OAuth Client Secret"
+                                PlaceholderColor="#7F85B2"
+                                TextColor="#CFD3FF"
+                                BackgroundColor="#1B2036"
+                                IsPassword="True" />
+                            <Entry
+                                Text="{Binding GoogleDriveRefreshToken}"
+                                Placeholder="Refresh Token"
+                                PlaceholderColor="#7F85B2"
+                                TextColor="#CFD3FF"
+                                BackgroundColor="#1B2036"
+                                IsPassword="True" />
+                            <Entry
+                                Text="{Binding GoogleDriveFileId}"
+                                Placeholder="Datei-ID (optional)"
+                                PlaceholderColor="#7F85B2"
+                                TextColor="#CFD3FF"
+                                BackgroundColor="#1B2036" />
+                            <Entry
+                                Text="{Binding GoogleDriveFileName}"
+                                Placeholder="Dateiname (z. B. vault.json.enc)"
+                                PlaceholderColor="#7F85B2"
+                                TextColor="#CFD3FF"
+                                BackgroundColor="#1B2036" />
+                            <Entry
+                                Text="{Binding GoogleDriveFolderId}"
+                                Placeholder="Ordner-ID (optional)"
+                                PlaceholderColor="#7F85B2"
+                                TextColor="#CFD3FF"
+                                BackgroundColor="#1B2036" />
+                            <Label
+                                Text="Nutze einen OAuth-Client mit Drive-Berechtigung (Drive oder Drive.File). Die Datei-ID ist optional, bei leerem Feld wird anhand des Dateinamens gesucht oder neu erstellt."
+                                FontSize="12"
+                                TextColor="#7F85B2" />
+                        </VerticalStackLayout>
+
+                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+                            <Button
+                                Text="Sync-Einstellungen speichern"
+                                Command="{Binding SaveSyncSettingsCommand}"
+                                IsEnabled="{Binding IsSyncSettingsDirty}"
+                                BackgroundColor="#3B4AD1"
+                                TextColor="White" />
+                            <Button
+                                Grid.Column="1"
+                                Text="Jetzt synchronisieren"
+                                Command="{Binding SyncNowCommand}"
+                                BackgroundColor="#2D3A7C"
+                                TextColor="White" />
+                        </Grid>
+
+                        <ActivityIndicator
+                            IsVisible="{Binding IsSyncBusy}"
+                            IsRunning="{Binding IsSyncBusy}"
+                            Color="#63F5A8" />
+                    </VerticalStackLayout>
+                </Border>
             </Grid>
 
             <CollectionView


### PR DESCRIPTION
## Summary
- add a Google Drive vault synchronization provider that uses refresh tokens to talk to the Drive REST API and tracks Merkle hashes for conflict detection
- surface Google Drive configuration fields in the vault page view model and XAML so users can configure OAuth credentials, target files, and folders
- register the Google Drive provider with the Maui app so it appears alongside the existing file system and S3 sync options

## Testing
- `dotnet build` *(fails: command not found in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911b5ee5d94832a86ccd3c3b403ad78)