### PR TITLE
Fix Android document picker ambiguities

### DIFF
--- a/Password Phrase Producer/Platforms/Android/Services/AndroidGoogleDriveDocumentPicker.cs
+++ b/Password Phrase Producer/Platforms/Android/Services/AndroidGoogleDriveDocumentPicker.cs
@@ -4,7 +4,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Android.App;
 using Android.Content;
-using Android.Net;
 using Android.OS;
 using Android.Provider;
 using Microsoft.Maui.ApplicationModel;
@@ -37,7 +36,7 @@ public sealed class AndroidGoogleDriveDocumentPicker : IGoogleDriveDocumentPicke
 
                 activity.ActivityResult -= handler;
 
-                if (args.ResultCode == Result.Ok && args.Data?.Data is Uri uri)
+                if (args.ResultCode == Result.Ok && args.Data?.Data is Android.Net.Uri uri)
                 {
                     var takeFlags = args.Data.Flags & (ActivityFlags.GrantReadUriPermission | ActivityFlags.GrantWriteUriPermission);
                     try
@@ -93,13 +92,13 @@ public sealed class AndroidGoogleDriveDocumentPicker : IGoogleDriveDocumentPicke
             return;
         }
 
-        var resolver = (MainActivity.Current ?? Application.Context)?.ContentResolver;
+        var resolver = (MainActivity.Current ?? Android.App.Application.Context)?.ContentResolver;
         if (resolver is null)
         {
             return;
         }
 
-        var uri = Uri.Parse(documentUri);
+        var uri = Android.Net.Uri.Parse(documentUri);
         try
         {
             resolver.ReleasePersistableUriPermission(uri, ActivityFlags.GrantReadUriPermission | ActivityFlags.GrantWriteUriPermission);


### PR DESCRIPTION
## Summary
- fully qualify Android types in the Google Drive document picker
- ensure the ContentResolver lookup uses the Android application context

## Testing
- dotnet build 'Password Phrase Producer.sln' -c Release -f net9.0-android *(fails: `dotnet` not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911cf5afff8832ab32687cfa7b22370)