### PR TITLE
Switch Google Drive sync to Android Storage Access Framework

### DIFF
--- a/Password Phrase Producer/MauiProgram.cs
+++ b/Password Phrase Producer/MauiProgram.cs
@@ -30,6 +30,11 @@ public static class MauiProgram
         builder.Services.AddSingleton<IVaultSyncProvider, S3VaultSyncProvider>();
         builder.Services.AddSingleton<IVaultSyncProvider, GoogleDriveVaultSyncProvider>();
 #if ANDROID
+        builder.Services.AddSingleton<IGoogleDriveDocumentPicker, Password_Phrase_Producer.Platforms.Android.Services.AndroidGoogleDriveDocumentPicker>();
+#else
+        builder.Services.AddSingleton<IGoogleDriveDocumentPicker, NoOpGoogleDriveDocumentPicker>();
+#endif
+#if ANDROID
         builder.Services.AddSingleton<IVaultSyncScheduler, Password_Phrase_Producer.Platforms.Android.VaultSyncScheduler>();
 #elif WINDOWS
         builder.Services.AddSingleton<IVaultSyncScheduler, Password_Phrase_Producer.Platforms.Windows.VaultSyncScheduler>();

--- a/Password Phrase Producer/Platforms/Android/MainActivity.cs
+++ b/Password Phrase Producer/Platforms/Android/MainActivity.cs
@@ -1,4 +1,6 @@
-﻿using Android.App;
+using System;
+using Android.App;
+using Android.Content;
 using Android.Content.PM;
 using Android.OS;
 
@@ -7,5 +9,48 @@ namespace Password_Phrase_Producer
     [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
     public class MainActivity : MauiAppCompatActivity
     {
+        public static MainActivity? Current { get; private set; }
+
+        public event EventHandler<ActivityResultEventArgs>? ActivityResult;
+
+        protected override void OnCreate(Bundle? savedInstanceState)
+        {
+            base.OnCreate(savedInstanceState);
+            Current = this;
+        }
+
+        protected override void OnDestroy()
+        {
+            if (ReferenceEquals(Current, this))
+            {
+                Current = null;
+            }
+
+            base.OnDestroy();
+        }
+
+        protected override void OnActivityResult(int requestCode, Result resultCode, Intent? data)
+        {
+#pragma warning disable CA1416
+            base.OnActivityResult(requestCode, resultCode, data);
+#pragma warning restore CA1416
+            ActivityResult?.Invoke(this, new ActivityResultEventArgs(requestCode, resultCode, data));
+        }
+    }
+
+    public sealed class ActivityResultEventArgs : EventArgs
+    {
+        public ActivityResultEventArgs(int requestCode, Result resultCode, Intent? data)
+        {
+            RequestCode = requestCode;
+            ResultCode = resultCode;
+            Data = data;
+        }
+
+        public int RequestCode { get; }
+
+        public Result ResultCode { get; }
+
+        public Intent? Data { get; }
     }
 }

--- a/Password Phrase Producer/Platforms/Android/Services/AndroidGoogleDriveDocumentPicker.cs
+++ b/Password Phrase Producer/Platforms/Android/Services/AndroidGoogleDriveDocumentPicker.cs
@@ -1,0 +1,113 @@
+#if ANDROID
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Android.App;
+using Android.Content;
+using Android.Net;
+using Android.OS;
+using Android.Provider;
+using Microsoft.Maui.ApplicationModel;
+using Password_Phrase_Producer.Services.Vault.Sync;
+using Password_Phrase_Producer;
+
+namespace Password_Phrase_Producer.Platforms.Android.Services;
+
+public sealed class AndroidGoogleDriveDocumentPicker : IGoogleDriveDocumentPicker
+{
+    private const int CreateDocumentRequestCode = 0x4632;
+    private readonly SemaphoreSlim _semaphore = new(1, 1);
+
+    public async Task<string?> CreateDocumentAsync(string suggestedFileName, CancellationToken cancellationToken = default)
+    {
+        var activity = MainActivity.Current ?? throw new InvalidOperationException("Kein aktives Android-Fenster verfügbar.");
+        await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            var tcs = new TaskCompletionSource<string?>();
+            EventHandler<ActivityResultEventArgs>? handler = null;
+
+            handler = (_, args) =>
+            {
+                if (args.RequestCode != CreateDocumentRequestCode)
+                {
+                    return;
+                }
+
+                activity.ActivityResult -= handler;
+
+                if (args.ResultCode == Result.Ok && args.Data?.Data is Uri uri)
+                {
+                    var takeFlags = args.Data.Flags & (ActivityFlags.GrantReadUriPermission | ActivityFlags.GrantWriteUriPermission);
+                    try
+                    {
+                        activity.ContentResolver?.TakePersistableUriPermission(uri, takeFlags);
+                    }
+                    catch (Exception)
+                    {
+                        // Ignorieren – manche Provider erlauben keine persistente Berechtigung.
+                    }
+
+                    tcs.TrySetResult(uri.ToString());
+                }
+                else
+                {
+                    tcs.TrySetResult(null);
+                }
+            };
+
+            using var registration = cancellationToken.Register(() =>
+            {
+                activity.ActivityResult -= handler;
+                tcs.TrySetCanceled(cancellationToken);
+            });
+
+            await MainThread.InvokeOnMainThreadAsync(() =>
+            {
+                activity.ActivityResult += handler;
+
+                var intent = new Intent(Intent.ActionCreateDocument);
+                intent.AddCategory(Intent.CategoryOpenable);
+                intent.SetType("application/octet-stream");
+                var title = string.IsNullOrWhiteSpace(suggestedFileName)
+                    ? GoogleDriveVaultSyncProvider.DefaultFileName
+                    : suggestedFileName.Trim();
+                intent.PutExtra(Intent.ExtraTitle, title);
+
+                activity.StartActivityForResult(intent, CreateDocumentRequestCode);
+            }).ConfigureAwait(false);
+
+            return await tcs.Task.ConfigureAwait(false);
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+
+    public void ReleasePersistedPermission(string documentUri)
+    {
+        if (string.IsNullOrWhiteSpace(documentUri))
+        {
+            return;
+        }
+
+        var resolver = (MainActivity.Current ?? Application.Context)?.ContentResolver;
+        if (resolver is null)
+        {
+            return;
+        }
+
+        var uri = Uri.Parse(documentUri);
+        try
+        {
+            resolver.ReleasePersistableUriPermission(uri, ActivityFlags.GrantReadUriPermission | ActivityFlags.GrantWriteUriPermission);
+        }
+        catch (Exception)
+        {
+            // Falls der Provider keine Berechtigungen vergibt, gibt es nichts zu tun.
+        }
+    }
+}
+#endif

--- a/Password Phrase Producer/Services/Vault/Sync/GoogleDriveVaultSyncProvider.cs
+++ b/Password Phrase Producer/Services/Vault/Sync/GoogleDriveVaultSyncProvider.cs
@@ -1,11 +1,6 @@
 using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Text;
-using System.Text.Json;
-using System.Text.Json.Serialization;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -14,33 +9,8 @@ namespace Password_Phrase_Producer.Services.Vault.Sync;
 public sealed class GoogleDriveVaultSyncProvider : IVaultSyncProvider
 {
     public const string ProviderKey = "GoogleDrive";
-    public const string ClientIdParameterKey = "clientId";
-    public const string ClientSecretParameterKey = "clientSecret";
-    public const string RefreshTokenParameterKey = "refreshToken";
-    public const string FileIdParameterKey = "fileId";
-    public const string FileNameParameterKey = "fileName";
-    public const string FolderIdParameterKey = "folderId";
-
-    private const string MerklePropertyKey = "vaultMerkleHash";
-    private const string DefaultFileName = "vault.json.enc";
-    private static readonly Uri TokenEndpoint = new("https://oauth2.googleapis.com/token");
-    private static readonly Uri DriveApiBaseUri = new("https://www.googleapis.com/drive/v3/");
-    private static readonly Uri DriveUploadBaseUri = new("https://www.googleapis.com/upload/drive/v3/");
-    private static readonly HttpClient SharedHttpClient = new()
-    {
-        Timeout = TimeSpan.FromSeconds(100)
-    };
-
-    private readonly HttpClient _httpClient;
-    private readonly JsonSerializerOptions _jsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true
-    };
-
-    public GoogleDriveVaultSyncProvider(HttpClient? httpClient = null)
-    {
-        _httpClient = httpClient ?? SharedHttpClient;
-    }
+    public const string DocumentUriParameterKey = "documentUri";
+    public const string DefaultFileName = "vault.json.enc";
 
     public string Key => ProviderKey;
 
@@ -49,310 +19,91 @@ public sealed class GoogleDriveVaultSyncProvider : IVaultSyncProvider
     public bool SupportsAutomaticSync => true;
 
     public Task<bool> IsConfiguredAsync(VaultSyncConfiguration configuration, CancellationToken cancellationToken = default)
-    {
-        var hasCoreParameters = configuration.Parameters.TryGetValue(ClientIdParameterKey, out var clientId) && !string.IsNullOrWhiteSpace(clientId)
-            && configuration.Parameters.TryGetValue(ClientSecretParameterKey, out var clientSecret) && !string.IsNullOrWhiteSpace(clientSecret)
-            && configuration.Parameters.TryGetValue(RefreshTokenParameterKey, out var refreshToken) && !string.IsNullOrWhiteSpace(refreshToken);
-
-        if (!hasCoreParameters)
-        {
-            return Task.FromResult(false);
-        }
-
-        if (configuration.Parameters.TryGetValue(FileIdParameterKey, out var fileId) && !string.IsNullOrWhiteSpace(fileId))
-        {
-            return Task.FromResult(true);
-        }
-
-        if (configuration.Parameters.TryGetValue(FileNameParameterKey, out var fileName) && !string.IsNullOrWhiteSpace(fileName))
-        {
-            return Task.FromResult(true);
-        }
-
-        return Task.FromResult(false);
-    }
+        => Task.FromResult(GetDocumentUri(configuration) is not null);
 
     public async Task<VaultSyncRemoteState?> GetRemoteStateAsync(VaultSyncConfiguration configuration, CancellationToken cancellationToken = default)
     {
-        if (!await IsConfiguredAsync(configuration, cancellationToken).ConfigureAwait(false))
+#if ANDROID
+        var documentUri = GetDocumentUri(configuration);
+        if (documentUri is null)
         {
             return null;
         }
 
-        var accessToken = await AcquireAccessTokenAsync(configuration, cancellationToken).ConfigureAwait(false);
-        var file = await ResolveFileAsync(configuration, accessToken, cancellationToken).ConfigureAwait(false);
-        if (file is null)
-        {
-            return null;
-        }
-
-        return CreateRemoteState(file);
+        var snapshot = await TryReadDocumentAsync(documentUri, cancellationToken).ConfigureAwait(false);
+        return snapshot is null ? null : CreateRemoteState(snapshot);
+#else
+        throw new PlatformNotSupportedException("Die Google-Drive-Synchronisation wird nur unter Android unterstützt.");
+#endif
     }
 
     public async Task<VaultSyncDownloadResult?> DownloadAsync(VaultSyncConfiguration configuration, CancellationToken cancellationToken = default)
     {
-        if (!await IsConfiguredAsync(configuration, cancellationToken).ConfigureAwait(false))
+#if ANDROID
+        var documentUri = GetDocumentUri(configuration);
+        if (documentUri is null)
         {
             return null;
         }
 
-        var accessToken = await AcquireAccessTokenAsync(configuration, cancellationToken).ConfigureAwait(false);
-        var file = await ResolveFileAsync(configuration, accessToken, cancellationToken).ConfigureAwait(false);
-        if (file is null || string.IsNullOrWhiteSpace(file.Id))
+        var snapshot = await TryReadDocumentAsync(documentUri, cancellationToken).ConfigureAwait(false);
+        if (snapshot is null)
         {
             return null;
         }
 
-        var payload = await DownloadFileAsync(file.Id, accessToken, cancellationToken).ConfigureAwait(false);
         return new VaultSyncDownloadResult
         {
-            Payload = payload,
-            RemoteState = CreateRemoteState(file)
+            Payload = snapshot.Payload,
+            RemoteState = CreateRemoteState(snapshot)
         };
+#else
+        throw new PlatformNotSupportedException("Die Google-Drive-Synchronisation wird nur unter Android unterstützt.");
+#endif
     }
 
     public async Task UploadAsync(VaultSyncUploadRequest request, VaultSyncConfiguration configuration, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        if (!await IsConfiguredAsync(configuration, cancellationToken).ConfigureAwait(false))
+#if ANDROID
+        var documentUri = GetDocumentUri(configuration);
+        if (documentUri is null)
         {
-            throw new InvalidOperationException("Die Google-Drive-Synchronisation ist nicht vollständig konfiguriert.");
+            throw new InvalidOperationException("Es wurde keine Google-Drive-Datei für die Synchronisation ausgewählt.");
         }
 
-        var accessToken = await AcquireAccessTokenAsync(configuration, cancellationToken).ConfigureAwait(false);
-        var file = await ResolveFileAsync(configuration, accessToken, cancellationToken).ConfigureAwait(false);
-
-        if (file is not null && request.RemoteStateBeforeUpload is not null)
+        if (request.RemoteStateBeforeUpload is not null)
         {
-            var remoteHash = file.AppProperties is not null && file.AppProperties.TryGetValue(MerklePropertyKey, out var merkle)
-                ? merkle
-                : string.Empty;
-            if (!string.Equals(remoteHash, request.RemoteStateBeforeUpload.MerkleHash, StringComparison.Ordinal))
+            var existingSnapshot = await TryReadDocumentAsync(documentUri, cancellationToken).ConfigureAwait(false);
+            if (existingSnapshot is not null)
             {
-                throw new InvalidOperationException("Der entfernte Tresor wurde seit der letzten Synchronisation verändert.");
+                var existingHash = PasswordVaultService.ComputeMerkleRoot(existingSnapshot.Payload);
+                if (!string.Equals(existingHash, request.RemoteStateBeforeUpload.MerkleHash, StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException("Der entfernte Tresor wurde seit der letzten Synchronisation verändert.");
+                }
             }
         }
 
-        if (file is null || string.IsNullOrWhiteSpace(file.Id))
-        {
-            await CreateFileAsync(request, configuration, accessToken, cancellationToken).ConfigureAwait(false);
-        }
-        else
-        {
-            await UpdateFileAsync(file.Id, request, configuration, accessToken, cancellationToken).ConfigureAwait(false);
-        }
+        await WriteDocumentAsync(documentUri, request.Payload, cancellationToken).ConfigureAwait(false);
+#else
+        throw new PlatformNotSupportedException("Die Google-Drive-Synchronisation wird nur unter Android unterstützt.");
+#endif
     }
 
-    private static VaultSyncRemoteState CreateRemoteState(DriveFileMetadata file)
-    {
-        var lastModified = file.ModifiedTimeRaw is null
-            ? DateTimeOffset.UtcNow
-            : DateTimeOffset.Parse(file.ModifiedTimeRaw, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
-
-        var merkleHash = file.AppProperties is not null && file.AppProperties.TryGetValue(MerklePropertyKey, out var merkle)
-            ? merkle
-            : string.Empty;
-
-        var contentLength = 0L;
-        if (file.SizeRaw is not null && long.TryParse(file.SizeRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedSize))
+    private static VaultSyncRemoteState CreateRemoteState(DocumentSnapshot snapshot)
+        => new()
         {
-            contentLength = parsedSize;
-        }
-
-        return new VaultSyncRemoteState
-        {
-            LastModifiedUtc = lastModified,
-            MerkleHash = merkleHash,
-            ContentLength = contentLength,
-            EntityTag = file.HeadRevisionId
-        };
-    }
-
-    private async Task<string> AcquireAccessTokenAsync(VaultSyncConfiguration configuration, CancellationToken cancellationToken)
-    {
-        var parameters = new Dictionary<string, string>
-        {
-            ["client_id"] = configuration.Parameters[ClientIdParameterKey],
-            ["client_secret"] = configuration.Parameters[ClientSecretParameterKey],
-            ["refresh_token"] = configuration.Parameters[RefreshTokenParameterKey],
-            ["grant_type"] = "refresh_token"
+            LastModifiedUtc = snapshot.LastModifiedUtc,
+            MerkleHash = PasswordVaultService.ComputeMerkleRoot(snapshot.Payload),
+            ContentLength = snapshot.ContentLength,
+            EntityTag = snapshot.LastModifiedUtc.ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture)
         };
 
-        using var request = new HttpRequestMessage(HttpMethod.Post, TokenEndpoint)
-        {
-            Content = new FormUrlEncodedContent(parameters)
-        };
-
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
-        var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-        if (!response.IsSuccessStatusCode)
-        {
-            var error = JsonSerializer.Deserialize<TokenErrorResponse>(content, _jsonOptions);
-            var message = error?.ErrorDescription ?? error?.Error ?? response.ReasonPhrase ?? "Unbekannter Fehler beim Abrufen des Tokens.";
-            throw new InvalidOperationException($"Google Drive Zugriffstoken konnte nicht aktualisiert werden: {message}");
-        }
-
-        var token = JsonSerializer.Deserialize<TokenSuccessResponse>(content, _jsonOptions);
-        if (token is null || string.IsNullOrWhiteSpace(token.AccessToken))
-        {
-            throw new InvalidOperationException("Google Drive hat kein gültiges Zugriffstoken zurückgegeben.");
-        }
-
-        return token.AccessToken;
-    }
-
-    private async Task<DriveFileMetadata?> ResolveFileAsync(VaultSyncConfiguration configuration, string accessToken, CancellationToken cancellationToken)
+    private static string? GetDocumentUri(VaultSyncConfiguration configuration)
     {
-        var fileId = GetOptionalParameter(configuration, FileIdParameterKey);
-        if (!string.IsNullOrWhiteSpace(fileId))
-        {
-            var metadata = await GetFileByIdAsync(fileId!, accessToken, cancellationToken).ConfigureAwait(false);
-            if (metadata is not null)
-            {
-                return metadata;
-            }
-        }
-
-        var fileName = GetFileName(configuration);
-        var folderId = GetOptionalParameter(configuration, FolderIdParameterKey);
-        return await FindFileByNameAsync(fileName, folderId, accessToken, cancellationToken).ConfigureAwait(false);
-    }
-
-    private async Task<DriveFileMetadata?> GetFileByIdAsync(string fileId, string accessToken, CancellationToken cancellationToken)
-    {
-        var requestUri = new Uri(DriveApiBaseUri, $"files/{Uri.EscapeDataString(fileId)}?fields=id,name,modifiedTime,size,headRevisionId,appProperties&supportsAllDrives=true");
-        using var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
-        if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
-        {
-            return null;
-        }
-
-        response.EnsureSuccessStatusCode();
-        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
-        var metadata = await JsonSerializer.DeserializeAsync<DriveFileMetadata>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
-        return metadata;
-    }
-
-    private async Task<DriveFileMetadata?> FindFileByNameAsync(string fileName, string? folderId, string accessToken, CancellationToken cancellationToken)
-    {
-        var sanitizedName = fileName.Replace("'", "\\'");
-        var queryBuilder = new StringBuilder();
-        queryBuilder.Append($"name = '{sanitizedName}' and trashed = false");
-        if (!string.IsNullOrWhiteSpace(folderId))
-        {
-            var sanitizedFolderId = folderId.Replace("'", "\\'");
-            queryBuilder.Append($" and '{sanitizedFolderId}' in parents");
-        }
-
-        var requestUri = new Uri(DriveApiBaseUri, $"files?q={Uri.EscapeDataString(queryBuilder.ToString())}&fields=files(id,name,modifiedTime,size,headRevisionId,appProperties)&pageSize=1&supportsAllDrives=true&includeItemsFromAllDrives=true");
-        using var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
-        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
-        var list = await JsonSerializer.DeserializeAsync<DriveFileListResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
-        return list?.Files is { Count: > 0 } ? list.Files[0] : null;
-    }
-
-    private async Task<byte[]> DownloadFileAsync(string fileId, string accessToken, CancellationToken cancellationToken)
-    {
-        var requestUri = new Uri(DriveApiBaseUri, $"files/{Uri.EscapeDataString(fileId)}?alt=media&supportsAllDrives=true");
-        using var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-
-        using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
-        return await response.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
-    }
-
-    private async Task CreateFileAsync(VaultSyncUploadRequest request, VaultSyncConfiguration configuration, string accessToken, CancellationToken cancellationToken)
-    {
-        var metadata = BuildMetadata(configuration, request.LocalState.MerkleHash, includeParents: true);
-        var uriBuilder = new StringBuilder("files?uploadType=multipart&supportsAllDrives=true");
-        var requestUri = new Uri(DriveUploadBaseUri, uriBuilder.ToString());
-
-        using var content = CreateMultipartContent(metadata, request.Payload);
-        using var httpRequest = new HttpRequestMessage(HttpMethod.Post, requestUri)
-        {
-            Content = content
-        };
-        httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-
-        using var response = await _httpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
-    }
-
-    private async Task UpdateFileAsync(string fileId, VaultSyncUploadRequest request, VaultSyncConfiguration configuration, string accessToken, CancellationToken cancellationToken)
-    {
-        var metadata = BuildMetadata(configuration, request.LocalState.MerkleHash, includeParents: false);
-        var requestUri = new Uri(DriveUploadBaseUri, $"files/{Uri.EscapeDataString(fileId)}?uploadType=multipart&supportsAllDrives=true");
-
-        using var content = CreateMultipartContent(metadata, request.Payload);
-        using var httpRequest = new HttpRequestMessage(HttpMethod.Patch, requestUri)
-        {
-            Content = content
-        };
-        httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-
-        using var response = await _httpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
-    }
-
-    private static MultipartContent CreateMultipartContent(GoogleDriveFileMetadata metadata, byte[] payload)
-    {
-        var multipart = new MultipartContent("related");
-        var metadataJson = JsonSerializer.Serialize(metadata);
-        var metadataContent = new StringContent(metadataJson, Encoding.UTF8, "application/json");
-        multipart.Add(metadataContent);
-
-        var fileContent = new ByteArrayContent(payload);
-        fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
-        multipart.Add(fileContent);
-
-        return multipart;
-    }
-
-    private static GoogleDriveFileMetadata BuildMetadata(VaultSyncConfiguration configuration, string merkleHash, bool includeParents)
-    {
-        var metadata = new GoogleDriveFileMetadata
-        {
-            Name = GetFileName(configuration),
-            AppProperties = new Dictionary<string, string>
-            {
-                [MerklePropertyKey] = merkleHash
-            }
-        };
-
-        if (includeParents)
-        {
-            var folderId = GetOptionalParameter(configuration, FolderIdParameterKey);
-            if (!string.IsNullOrWhiteSpace(folderId))
-            {
-                metadata.Parents = new List<string> { folderId! };
-            }
-        }
-
-        return metadata;
-    }
-
-    private static string GetFileName(VaultSyncConfiguration configuration)
-    {
-        if (configuration.Parameters.TryGetValue(FileNameParameterKey, out var fileName) && !string.IsNullOrWhiteSpace(fileName))
-        {
-            return fileName.Trim();
-        }
-
-        return DefaultFileName;
-    }
-
-    private static string? GetOptionalParameter(VaultSyncConfiguration configuration, string key)
-    {
-        if (configuration.Parameters.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value))
+        if (configuration.Parameters.TryGetValue(DocumentUriParameterKey, out var value) && !string.IsNullOrWhiteSpace(value))
         {
             return value.Trim();
         }
@@ -360,60 +111,112 @@ public sealed class GoogleDriveVaultSyncProvider : IVaultSyncProvider
         return null;
     }
 
-    private sealed class TokenSuccessResponse
+#if ANDROID
+    private static async Task<DocumentSnapshot?> TryReadDocumentAsync(string documentUri, CancellationToken cancellationToken)
     {
-        [JsonPropertyName("access_token")]
-        public string AccessToken { get; set; } = string.Empty;
+        var context = Android.App.Application.Context;
+        var resolver = context?.ContentResolver;
+        if (resolver is null)
+        {
+            return null;
+        }
+
+        var uri = Android.Net.Uri.Parse(documentUri);
+        try
+        {
+            await using var stream = resolver.OpenInputStream(uri);
+            if (stream is null)
+            {
+                return null;
+            }
+
+            using var buffer = new MemoryStream();
+            await stream.CopyToAsync(buffer, 81920, cancellationToken).ConfigureAwait(false);
+            var payload = buffer.ToArray();
+
+            var metadata = QueryDocumentMetadata(resolver, uri);
+            var lastModified = metadata.LastModifiedUtc ?? DateTimeOffset.UtcNow;
+            var length = metadata.Size ?? payload.LongLength;
+
+            return new DocumentSnapshot(payload, lastModified, length);
+        }
+        catch (Java.IO.FileNotFoundException)
+        {
+            return null;
+        }
     }
 
-    private sealed class TokenErrorResponse
+    private static async Task WriteDocumentAsync(string documentUri, byte[] payload, CancellationToken cancellationToken)
     {
-        [JsonPropertyName("error")]
-        public string? Error { get; set; }
+        var context = Android.App.Application.Context;
+        var resolver = context?.ContentResolver;
+        if (resolver is null)
+        {
+            throw new InvalidOperationException("Die Google-Drive-Datei konnte nicht geöffnet werden.");
+        }
 
-        [JsonPropertyName("error_description")]
-        public string? ErrorDescription { get; set; }
+        var uri = Android.Net.Uri.Parse(documentUri);
+        try
+        {
+            await using var stream = resolver.OpenOutputStream(uri, "wt");
+            if (stream is null)
+            {
+                throw new InvalidOperationException("Die Google-Drive-Datei konnte nicht geschrieben werden.");
+            }
+
+            await stream.WriteAsync(payload.AsMemory(), cancellationToken).ConfigureAwait(false);
+            await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Java.IO.FileNotFoundException ex)
+        {
+            throw new InvalidOperationException("Die Google-Drive-Datei konnte nicht geöffnet werden.", ex);
+        }
     }
 
-    private sealed class DriveFileMetadata
+    private static DocumentMetadata QueryDocumentMetadata(Android.Content.ContentResolver resolver, Android.Net.Uri uri)
     {
-        [JsonPropertyName("id")]
-        public string? Id { get; set; }
+        var projection = new[]
+        {
+            Android.Provider.DocumentsContract.Document.ColumnLastModified,
+            Android.Provider.DocumentsContract.Document.ColumnSize
+        };
 
-        [JsonPropertyName("name")]
-        public string? Name { get; set; }
+        using var cursor = resolver.Query(uri, projection, null, null, null);
+        if (cursor is null || !cursor.MoveToFirst())
+        {
+            return new DocumentMetadata(null, null);
+        }
 
-        [JsonPropertyName("modifiedTime")]
-        public string? ModifiedTimeRaw { get; set; }
+        DateTimeOffset? lastModified = null;
+        long? size = null;
 
-        [JsonPropertyName("size")]
-        public string? SizeRaw { get; set; }
+        var lastModifiedIndex = cursor.GetColumnIndex(Android.Provider.DocumentsContract.Document.ColumnLastModified);
+        if (lastModifiedIndex >= 0 && !cursor.IsNull(lastModifiedIndex))
+        {
+            var value = cursor.GetLong(lastModifiedIndex);
+            if (value > 0)
+            {
+                lastModified = DateTimeOffset.FromUnixTimeMilliseconds(value);
+            }
+        }
 
-        [JsonPropertyName("headRevisionId")]
-        public string? HeadRevisionId { get; set; }
+        var sizeIndex = cursor.GetColumnIndex(Android.Provider.DocumentsContract.Document.ColumnSize);
+        if (sizeIndex >= 0 && !cursor.IsNull(sizeIndex))
+        {
+            var value = cursor.GetLong(sizeIndex);
+            if (value >= 0)
+            {
+                size = value;
+            }
+        }
 
-        [JsonPropertyName("appProperties")]
-        public Dictionary<string, string>? AppProperties { get; set; }
-
-        [JsonPropertyName("parents")]
-        public List<string>? Parents { get; set; }
+        return new DocumentMetadata(lastModified, size);
     }
+#endif
 
-    private sealed class DriveFileListResponse
-    {
-        [JsonPropertyName("files")]
-        public List<DriveFileMetadata> Files { get; set; } = new();
-    }
+    private sealed record DocumentSnapshot(byte[] Payload, DateTimeOffset LastModifiedUtc, long ContentLength);
 
-    private sealed class GoogleDriveFileMetadata
-    {
-        [JsonPropertyName("name")]
-        public string Name { get; set; } = DefaultFileName;
-
-        [JsonPropertyName("appProperties")]
-        public Dictionary<string, string> AppProperties { get; set; } = new();
-
-        [JsonPropertyName("parents")]
-        public List<string>? Parents { get; set; }
-    }
+#if ANDROID
+    private sealed record DocumentMetadata(DateTimeOffset? LastModifiedUtc, long? Size);
+#endif
 }

--- a/Password Phrase Producer/Services/Vault/Sync/IGoogleDriveDocumentPicker.cs
+++ b/Password Phrase Producer/Services/Vault/Sync/IGoogleDriveDocumentPicker.cs
@@ -1,0 +1,11 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Password_Phrase_Producer.Services.Vault.Sync;
+
+public interface IGoogleDriveDocumentPicker
+{
+    Task<string?> CreateDocumentAsync(string suggestedFileName, CancellationToken cancellationToken = default);
+
+    void ReleasePersistedPermission(string documentUri);
+}

--- a/Password Phrase Producer/Services/Vault/Sync/NoOpGoogleDriveDocumentPicker.cs
+++ b/Password Phrase Producer/Services/Vault/Sync/NoOpGoogleDriveDocumentPicker.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Password_Phrase_Producer.Services.Vault.Sync;
+
+public sealed class NoOpGoogleDriveDocumentPicker : IGoogleDriveDocumentPicker
+{
+    public Task<string?> CreateDocumentAsync(string suggestedFileName, CancellationToken cancellationToken = default)
+        => Task.FromException<string?>(new PlatformNotSupportedException("Die Dateiauswahl für Google Drive wird nur unter Android unterstützt."));
+
+    public void ReleasePersistedPermission(string documentUri)
+    {
+        // Nicht erforderlich auf nicht unterstützten Plattformen.
+    }
+}

--- a/Password Phrase Producer/Views/VaultPage.xaml
+++ b/Password Phrase Producer/Views/VaultPage.xaml
@@ -301,49 +301,30 @@
                         </VerticalStackLayout>
 
                         <VerticalStackLayout IsVisible="{Binding IsGoogleDriveProviderSelected}" Spacing="6">
-                            <Label Text="Google Drive Konfiguration" TextColor="#7F85B2" />
-                            <Entry
-                                Text="{Binding GoogleDriveClientId}"
-                                Placeholder="OAuth Client ID"
-                                PlaceholderColor="#7F85B2"
-                                TextColor="#CFD3FF"
-                                BackgroundColor="#1B2036" />
-                            <Entry
-                                Text="{Binding GoogleDriveClientSecret}"
-                                Placeholder="OAuth Client Secret"
-                                PlaceholderColor="#7F85B2"
-                                TextColor="#CFD3FF"
-                                BackgroundColor="#1B2036"
-                                IsPassword="True" />
-                            <Entry
-                                Text="{Binding GoogleDriveRefreshToken}"
-                                Placeholder="Refresh Token"
-                                PlaceholderColor="#7F85B2"
-                                TextColor="#CFD3FF"
-                                BackgroundColor="#1B2036"
-                                IsPassword="True" />
-                            <Entry
-                                Text="{Binding GoogleDriveFileId}"
-                                Placeholder="Datei-ID (optional)"
-                                PlaceholderColor="#7F85B2"
-                                TextColor="#CFD3FF"
-                                BackgroundColor="#1B2036" />
-                            <Entry
-                                Text="{Binding GoogleDriveFileName}"
-                                Placeholder="Dateiname (z. B. vault.json.enc)"
-                                PlaceholderColor="#7F85B2"
-                                TextColor="#CFD3FF"
-                                BackgroundColor="#1B2036" />
-                            <Entry
-                                Text="{Binding GoogleDriveFolderId}"
-                                Placeholder="Ordner-ID (optional)"
-                                PlaceholderColor="#7F85B2"
-                                TextColor="#CFD3FF"
-                                BackgroundColor="#1B2036" />
+                            <Label Text="Google Drive Synchronisation" TextColor="#7F85B2" />
                             <Label
-                                Text="Nutze einen OAuth-Client mit Drive-Berechtigung (Drive oder Drive.File). Die Datei-ID ist optional, bei leerem Feld wird anhand des Dateinamens gesucht oder neu erstellt."
+                                Text="Wähle die Zieldatei über das Android Storage Access Framework aus. Die Datei kann sich auch in Google Drive befinden."
                                 FontSize="12"
                                 TextColor="#7F85B2" />
+                            <Entry
+                                Text="{Binding GoogleDriveDocumentUri}"
+                                Placeholder="Keine Datei ausgewählt"
+                                PlaceholderColor="#7F85B2"
+                                TextColor="#CFD3FF"
+                                BackgroundColor="#1B2036"
+                                IsReadOnly="True" />
+                            <HorizontalStackLayout Spacing="12">
+                                <Button
+                                    Text="Datei auswählen"
+                                    Command="{Binding SelectGoogleDriveDocumentCommand}"
+                                    BackgroundColor="#3B4AD1"
+                                    TextColor="White" />
+                                <Button
+                                    Text="Auswahl zurücksetzen"
+                                    Command="{Binding ClearGoogleDriveDocumentCommand}"
+                                    BackgroundColor="#2D3A7C"
+                                    TextColor="White" />
+                            </HorizontalStackLayout>
                         </VerticalStackLayout>
 
                         <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">


### PR DESCRIPTION
## Summary
- replace the Google Drive sync provider with an implementation that reads and writes via a persisted Storage Access Framework document URI
- add an Android-specific document picker service plus view-model commands to select or clear the Google Drive vault file
- update the sync configuration storage and settings UI to use the SAF document URI instead of OAuth credentials

## Testing
- dotnet build *(fails: `dotnet`: command not found in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911c5fb6f94832a911d72ed883af767)