### PR TITLE
Fix Android namespace resolutions for Google Drive sync

### DIFF
--- a/Password Phrase Producer/Platforms/Android/Services/AndroidGoogleDriveDocumentPicker.cs
+++ b/Password Phrase Producer/Platforms/Android/Services/AndroidGoogleDriveDocumentPicker.cs
@@ -94,7 +94,7 @@ public sealed class AndroidGoogleDriveDocumentPicker : IGoogleDriveDocumentPicke
             return;
         }
 
-        var resolver = (MainActivity.Current ?? Android.App.Application.Context)?.ContentResolver;
+        var resolver = (MainActivity.Current ?? global::Android.App.Application.Context)?.ContentResolver;
         if (resolver is null)
         {
             return;


### PR DESCRIPTION
## Summary
- ensure the Android document picker resolves the global Android application context
- add Android type aliases in the Google Drive vault sync provider to avoid nested namespace collisions

## Testing
- not run (dotnet CLI unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911dd9f1e5c832ab542cb657bb0608f)