### PR TITLE
Fix Android namespace resolution for document picker

### DIFF
--- a/Password Phrase Producer/Platforms/Android/Services/AndroidGoogleDriveDocumentPicker.cs
+++ b/Password Phrase Producer/Platforms/Android/Services/AndroidGoogleDriveDocumentPicker.cs
@@ -2,13 +2,15 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Android.App;
-using Android.Content;
-using Android.OS;
-using Android.Provider;
+using global::Android.App;
+using global::Android.Content;
+using global::Android.OS;
+using global::Android.Provider;
 using Microsoft.Maui.ApplicationModel;
 using Password_Phrase_Producer.Services.Vault.Sync;
 using Password_Phrase_Producer;
+
+using AndroidUri = global::Android.Net.Uri;
 
 namespace Password_Phrase_Producer.Platforms.Android.Services;
 
@@ -36,7 +38,7 @@ public sealed class AndroidGoogleDriveDocumentPicker : IGoogleDriveDocumentPicke
 
                 activity.ActivityResult -= handler;
 
-                if (args.ResultCode == Result.Ok && args.Data?.Data is Android.Net.Uri uri)
+                if (args.ResultCode == Result.Ok && args.Data?.Data is AndroidUri uri)
                 {
                     var takeFlags = args.Data.Flags & (ActivityFlags.GrantReadUriPermission | ActivityFlags.GrantWriteUriPermission);
                     try
@@ -98,7 +100,7 @@ public sealed class AndroidGoogleDriveDocumentPicker : IGoogleDriveDocumentPicke
             return;
         }
 
-        var uri = Android.Net.Uri.Parse(documentUri);
+        var uri = AndroidUri.Parse(documentUri);
         try
         {
             resolver.ReleasePersistableUriPermission(uri, ActivityFlags.GrantReadUriPermission | ActivityFlags.GrantWriteUriPermission);


### PR DESCRIPTION
## Summary
- ensure Android namespace usage resolves to the platform SDK within AndroidGoogleDriveDocumentPicker
- add URI alias to avoid collisions with the app namespace during Android builds

## Testing
- not run (CI only environment)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911d9adf884832abf908eb4034ef270)