### PR TITLE
Add dedicated settings page for vault sync and maintenance

### DIFF
--- a/Password Phrase Producer/AppShell.xaml
+++ b/Password Phrase Producer/AppShell.xaml
@@ -24,4 +24,12 @@
             ContentTemplate="{DataTemplate views:VaultPage}" />
     </FlyoutItem>
 
+    <FlyoutItem Title="Einstellungen"
+                Route="settings"
+                FlyoutDisplayOptions="AsSingleItem">
+        <ShellContent
+            Title="Einstellungen"
+            ContentTemplate="{DataTemplate views:SettingsPage}" />
+    </FlyoutItem>
+
 </Shell>

--- a/Password Phrase Producer/MauiProgram.cs
+++ b/Password Phrase Producer/MauiProgram.cs
@@ -44,7 +44,9 @@ public static class MauiProgram
         builder.Services.AddSingleton<PasswordVaultService>();
         builder.Services.AddSingleton<IBiometricAuthenticationService, BiometricAuthenticationService>();
         builder.Services.AddTransient<VaultPageViewModel>();
+        builder.Services.AddTransient<VaultSettingsViewModel>();
         builder.Services.AddTransient<VaultPage>();
+        builder.Services.AddTransient<SettingsPage>();
         builder.Services.AddTransient<VaultEntryEditorPage>();
 
         return builder.Build();

--- a/Password Phrase Producer/ViewModels/VaultSettingsViewModel.cs
+++ b/Password Phrase Producer/ViewModels/VaultSettingsViewModel.cs
@@ -1,0 +1,798 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls;
+using Password_Phrase_Producer.Services.Security;
+using Password_Phrase_Producer.Services.Vault;
+using Password_Phrase_Producer.Services.Vault.Sync;
+
+namespace Password_Phrase_Producer.ViewModels;
+
+public class VaultSettingsViewModel : INotifyPropertyChanged
+{
+    private readonly PasswordVaultService _vaultService;
+    private readonly IBiometricAuthenticationService _biometricAuthenticationService;
+    private readonly IGoogleDriveDocumentPicker _googleDriveDocumentPicker;
+    private readonly ObservableCollection<VaultSyncProviderDescriptor> _syncProviders = new();
+    private readonly Command _selectGoogleDriveDocumentCommand;
+    private readonly Command _clearGoogleDriveDocumentCommand;
+    private readonly Command _changePasswordCommand;
+    private VaultSyncProviderDescriptor? _selectedSyncProvider;
+    private bool _isSyncEnabled;
+    private bool _isAutoSyncEnabled;
+    private bool _isSyncBusy;
+    private bool _isSyncSettingsDirty;
+    private bool _isLoadingSyncSettings;
+    private string _syncStatusMessage = "Synchronisation inaktiv.";
+    private string _fileSyncPath = string.Empty;
+    private string _s3BucketName = string.Empty;
+    private string _s3ObjectKey = "vault.json.enc";
+    private string _s3Region = string.Empty;
+    private string _s3AccessKeyId = string.Empty;
+    private string _s3SecretAccessKey = string.Empty;
+    private string? _currentS3Secret;
+    private bool _hasS3Secret;
+    private string _googleDriveDocumentUri = string.Empty;
+    private DateTimeOffset? _lastSyncUtc;
+    private VaultSyncOperation _lastSyncOperation = VaultSyncOperation.None;
+    private string? _lastSyncError;
+    private bool _isListening;
+
+    private bool _isVaultUnlocked;
+    private bool _canUseBiometric;
+    private bool _isBiometricConfigured;
+    private bool _enableBiometric;
+    private string _newMasterPassword = string.Empty;
+    private string _confirmMasterPassword = string.Empty;
+    private string? _changePasswordError;
+    private string? _changePasswordSuccess;
+    private bool _isPasswordChangeBusy;
+
+    public VaultSettingsViewModel(
+        PasswordVaultService vaultService,
+        IBiometricAuthenticationService biometricAuthenticationService,
+        IGoogleDriveDocumentPicker googleDriveDocumentPicker)
+    {
+        _vaultService = vaultService;
+        _biometricAuthenticationService = biometricAuthenticationService;
+        _googleDriveDocumentPicker = googleDriveDocumentPicker;
+        SyncProviders = _syncProviders;
+
+        SaveSyncSettingsCommand = new Command(async () => await SaveSyncSettingsAsync(), () => IsSyncSettingsDirty && !IsSyncBusy);
+        SyncNowCommand = new Command(async () => await SyncNowAsync(), () => !IsSyncBusy && IsSyncEnabled);
+        _selectGoogleDriveDocumentCommand = new Command(async () => await SelectGoogleDriveDocumentAsync(), () => !IsSyncBusy && IsGoogleDriveProviderSelected);
+        _clearGoogleDriveDocumentCommand = new Command(ClearGoogleDriveDocumentSelection, () => !IsSyncBusy && IsGoogleDriveProviderSelected && !string.IsNullOrWhiteSpace(GoogleDriveDocumentUri));
+        SelectGoogleDriveDocumentCommand = _selectGoogleDriveDocumentCommand;
+        ClearGoogleDriveDocumentCommand = _clearGoogleDriveDocumentCommand;
+
+        _changePasswordCommand = new Command(async () => await ChangeMasterPasswordAsync(), () => !IsPasswordChangeBusy && IsVaultUnlocked);
+        ChangePasswordCommand = _changePasswordCommand;
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public ObservableCollection<VaultSyncProviderDescriptor> SyncProviders { get; }
+
+    public ICommand SaveSyncSettingsCommand { get; }
+
+    public ICommand SyncNowCommand { get; }
+
+    public ICommand SelectGoogleDriveDocumentCommand { get; }
+
+    public ICommand ClearGoogleDriveDocumentCommand { get; }
+
+    public ICommand ChangePasswordCommand { get; }
+
+    public bool IsSyncEnabled
+    {
+        get => _isSyncEnabled;
+        set
+        {
+            if (SetProperty(ref _isSyncEnabled, value) && !_isLoadingSyncSettings)
+            {
+                MarkSyncSettingsDirty();
+                UpdateSyncCommandStates();
+            }
+        }
+    }
+
+    public bool IsAutoSyncEnabled
+    {
+        get => _isAutoSyncEnabled;
+        set
+        {
+            if (SetProperty(ref _isAutoSyncEnabled, value) && !_isLoadingSyncSettings)
+            {
+                MarkSyncSettingsDirty();
+                UpdateSyncCommandStates();
+            }
+        }
+    }
+
+    public bool IsSyncBusy
+    {
+        get => _isSyncBusy;
+        private set
+        {
+            if (SetProperty(ref _isSyncBusy, value))
+            {
+                UpdateSyncCommandStates();
+            }
+        }
+    }
+
+    public bool IsSyncSettingsDirty
+    {
+        get => _isSyncSettingsDirty;
+        private set
+        {
+            if (SetProperty(ref _isSyncSettingsDirty, value))
+            {
+                UpdateSyncCommandStates();
+            }
+        }
+    }
+
+    public VaultSyncProviderDescriptor? SelectedSyncProvider
+    {
+        get => _selectedSyncProvider;
+        set
+        {
+            if (SetProperty(ref _selectedSyncProvider, value) && !_isLoadingSyncSettings)
+            {
+                MarkSyncSettingsDirty();
+                OnPropertyChanged(nameof(IsS3ProviderSelected));
+                OnPropertyChanged(nameof(IsFileProviderSelected));
+                OnPropertyChanged(nameof(IsGoogleDriveProviderSelected));
+                UpdateSyncCommandStates();
+            }
+        }
+    }
+
+    public bool IsS3ProviderSelected => string.Equals(SelectedSyncProvider?.Key, S3VaultSyncProvider.ProviderKey, StringComparison.OrdinalIgnoreCase);
+
+    public bool IsFileProviderSelected => string.Equals(SelectedSyncProvider?.Key, FileSystemVaultSyncProvider.ProviderKey, StringComparison.OrdinalIgnoreCase);
+
+    public bool IsGoogleDriveProviderSelected => string.Equals(SelectedSyncProvider?.Key, GoogleDriveVaultSyncProvider.ProviderKey, StringComparison.OrdinalIgnoreCase);
+
+    public string FileSyncPath
+    {
+        get => _fileSyncPath;
+        set
+        {
+            if (SetProperty(ref _fileSyncPath, value) && !_isLoadingSyncSettings)
+            {
+                MarkSyncSettingsDirty();
+            }
+        }
+    }
+
+    public string S3BucketName
+    {
+        get => _s3BucketName;
+        set
+        {
+            if (SetProperty(ref _s3BucketName, value) && !_isLoadingSyncSettings)
+            {
+                MarkSyncSettingsDirty();
+            }
+        }
+    }
+
+    public string S3ObjectKey
+    {
+        get => _s3ObjectKey;
+        set
+        {
+            if (SetProperty(ref _s3ObjectKey, value) && !_isLoadingSyncSettings)
+            {
+                MarkSyncSettingsDirty();
+            }
+        }
+    }
+
+    public string S3Region
+    {
+        get => _s3Region;
+        set
+        {
+            if (SetProperty(ref _s3Region, value) && !_isLoadingSyncSettings)
+            {
+                MarkSyncSettingsDirty();
+            }
+        }
+    }
+
+    public string S3AccessKeyId
+    {
+        get => _s3AccessKeyId;
+        set
+        {
+            if (SetProperty(ref _s3AccessKeyId, value) && !_isLoadingSyncSettings)
+            {
+                MarkSyncSettingsDirty();
+            }
+        }
+    }
+
+    public string S3SecretAccessKey
+    {
+        get => _s3SecretAccessKey;
+        set
+        {
+            if (SetProperty(ref _s3SecretAccessKey, value) && !_isLoadingSyncSettings)
+            {
+                MarkSyncSettingsDirty();
+            }
+        }
+    }
+
+    public bool HasS3Secret
+    {
+        get => _hasS3Secret;
+        private set => SetProperty(ref _hasS3Secret, value);
+    }
+
+    public string GoogleDriveDocumentUri
+    {
+        get => _googleDriveDocumentUri;
+        set
+        {
+            if (SetProperty(ref _googleDriveDocumentUri, value))
+            {
+                if (!_isLoadingSyncSettings)
+                {
+                    MarkSyncSettingsDirty();
+                }
+
+                UpdateSyncCommandStates();
+            }
+        }
+    }
+
+    public DateTimeOffset? LastSyncUtc
+    {
+        get => _lastSyncUtc;
+        private set => SetProperty(ref _lastSyncUtc, value);
+    }
+
+    public string SyncStatusMessage
+    {
+        get => _syncStatusMessage;
+        private set => SetProperty(ref _syncStatusMessage, value);
+    }
+
+    public bool IsVaultUnlocked
+    {
+        get => _isVaultUnlocked;
+        private set
+        {
+            if (SetProperty(ref _isVaultUnlocked, value))
+            {
+                UpdatePasswordCommandState();
+            }
+        }
+    }
+
+    public bool CanUseBiometric
+    {
+        get => _canUseBiometric;
+        private set => SetProperty(ref _canUseBiometric, value);
+    }
+
+    public bool IsBiometricConfigured
+    {
+        get => _isBiometricConfigured;
+        private set => SetProperty(ref _isBiometricConfigured, value);
+    }
+
+    public bool EnableBiometric
+    {
+        get => _enableBiometric;
+        set => SetProperty(ref _enableBiometric, value);
+    }
+
+    public string NewMasterPassword
+    {
+        get => _newMasterPassword;
+        set
+        {
+            if (SetProperty(ref _newMasterPassword, value))
+            {
+                if (!string.IsNullOrEmpty(ChangePasswordError))
+                {
+                    ChangePasswordError = null;
+                }
+
+                if (!string.IsNullOrEmpty(ChangePasswordSuccess))
+                {
+                    ChangePasswordSuccess = null;
+                }
+            }
+        }
+    }
+
+    public string ConfirmMasterPassword
+    {
+        get => _confirmMasterPassword;
+        set
+        {
+            if (SetProperty(ref _confirmMasterPassword, value))
+            {
+                if (!string.IsNullOrEmpty(ChangePasswordError))
+                {
+                    ChangePasswordError = null;
+                }
+
+                if (!string.IsNullOrEmpty(ChangePasswordSuccess))
+                {
+                    ChangePasswordSuccess = null;
+                }
+            }
+        }
+    }
+
+    public string? ChangePasswordError
+    {
+        get => _changePasswordError;
+        private set => SetProperty(ref _changePasswordError, value);
+    }
+
+    public string? ChangePasswordSuccess
+    {
+        get => _changePasswordSuccess;
+        private set => SetProperty(ref _changePasswordSuccess, value);
+    }
+
+    public bool IsPasswordChangeBusy
+    {
+        get => _isPasswordChangeBusy;
+        private set
+        {
+            if (SetProperty(ref _isPasswordChangeBusy, value))
+            {
+                UpdatePasswordCommandState();
+            }
+        }
+    }
+
+    public void Activate()
+    {
+        if (_isListening)
+        {
+            return;
+        }
+
+        MessagingCenter.Subscribe<PasswordVaultService, VaultSyncResult>(this, VaultMessages.SyncStatusChanged, OnSyncStatusChanged);
+        _isListening = true;
+    }
+
+    public void Deactivate()
+    {
+        if (!_isListening)
+        {
+            return;
+        }
+
+        MessagingCenter.Unsubscribe<PasswordVaultService, VaultSyncResult>(this, VaultMessages.SyncStatusChanged);
+        _isListening = false;
+    }
+
+    public async Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        await LoadSyncConfigurationAsync(cancellationToken).ConfigureAwait(false);
+        await RefreshVaultStateAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task RefreshVaultStateAsync(CancellationToken cancellationToken = default)
+    {
+        var unlocked = _vaultService.IsUnlocked;
+        var canUseBiometric = await _biometricAuthenticationService.IsAvailableAsync(cancellationToken).ConfigureAwait(false);
+        var biometricConfigured = canUseBiometric && await _vaultService.HasBiometricKeyAsync(cancellationToken).ConfigureAwait(false);
+
+        await MainThread.InvokeOnMainThreadAsync(() =>
+        {
+            IsVaultUnlocked = unlocked;
+            CanUseBiometric = canUseBiometric;
+            IsBiometricConfigured = biometricConfigured;
+            EnableBiometric = biometricConfigured;
+
+            if (!unlocked)
+            {
+                NewMasterPassword = string.Empty;
+                ConfirmMasterPassword = string.Empty;
+            }
+
+            ChangePasswordError = null;
+            ChangePasswordSuccess = null;
+        }).ConfigureAwait(false);
+    }
+
+    public Task<byte[]> CreateBackupAsync(CancellationToken cancellationToken = default)
+        => _vaultService.CreateBackupAsync(cancellationToken);
+
+    public Task RestoreBackupAsync(Stream backupStream, CancellationToken cancellationToken = default)
+        => _vaultService.RestoreBackupAsync(backupStream, cancellationToken);
+
+    public Task<byte[]> ExportEncryptedVaultAsync(CancellationToken cancellationToken = default)
+        => _vaultService.ExportEncryptedVaultAsync(cancellationToken);
+
+    public Task ImportEncryptedVaultAsync(Stream encryptedStream, CancellationToken cancellationToken = default)
+        => _vaultService.ImportEncryptedVaultAsync(encryptedStream, cancellationToken);
+
+    private async Task LoadSyncConfigurationAsync(CancellationToken cancellationToken = default)
+    {
+        _isLoadingSyncSettings = true;
+        try
+        {
+            var providers = _vaultService.GetAvailableSyncProviders().ToList();
+            await MainThread.InvokeOnMainThreadAsync(() =>
+            {
+                _syncProviders.Clear();
+                foreach (var provider in providers)
+                {
+                    _syncProviders.Add(provider);
+                }
+            }).ConfigureAwait(false);
+
+            var configuration = await _vaultService.GetSyncConfigurationAsync(cancellationToken).ConfigureAwait(false);
+            var status = await _vaultService.GetSyncStatusAsync(cancellationToken).ConfigureAwait(false);
+
+            configuration.Parameters.TryGetValue(FileSystemVaultSyncProvider.PathParameterKey, out var path);
+            configuration.Parameters.TryGetValue(S3VaultSyncProvider.BucketParameterKey, out var bucket);
+            configuration.Parameters.TryGetValue(S3VaultSyncProvider.ObjectKeyParameterKey, out var objectKey);
+            configuration.Parameters.TryGetValue(S3VaultSyncProvider.RegionParameterKey, out var region);
+            configuration.Parameters.TryGetValue(S3VaultSyncProvider.AccessKeyIdParameterKey, out var accessKeyId);
+            configuration.Parameters.TryGetValue(S3VaultSyncProvider.SecretAccessKeyParameterKey, out var secret);
+            configuration.Parameters.TryGetValue(GoogleDriveVaultSyncProvider.DocumentUriParameterKey, out var googleDocumentUri);
+
+            await MainThread.InvokeOnMainThreadAsync(() =>
+            {
+                SelectedSyncProvider = providers.FirstOrDefault(p => string.Equals(p.Key, configuration.ProviderKey, StringComparison.OrdinalIgnoreCase));
+                IsSyncEnabled = configuration.IsEnabled;
+                IsAutoSyncEnabled = configuration.AutoSyncEnabled;
+                FileSyncPath = path ?? string.Empty;
+                S3BucketName = bucket ?? string.Empty;
+                S3ObjectKey = string.IsNullOrWhiteSpace(objectKey) ? "vault.json.enc" : objectKey;
+                S3Region = region ?? string.Empty;
+                S3AccessKeyId = accessKeyId ?? string.Empty;
+                _currentS3Secret = secret;
+                HasS3Secret = !string.IsNullOrWhiteSpace(_currentS3Secret);
+                S3SecretAccessKey = string.Empty;
+                GoogleDriveDocumentUri = googleDocumentUri ?? string.Empty;
+                UpdateSyncStatusMessage(status, null);
+                IsSyncSettingsDirty = false;
+            }).ConfigureAwait(false);
+        }
+        finally
+        {
+            _isLoadingSyncSettings = false;
+        }
+    }
+
+    private async Task SaveSyncSettingsAsync()
+    {
+        try
+        {
+            var configuration = BuildSyncConfiguration();
+            await _vaultService.UpdateSyncConfigurationAsync(configuration).ConfigureAwait(false);
+            await MainThread.InvokeOnMainThreadAsync(() =>
+            {
+                _currentS3Secret = configuration.Parameters.TryGetValue(S3VaultSyncProvider.SecretAccessKeyParameterKey, out var secret)
+                    ? secret
+                    : null;
+                HasS3Secret = !string.IsNullOrWhiteSpace(_currentS3Secret);
+                S3SecretAccessKey = string.Empty;
+                IsSyncSettingsDirty = false;
+            }).ConfigureAwait(false);
+            await RefreshSyncStatusAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            await MainThread.InvokeOnMainThreadAsync(() =>
+            {
+                SyncStatusMessage = $"Fehler beim Speichern der Synchronisation: {ex.Message}";
+            }).ConfigureAwait(false);
+        }
+    }
+
+    private async Task SyncNowAsync()
+    {
+        if (IsSyncBusy)
+        {
+            return;
+        }
+
+        try
+        {
+            await MainThread.InvokeOnMainThreadAsync(() => IsSyncBusy = true).ConfigureAwait(false);
+            var result = await _vaultService.SynchronizeAsync().ConfigureAwait(false);
+            await RefreshSyncStatusAsync(result).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            await MainThread.InvokeOnMainThreadAsync(() =>
+            {
+                SyncStatusMessage = $"Fehler bei der Synchronisation: {ex.Message}";
+            }).ConfigureAwait(false);
+        }
+        finally
+        {
+            await MainThread.InvokeOnMainThreadAsync(() => IsSyncBusy = false).ConfigureAwait(false);
+        }
+    }
+
+    private VaultSyncConfiguration BuildSyncConfiguration()
+    {
+        var configuration = new VaultSyncConfiguration
+        {
+            IsEnabled = IsSyncEnabled,
+            AutoSyncEnabled = IsAutoSyncEnabled,
+            ProviderKey = SelectedSyncProvider?.Key
+        };
+
+        if (IsFileProviderSelected && !string.IsNullOrWhiteSpace(FileSyncPath))
+        {
+            configuration.Parameters[FileSystemVaultSyncProvider.PathParameterKey] = FileSyncPath.Trim();
+        }
+
+        if (IsS3ProviderSelected)
+        {
+            if (!string.IsNullOrWhiteSpace(S3BucketName))
+            {
+                configuration.Parameters[S3VaultSyncProvider.BucketParameterKey] = S3BucketName.Trim();
+            }
+
+            configuration.Parameters[S3VaultSyncProvider.ObjectKeyParameterKey] = string.IsNullOrWhiteSpace(S3ObjectKey)
+                ? "vault.json.enc"
+                : S3ObjectKey.Trim();
+
+            if (!string.IsNullOrWhiteSpace(S3Region))
+            {
+                configuration.Parameters[S3VaultSyncProvider.RegionParameterKey] = S3Region.Trim();
+            }
+
+            if (!string.IsNullOrWhiteSpace(S3AccessKeyId))
+            {
+                configuration.Parameters[S3VaultSyncProvider.AccessKeyIdParameterKey] = S3AccessKeyId.Trim();
+            }
+
+            if (!string.IsNullOrWhiteSpace(S3SecretAccessKey))
+            {
+                configuration.Parameters[S3VaultSyncProvider.SecretAccessKeyParameterKey] = S3SecretAccessKey;
+            }
+            else if (!string.IsNullOrWhiteSpace(_currentS3Secret))
+            {
+                configuration.Parameters[S3VaultSyncProvider.SecretAccessKeyParameterKey] = _currentS3Secret!;
+            }
+        }
+
+        if (IsGoogleDriveProviderSelected && !string.IsNullOrWhiteSpace(GoogleDriveDocumentUri))
+        {
+            configuration.Parameters[GoogleDriveVaultSyncProvider.DocumentUriParameterKey] = GoogleDriveDocumentUri.Trim();
+        }
+
+        return configuration;
+    }
+
+    private async Task RefreshSyncStatusAsync(VaultSyncResult? result = null, CancellationToken cancellationToken = default)
+    {
+        var status = await _vaultService.GetSyncStatusAsync(cancellationToken).ConfigureAwait(false);
+        await MainThread.InvokeOnMainThreadAsync(() => UpdateSyncStatusMessage(status, result)).ConfigureAwait(false);
+    }
+
+    private async Task SelectGoogleDriveDocumentAsync()
+    {
+        if (!IsGoogleDriveProviderSelected)
+        {
+            return;
+        }
+
+        try
+        {
+            var uri = await _googleDriveDocumentPicker.CreateDocumentAsync(GoogleDriveVaultSyncProvider.DefaultFileName).ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(uri))
+            {
+                GoogleDriveDocumentUri = uri!;
+            }
+        }
+        catch (TaskCanceledException)
+        {
+            // Auswahl wurde abgebrochen – nichts weiter zu tun.
+        }
+        catch (Exception ex)
+        {
+            await MainThread.InvokeOnMainThreadAsync(async () =>
+            {
+                var page = Application.Current?.MainPage;
+                if (page is not null)
+                {
+                    await page.DisplayAlert("Google Drive", ex.Message, "OK");
+                }
+            }).ConfigureAwait(false);
+        }
+    }
+
+    private void ClearGoogleDriveDocumentSelection()
+    {
+        if (string.IsNullOrWhiteSpace(GoogleDriveDocumentUri))
+        {
+            return;
+        }
+
+        try
+        {
+            _googleDriveDocumentPicker.ReleasePersistedPermission(GoogleDriveDocumentUri);
+        }
+        catch (Exception)
+        {
+            // Einige Provider unterstützen keine persistente Berechtigung – ignorieren.
+        }
+
+        GoogleDriveDocumentUri = string.Empty;
+    }
+
+    private async Task ChangeMasterPasswordAsync()
+    {
+        if (!IsVaultUnlocked)
+        {
+            ChangePasswordSuccess = null;
+            ChangePasswordError = "Der Tresor ist gesperrt. Bitte entsperre ihn zuerst.";
+            return;
+        }
+
+        var password = NewMasterPassword?.Trim();
+        var confirm = ConfirmMasterPassword?.Trim();
+
+        if (string.IsNullOrWhiteSpace(password))
+        {
+            ChangePasswordSuccess = null;
+            ChangePasswordError = "Bitte gib ein neues Master-Passwort ein.";
+            return;
+        }
+
+        if (!string.Equals(password, confirm, StringComparison.Ordinal))
+        {
+            ChangePasswordSuccess = null;
+            ChangePasswordError = "Die Passwörter stimmen nicht überein.";
+            return;
+        }
+
+        try
+        {
+            ChangePasswordError = null;
+            ChangePasswordSuccess = null;
+            IsPasswordChangeBusy = true;
+
+            await _vaultService.ChangeMasterPasswordAsync(password, EnableBiometric && CanUseBiometric).ConfigureAwait(false);
+
+            await MainThread.InvokeOnMainThreadAsync(() =>
+            {
+                NewMasterPassword = string.Empty;
+                ConfirmMasterPassword = string.Empty;
+                ChangePasswordSuccess = "Das Master-Passwort wurde aktualisiert.";
+                IsBiometricConfigured = EnableBiometric && CanUseBiometric;
+            }).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            await MainThread.InvokeOnMainThreadAsync(() =>
+            {
+                ChangePasswordSuccess = null;
+                ChangePasswordError = $"Fehler beim Ändern des Master-Passworts: {ex.Message}";
+            }).ConfigureAwait(false);
+        }
+        finally
+        {
+            await MainThread.InvokeOnMainThreadAsync(() =>
+            {
+                IsPasswordChangeBusy = false;
+            }).ConfigureAwait(false);
+        }
+    }
+
+    private void OnSyncStatusChanged(PasswordVaultService sender, VaultSyncResult result)
+    {
+        _ = RefreshSyncStatusAsync(result).ContinueWith(task =>
+        {
+            if (task.Exception is not null)
+            {
+                System.Diagnostics.Debug.WriteLine($"Fehler beim Aktualisieren des Sync-Status: {task.Exception}");
+            }
+        }, TaskScheduler.Default);
+    }
+
+    private void UpdateSyncStatusMessage(VaultSyncStatus status, VaultSyncResult? result)
+    {
+        LastSyncUtc = status.LastSyncUtc;
+        _lastSyncOperation = status.LastOperation;
+        _lastSyncError = result?.ErrorMessage ?? status.LastError;
+
+        var builder = new StringBuilder();
+        builder.Append("Status: ").Append(DescribeSyncOperation(status.LastOperation));
+
+        if (status.LastSyncUtc is DateTimeOffset lastSync)
+        {
+            builder.Append(" • Letzte Synchronisation: ").Append(lastSync.ToLocalTime().ToString("g"));
+        }
+
+        var error = result?.ErrorMessage ?? status.LastError;
+        if (!string.IsNullOrWhiteSpace(error))
+        {
+            builder.Append(" • Fehler: ").Append(error);
+        }
+        else if (status.RemoteState is { } remote)
+        {
+            builder.Append(" • Remote-Stand: ").Append(remote.LastModifiedUtc.ToLocalTime().ToString("g"));
+        }
+
+        SyncStatusMessage = builder.ToString();
+    }
+
+    private static string DescribeSyncOperation(VaultSyncOperation operation)
+        => operation switch
+        {
+            VaultSyncOperation.None => "Keine Synchronisation",
+            VaultSyncOperation.Disabled => "Deaktiviert",
+            VaultSyncOperation.NoProvider => "Kein Anbieter",
+            VaultSyncOperation.UpToDate => "Aktuell",
+            VaultSyncOperation.Uploaded => "Hochgeladen",
+            VaultSyncOperation.Downloaded => "Heruntergeladen",
+            VaultSyncOperation.Conflict => "Konflikt",
+            VaultSyncOperation.Error => "Fehler",
+            _ => "Unbekannt"
+        };
+
+    private void MarkSyncSettingsDirty()
+    {
+        if (_isLoadingSyncSettings)
+        {
+            return;
+        }
+
+        IsSyncSettingsDirty = true;
+    }
+
+    private void UpdateSyncCommandStates()
+    {
+        if (SaveSyncSettingsCommand is Command saveCommand)
+        {
+            MainThread.BeginInvokeOnMainThread(saveCommand.ChangeCanExecute);
+        }
+
+        if (SyncNowCommand is Command syncCommand)
+        {
+            MainThread.BeginInvokeOnMainThread(syncCommand.ChangeCanExecute);
+        }
+
+        MainThread.BeginInvokeOnMainThread(_selectGoogleDriveDocumentCommand.ChangeCanExecute);
+        MainThread.BeginInvokeOnMainThread(_clearGoogleDriveDocumentCommand.ChangeCanExecute);
+    }
+
+    private void UpdatePasswordCommandState()
+        => MainThread.BeginInvokeOnMainThread(_changePasswordCommand.ChangeCanExecute);
+
+    private bool SetProperty<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value))
+        {
+            return false;
+        }
+
+        field = value;
+        OnPropertyChanged(propertyName);
+        return true;
+    }
+
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+}

--- a/Password Phrase Producer/Views/SettingsPage.xaml
+++ b/Password Phrase Producer/Views/SettingsPage.xaml
@@ -1,0 +1,367 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    x:Class="Password_Phrase_Producer.Views.SettingsPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:converters="clr-namespace:Password_Phrase_Producer.Converters"
+    xmlns:viewmodels="clr-namespace:Password_Phrase_Producer.ViewModels"
+    Padding="0"
+    Shell.NavBarIsVisible="False">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <converters:StringNotNullOrWhiteSpaceConverter x:Key="StringNotNullOrWhiteSpaceConverter" />
+        </ResourceDictionary>
+    </ContentPage.Resources>
+
+    <ContentPage.Background>
+        <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
+            <GradientStop Color="#0F111A" Offset="0" />
+            <GradientStop Color="#151728" Offset="0.5" />
+            <GradientStop Color="#111322" Offset="1" />
+        </LinearGradientBrush>
+    </ContentPage.Background>
+
+    <Grid RowDefinitions="Auto,*">
+        <Grid
+            Padding="24,40,24,16"
+            ColumnDefinitions="Auto,*,Auto"
+            ColumnSpacing="16">
+            <Border
+                WidthRequest="52"
+                HeightRequest="52"
+                BackgroundColor="#1F2338"
+                StrokeThickness="0"
+                VerticalOptions="Center">
+                <Border.StrokeShape>
+                    <RoundRectangle CornerRadius="18" />
+                </Border.StrokeShape>
+                <Border.Shadow>
+                    <Shadow Brush="#25000000" Radius="12" Offset="0,8" />
+                </Border.Shadow>
+                <Border.GestureRecognizers>
+                    <TapGestureRecognizer Tapped="OnBackTapped" />
+                </Border.GestureRecognizers>
+                <Label
+                    Text="←"
+                    FontSize="20"
+                    HorizontalOptions="Center"
+                    VerticalOptions="Center"
+                    TextColor="#CFD3FF" />
+            </Border>
+
+            <VerticalStackLayout Grid.Column="1" VerticalOptions="Center">
+                <Label
+                    Text="Einstellungen"
+                    FontSize="28"
+                    FontAttributes="Bold"
+                    TextColor="White" />
+                <Label
+                    Text="Verwalte Synchronisation, Backups und dein Master-Passwort"
+                    FontSize="14"
+                    TextColor="#9EA3C4" />
+            </VerticalStackLayout>
+
+            <Border
+                Grid.Column="2"
+                WidthRequest="52"
+                HeightRequest="52"
+                BackgroundColor="#1F2338"
+                StrokeThickness="0"
+                HorizontalOptions="End"
+                VerticalOptions="Center">
+                <Border.StrokeShape>
+                    <RoundRectangle CornerRadius="18" />
+                </Border.StrokeShape>
+                <Border.Shadow>
+                    <Shadow Brush="#25000000" Radius="12" Offset="0,8" />
+                </Border.Shadow>
+                <Border.GestureRecognizers>
+                    <TapGestureRecognizer Tapped="OnOpenFlyoutTapped" />
+                </Border.GestureRecognizers>
+                <Label
+                    Text="☰"
+                    FontSize="20"
+                    HorizontalOptions="Center"
+                    VerticalOptions="Center"
+                    TextColor="#CFD3FF" />
+            </Border>
+        </Grid>
+
+        <ScrollView Grid.Row="1">
+            <VerticalStackLayout Padding="24,0,24,32" Spacing="24">
+                <Border
+                    BackgroundColor="#1F2338"
+                    Padding="20"
+                    StrokeThickness="0">
+                    <Border.StrokeShape>
+                        <RoundRectangle CornerRadius="22" />
+                    </Border.StrokeShape>
+                    <Border.Shadow>
+                        <Shadow Brush="#1A000000" Radius="18" Offset="0,10" />
+                    </Border.Shadow>
+                    <VerticalStackLayout Spacing="16">
+                        <Label
+                            Text="Synchronisation"
+                            FontSize="22"
+                            FontAttributes="Bold"
+                            TextColor="White" />
+                        <Label
+                            Text="{Binding SyncStatusMessage}"
+                            TextColor="#CFD3FF"
+                            FontSize="14" />
+
+                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16">
+                            <HorizontalStackLayout Spacing="10" VerticalOptions="Center">
+                                <Label Text="Sync aktiv" TextColor="#CFD3FF" />
+                                <Switch IsToggled="{Binding IsSyncEnabled}" />
+                            </HorizontalStackLayout>
+                            <HorizontalStackLayout Grid.Column="1" Spacing="10" VerticalOptions="Center">
+                                <Label Text="Auto-Sync" TextColor="#CFD3FF" />
+                                <Switch IsToggled="{Binding IsAutoSyncEnabled}" />
+                            </HorizontalStackLayout>
+                        </Grid>
+
+                        <Picker
+                            Title="Synchronisationsanbieter"
+                            ItemsSource="{Binding SyncProviders}"
+                            ItemDisplayBinding="{Binding DisplayName}"
+                            SelectedItem="{Binding SelectedSyncProvider}"
+                            TextColor="#CFD3FF"
+                            BackgroundColor="#242846" />
+
+                        <VerticalStackLayout IsVisible="{Binding IsFileProviderSelected}" Spacing="6">
+                            <Label Text="Zielpfad (z. B. Netzlaufwerk)" TextColor="#7F85B2" />
+                            <Entry
+                                Text="{Binding FileSyncPath}"
+                                Placeholder="\\\\Server\\Freigabe\\vault.json.enc"
+                                PlaceholderColor="#7F85B2"
+                                TextColor="#CFD3FF"
+                                BackgroundColor="#1B2036" />
+                        </VerticalStackLayout>
+
+                        <VerticalStackLayout IsVisible="{Binding IsS3ProviderSelected}" Spacing="6">
+                            <Label Text="Amazon S3 Konfiguration" TextColor="#7F85B2" />
+                            <Entry
+                                Text="{Binding S3BucketName}"
+                                Placeholder="Bucket"
+                                PlaceholderColor="#7F85B2"
+                                TextColor="#CFD3FF"
+                                BackgroundColor="#1B2036" />
+                            <Entry
+                                Text="{Binding S3ObjectKey}"
+                                Placeholder="Objektschlüssel"
+                                PlaceholderColor="#7F85B2"
+                                TextColor="#CFD3FF"
+                                BackgroundColor="#1B2036" />
+                            <Entry
+                                Text="{Binding S3Region}"
+                                Placeholder="Region (z. B. eu-central-1)"
+                                PlaceholderColor="#7F85B2"
+                                TextColor="#CFD3FF"
+                                BackgroundColor="#1B2036" />
+                            <Entry
+                                Text="{Binding S3AccessKeyId}"
+                                Placeholder="Access Key ID"
+                                PlaceholderColor="#7F85B2"
+                                TextColor="#CFD3FF"
+                                BackgroundColor="#1B2036" />
+                            <Entry
+                                Text="{Binding S3SecretAccessKey}"
+                                Placeholder="Secret Access Key"
+                                PlaceholderColor="#7F85B2"
+                                TextColor="#CFD3FF"
+                                IsPassword="True"
+                                BackgroundColor="#1B2036" />
+                            <Label
+                                IsVisible="{Binding HasS3Secret}"
+                                Text="Ein geheimes Zugriffstoken ist gespeichert."
+                                FontSize="12"
+                                TextColor="#63F5A8" />
+                        </VerticalStackLayout>
+
+                        <VerticalStackLayout IsVisible="{Binding IsGoogleDriveProviderSelected}" Spacing="6">
+                            <Label Text="Google Drive Synchronisation" TextColor="#7F85B2" />
+                            <Label
+                                Text="Wähle die Zieldatei über das Android Storage Access Framework aus. Die Datei kann sich auch in Google Drive befinden."
+                                FontSize="12"
+                                TextColor="#7F85B2" />
+                            <Entry
+                                Text="{Binding GoogleDriveDocumentUri}"
+                                Placeholder="Keine Datei ausgewählt"
+                                PlaceholderColor="#7F85B2"
+                                TextColor="#CFD3FF"
+                                BackgroundColor="#1B2036"
+                                IsReadOnly="True" />
+                            <HorizontalStackLayout Spacing="12">
+                                <Button
+                                    Text="Datei auswählen"
+                                    Command="{Binding SelectGoogleDriveDocumentCommand}"
+                                    BackgroundColor="#3B4AD1"
+                                    TextColor="White" />
+                                <Button
+                                    Text="Auswahl zurücksetzen"
+                                    Command="{Binding ClearGoogleDriveDocumentCommand}"
+                                    BackgroundColor="#2D3A7C"
+                                    TextColor="White" />
+                            </HorizontalStackLayout>
+                        </VerticalStackLayout>
+
+                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16">
+                            <Button
+                                Text="Sync-Einstellungen speichern"
+                                Command="{Binding SaveSyncSettingsCommand}"
+                                IsEnabled="{Binding IsSyncSettingsDirty}"
+                                BackgroundColor="#3B4AD1"
+                                TextColor="White" />
+                            <Button
+                                Grid.Column="1"
+                                Text="Jetzt synchronisieren"
+                                Command="{Binding SyncNowCommand}"
+                                BackgroundColor="#2D3A7C"
+                                TextColor="White" />
+                        </Grid>
+
+                        <ActivityIndicator
+                            IsVisible="{Binding IsSyncBusy}"
+                            IsRunning="{Binding IsSyncBusy}"
+                            Color="#63F5A8" />
+                    </VerticalStackLayout>
+                </Border>
+
+                <Border
+                    BackgroundColor="#1F2338"
+                    Padding="20"
+                    StrokeThickness="0">
+                    <Border.StrokeShape>
+                        <RoundRectangle CornerRadius="22" />
+                    </Border.StrokeShape>
+                    <Border.Shadow>
+                        <Shadow Brush="#1A000000" Radius="18" Offset="0,10" />
+                    </Border.Shadow>
+                    <VerticalStackLayout Spacing="12">
+                        <Label
+                            Text="Datensicherung"
+                            FontSize="22"
+                            FontAttributes="Bold"
+                            TextColor="White" />
+                        <Label
+                            Text="Exportiere verschlüsselte Tresordaten oder Backups und importiere vorhandene Dateien."
+                            FontSize="14"
+                            TextColor="#9EA3C4" />
+                        <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="*,*" ColumnSpacing="12" RowSpacing="12">
+                            <Button
+                                Text="Backup exportieren"
+                                Clicked="OnExportBackupClicked"
+                                BackgroundColor="#3B4AD1"
+                                TextColor="White" />
+                            <Button
+                                Grid.Column="1"
+                                Text="Backup importieren"
+                                Clicked="OnImportBackupClicked"
+                                BackgroundColor="#2D3A7C"
+                                TextColor="White" />
+                            <Button
+                                Grid.Row="1"
+                                Text="Verschlüsselten Tresor exportieren"
+                                Clicked="OnExportEncryptedClicked"
+                                BackgroundColor="#3B4AD1"
+                                TextColor="White" />
+                            <Button
+                                Grid.Row="1"
+                                Grid.Column="1"
+                                Text="Verschlüsselten Tresor importieren"
+                                Clicked="OnImportEncryptedClicked"
+                                BackgroundColor="#2D3A7C"
+                                TextColor="White" />
+                        </Grid>
+                    </VerticalStackLayout>
+                </Border>
+
+                <Border
+                    BackgroundColor="#1F2338"
+                    Padding="20"
+                    StrokeThickness="0">
+                    <Border.StrokeShape>
+                        <RoundRectangle CornerRadius="22" />
+                    </Border.StrokeShape>
+                    <Border.Shadow>
+                        <Shadow Brush="#1A000000" Radius="18" Offset="0,10" />
+                    </Border.Shadow>
+                    <VerticalStackLayout Spacing="12">
+                        <Label
+                            Text="Master-Passwort"
+                            FontSize="22"
+                            FontAttributes="Bold"
+                            TextColor="White" />
+                        <Label
+                            Text="Der Tresor muss entsperrt sein, um das Passwort zu ändern."
+                            TextColor="#9EA3C4"
+                            FontSize="14">
+                            <Label.Triggers>
+                                <DataTrigger TargetType="Label" Binding="{Binding IsVaultUnlocked}" Value="True">
+                                    <Setter Property="IsVisible" Value="False" />
+                                </DataTrigger>
+                            </Label.Triggers>
+                        </Label>
+
+                        <Entry
+                            Text="{Binding NewMasterPassword}"
+                            Placeholder="Neues Master-Passwort"
+                            PlaceholderColor="#7F85B2"
+                            TextColor="White"
+                            BackgroundColor="#1B2036"
+                            IsPassword="True"
+                            IsEnabled="{Binding IsVaultUnlocked}" />
+                        <Entry
+                            Text="{Binding ConfirmMasterPassword}"
+                            Placeholder="Passwort bestätigen"
+                            PlaceholderColor="#7F85B2"
+                            TextColor="White"
+                            BackgroundColor="#1B2036"
+                            IsPassword="True"
+                            IsEnabled="{Binding IsVaultUnlocked}" />
+
+                        <Grid ColumnDefinitions="Auto,*" IsVisible="{Binding CanUseBiometric}">
+                            <Switch
+                                Grid.Column="0"
+                                IsToggled="{Binding EnableBiometric}"
+                                IsEnabled="{Binding IsVaultUnlocked}" />
+                            <Label
+                                Grid.Column="1"
+                                Text="Biometrische Anmeldung speichern"
+                                FontSize="12"
+                                TextColor="#D7DBF7"
+                                Margin="12,0,0,0"
+                                VerticalOptions="Center"
+                                LineBreakMode="WordWrap" />
+                        </Grid>
+
+                        <Label
+                            Text="{Binding ChangePasswordError}"
+                            TextColor="#FF9A9A"
+                            FontSize="12"
+                            IsVisible="{Binding ChangePasswordError, Converter={StaticResource StringNotNullOrWhiteSpaceConverter}}" />
+                        <Label
+                            Text="{Binding ChangePasswordSuccess}"
+                            TextColor="#63F5A8"
+                            FontSize="12"
+                            IsVisible="{Binding ChangePasswordSuccess, Converter={StaticResource StringNotNullOrWhiteSpaceConverter}}" />
+
+                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16" VerticalOptions="Center">
+                            <Button
+                                Text="Passwort aktualisieren"
+                                Command="{Binding ChangePasswordCommand}"
+                                BackgroundColor="#3B4AD1"
+                                TextColor="White" />
+                            <ActivityIndicator
+                                Grid.Column="1"
+                                IsRunning="{Binding IsPasswordChangeBusy}"
+                                IsVisible="{Binding IsPasswordChangeBusy}"
+                                Color="#63F5A8" />
+                        </Grid>
+                    </VerticalStackLayout>
+                </Border>
+            </VerticalStackLayout>
+        </ScrollView>
+    </Grid>
+</ContentPage>

--- a/Password Phrase Producer/Views/SettingsPage.xaml.cs
+++ b/Password Phrase Producer/Views/SettingsPage.xaml.cs
@@ -1,0 +1,137 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Maui.Storage;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Storage;
+using Password_Phrase_Producer.ViewModels;
+
+namespace Password_Phrase_Producer.Views;
+
+public partial class SettingsPage : ContentPage
+{
+    private readonly VaultSettingsViewModel _viewModel;
+
+    public SettingsPage(VaultSettingsViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = _viewModel = viewModel;
+    }
+
+    protected override async void OnAppearing()
+    {
+        base.OnAppearing();
+        _viewModel.Activate();
+        await _viewModel.InitializeAsync();
+    }
+
+    protected override void OnDisappearing()
+    {
+        base.OnDisappearing();
+        _viewModel.Deactivate();
+    }
+
+    private async void OnBackTapped(object? sender, TappedEventArgs e)
+    {
+        if (Shell.Current is not null)
+        {
+            await Shell.Current.GoToAsync("//vault");
+        }
+    }
+
+    private void OnOpenFlyoutTapped(object? sender, TappedEventArgs e)
+    {
+        if (Shell.Current is not null)
+        {
+            Shell.Current.FlyoutIsPresented = true;
+        }
+    }
+
+    private async void OnExportBackupClicked(object? sender, EventArgs e)
+        => await ExecuteSettingsActionAsync(ExportBackupAsync);
+
+    private async void OnImportBackupClicked(object? sender, EventArgs e)
+        => await ExecuteSettingsActionAsync(async () =>
+        {
+            await ImportBackupAsync();
+            await _viewModel.RefreshVaultStateAsync();
+        });
+
+    private async void OnExportEncryptedClicked(object? sender, EventArgs e)
+        => await ExecuteSettingsActionAsync(ExportEncryptedAsync);
+
+    private async void OnImportEncryptedClicked(object? sender, EventArgs e)
+        => await ExecuteSettingsActionAsync(async () =>
+        {
+            await ImportEncryptedAsync();
+            await _viewModel.RefreshVaultStateAsync();
+        });
+
+    private async Task ExportBackupAsync()
+    {
+        var backupBytes = await _viewModel.CreateBackupAsync();
+        await using var stream = new MemoryStream(backupBytes);
+        var result = await FileSaver.Default.SaveAsync("vault-backup.json", stream, CancellationToken.None);
+        if (!result.IsSuccessful && result.Exception is not null)
+        {
+            throw new InvalidOperationException(result.Exception.Message, result.Exception);
+        }
+    }
+
+    private async Task ImportBackupAsync()
+    {
+        var file = await FilePicker.Default.PickAsync(new PickOptions
+        {
+            PickerTitle = "Backup auswählen"
+        });
+
+        if (file is null)
+        {
+            return;
+        }
+
+        await using var stream = await file.OpenReadAsync();
+        await _viewModel.RestoreBackupAsync(stream);
+    }
+
+    private async Task ExportEncryptedAsync()
+    {
+        var bytes = await _viewModel.ExportEncryptedVaultAsync();
+        await using var stream = new MemoryStream(bytes);
+        var result = await FileSaver.Default.SaveAsync("vault.json.enc", stream, CancellationToken.None);
+        if (!result.IsSuccessful && result.Exception is not null)
+        {
+            throw new InvalidOperationException(result.Exception.Message, result.Exception);
+        }
+    }
+
+    private async Task ImportEncryptedAsync()
+    {
+        var file = await FilePicker.Default.PickAsync(new PickOptions
+        {
+            PickerTitle = "Verschlüsselte Tresordatei auswählen"
+        });
+
+        if (file is null)
+        {
+            return;
+        }
+
+        await using var stream = await file.OpenReadAsync();
+        await _viewModel.ImportEncryptedVaultAsync(stream);
+    }
+
+    private async Task ExecuteSettingsActionAsync(Func<Task> action)
+    {
+        try
+        {
+            await action();
+        }
+        catch (Exception ex)
+        {
+            await DisplayAlert("Fehler", ex.Message, "OK");
+        }
+    }
+}

--- a/Password Phrase Producer/Views/VaultPage.xaml
+++ b/Password Phrase Producer/Views/VaultPage.xaml
@@ -28,7 +28,7 @@
             <Grid
                 Padding="24,40,24,16"
                 RowSpacing="12"
-                RowDefinitions="Auto,Auto,Auto">
+                RowDefinitions="Auto,Auto">
                 <Grid
                     ColumnDefinitions="Auto,*,Auto,Auto,Auto"
                     ColumnSpacing="16"
@@ -97,7 +97,7 @@
                             <Shadow Brush="#25000000" Radius="12" Offset="0,8" />
                         </Border.Shadow>
                         <Border.GestureRecognizers>
-                            <TapGestureRecognizer Tapped="OnVaultActionsTapped" />
+                            <TapGestureRecognizer Tapped="OnSettingsTapped" />
                         </Border.GestureRecognizers>
                         <Label
                             Text="⚙"
@@ -211,143 +211,6 @@
                         </Grid>
                     </Border>
                 </Grid>
-                <Border
-                    Grid.Row="2"
-                    BackgroundColor="#1F2338"
-                    StrokeThickness="0"
-                    Padding="16"
-                    HorizontalOptions="Fill"
-                    VerticalOptions="Start">
-                    <Border.StrokeShape>
-                        <RoundRectangle CornerRadius="20" />
-                    </Border.StrokeShape>
-                    <Border.Shadow>
-                        <Shadow Brush="#1A000000" Radius="12" Offset="0,8" />
-                    </Border.Shadow>
-                    <VerticalStackLayout Spacing="12">
-                        <Label
-                            Text="{Binding SyncStatusMessage}"
-                            TextColor="#CFD3FF"
-                            FontAttributes="Bold"
-                            FontSize="14" />
-
-                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
-                            <HorizontalStackLayout Spacing="8" VerticalOptions="Center">
-                                <Label Text="Sync aktiv" TextColor="#CFD3FF" />
-                                <Switch IsToggled="{Binding IsSyncEnabled}" />
-                            </HorizontalStackLayout>
-                            <HorizontalStackLayout Grid.Column="1" Spacing="8" VerticalOptions="Center">
-                                <Label Text="Auto-Sync" TextColor="#CFD3FF" />
-                                <Switch IsToggled="{Binding IsAutoSyncEnabled}" />
-                            </HorizontalStackLayout>
-                        </Grid>
-
-                        <Picker
-                            Title="Synchronisationsanbieter"
-                            ItemsSource="{Binding SyncProviders}"
-                            ItemDisplayBinding="{Binding DisplayName}"
-                            SelectedItem="{Binding SelectedSyncProvider}"
-                            TextColor="#CFD3FF"
-                            BackgroundColor="#242846" />
-
-                        <VerticalStackLayout IsVisible="{Binding IsFileProviderSelected}" Spacing="6">
-                            <Label Text="Zielpfad (z. B. Netzlaufwerk)" TextColor="#7F85B2" />
-                            <Entry
-                                Text="{Binding FileSyncPath}"
-                                Placeholder="\\\\Server\\Freigabe\\vault.json.enc"
-                                PlaceholderColor="#7F85B2"
-                                TextColor="#CFD3FF"
-                                BackgroundColor="#1B2036" />
-                        </VerticalStackLayout>
-
-                        <VerticalStackLayout IsVisible="{Binding IsS3ProviderSelected}" Spacing="6">
-                            <Label Text="Amazon S3 Konfiguration" TextColor="#7F85B2" />
-                            <Entry
-                                Text="{Binding S3BucketName}"
-                                Placeholder="Bucket"
-                                PlaceholderColor="#7F85B2"
-                                TextColor="#CFD3FF"
-                                BackgroundColor="#1B2036" />
-                            <Entry
-                                Text="{Binding S3ObjectKey}"
-                                Placeholder="Objektschlüssel"
-                                PlaceholderColor="#7F85B2"
-                                TextColor="#CFD3FF"
-                                BackgroundColor="#1B2036" />
-                            <Entry
-                                Text="{Binding S3Region}"
-                                Placeholder="Region (z. B. eu-central-1)"
-                                PlaceholderColor="#7F85B2"
-                                TextColor="#CFD3FF"
-                                BackgroundColor="#1B2036" />
-                            <Entry
-                                Text="{Binding S3AccessKeyId}"
-                                Placeholder="Access Key ID"
-                                PlaceholderColor="#7F85B2"
-                                TextColor="#CFD3FF"
-                                BackgroundColor="#1B2036" />
-                            <Entry
-                                Text="{Binding S3SecretAccessKey}"
-                                Placeholder="Secret Access Key"
-                                PlaceholderColor="#7F85B2"
-                                TextColor="#CFD3FF"
-                                IsPassword="True"
-                                BackgroundColor="#1B2036" />
-                            <Label
-                                IsVisible="{Binding HasS3Secret}"
-                                Text="Ein geheimes Zugriffstoken ist gespeichert."
-                                FontSize="12"
-                                TextColor="#63F5A8" />
-                        </VerticalStackLayout>
-
-                        <VerticalStackLayout IsVisible="{Binding IsGoogleDriveProviderSelected}" Spacing="6">
-                            <Label Text="Google Drive Synchronisation" TextColor="#7F85B2" />
-                            <Label
-                                Text="Wähle die Zieldatei über das Android Storage Access Framework aus. Die Datei kann sich auch in Google Drive befinden."
-                                FontSize="12"
-                                TextColor="#7F85B2" />
-                            <Entry
-                                Text="{Binding GoogleDriveDocumentUri}"
-                                Placeholder="Keine Datei ausgewählt"
-                                PlaceholderColor="#7F85B2"
-                                TextColor="#CFD3FF"
-                                BackgroundColor="#1B2036"
-                                IsReadOnly="True" />
-                            <HorizontalStackLayout Spacing="12">
-                                <Button
-                                    Text="Datei auswählen"
-                                    Command="{Binding SelectGoogleDriveDocumentCommand}"
-                                    BackgroundColor="#3B4AD1"
-                                    TextColor="White" />
-                                <Button
-                                    Text="Auswahl zurücksetzen"
-                                    Command="{Binding ClearGoogleDriveDocumentCommand}"
-                                    BackgroundColor="#2D3A7C"
-                                    TextColor="White" />
-                            </HorizontalStackLayout>
-                        </VerticalStackLayout>
-
-                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
-                            <Button
-                                Text="Sync-Einstellungen speichern"
-                                Command="{Binding SaveSyncSettingsCommand}"
-                                IsEnabled="{Binding IsSyncSettingsDirty}"
-                                BackgroundColor="#3B4AD1"
-                                TextColor="White" />
-                            <Button
-                                Grid.Column="1"
-                                Text="Jetzt synchronisieren"
-                                Command="{Binding SyncNowCommand}"
-                                BackgroundColor="#2D3A7C"
-                                TextColor="White" />
-                        </Grid>
-
-                        <ActivityIndicator
-                            IsVisible="{Binding IsSyncBusy}"
-                            IsRunning="{Binding IsSyncBusy}"
-                            Color="#63F5A8" />
-                    </VerticalStackLayout>
-                </Border>
             </Grid>
 
             <CollectionView
@@ -728,6 +591,15 @@
                             FontSize="14"
                             TextColor="#C4C8E8"
                             HorizontalTextAlignment="Center" />
+                        <Button
+                            Text="Einstellungen öffnen"
+                            Clicked="OnSettingsButtonClicked"
+                            BackgroundColor="#1F243C"
+                            TextColor="#D7DBF7"
+                            CornerRadius="18"
+                            HeightRequest="48"
+                            Padding="18,12"
+                            Margin="0,12,0,0" />
                     </VerticalStackLayout>
 
                     <VerticalStackLayout Spacing="14">

--- a/Password Phrase Producer/Views/VaultPage.xaml.cs
+++ b/Password Phrase Producer/Views/VaultPage.xaml.cs
@@ -9,14 +9,9 @@ using System.Threading;
 using CommunityToolkit.Maui.Views;
 using CommunityToolkit.Maui.Storage;
 using Microsoft.Maui.ApplicationModel;
-using Microsoft.Maui.Controls;
 using Microsoft.Maui.ApplicationModel.DataTransfer;
+using Microsoft.Maui.Controls;
 using Microsoft.Maui.Storage;
-#if WINDOWS
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
-using WinUIFlyoutBase = Microsoft.UI.Xaml.Controls.Primitives.FlyoutBase;
-#endif
 using Password_Phrase_Producer.Models;
 using Password_Phrase_Producer.Services.Vault;
 using Password_Phrase_Producer.ViewModels;
@@ -30,17 +25,11 @@ public partial class VaultPage : ContentPage
     private int _modalDepth;
     private PendingVaultEntryRequest? _pendingVaultRequest;
     private bool _isSubscribedToUnlockChanges;
-#if WINDOWS
-    private readonly Microsoft.UI.Xaml.Controls.MenuFlyout _vaultActionsFlyout;
-#endif
 
     public VaultPage(VaultPageViewModel viewModel)
     {
         InitializeComponent();
         BindingContext = _viewModel = viewModel;
-#if WINDOWS
-        _vaultActionsFlyout = CreateVaultActionsFlyout();
-#endif
     }
 
     protected override async void OnAppearing()
@@ -366,52 +355,20 @@ public partial class VaultPage : ContentPage
         }
     }
 
-    private async void OnVaultActionsTapped(object? sender, TappedEventArgs e)
+    private async void OnSettingsTapped(object? sender, TappedEventArgs e)
+        => await NavigateToSettingsAsync();
+
+    private async void OnSettingsButtonClicked(object? sender, EventArgs e)
+        => await NavigateToSettingsAsync();
+
+    private static async Task NavigateToSettingsAsync()
     {
-#if WINDOWS
-        if (sender is Element element && element.Handler?.PlatformView is Microsoft.UI.Xaml.FrameworkElement frameworkElement)
+        if (Shell.Current is null)
         {
-            WinUIFlyoutBase.SetAttachedFlyout(frameworkElement, _vaultActionsFlyout);
-            WinUIFlyoutBase.ShowAttachedFlyout(frameworkElement);
+            return;
         }
-#else
-        const string exportBackup = "Backup exportieren";
-        const string importBackup = "Backup importieren";
-        const string exportEncrypted = "Verschlüsselten Tresor exportieren";
-        const string importEncrypted = "Verschlüsselten Tresor importieren";
-        const string changePassword = "Master-Passwort ändern";
 
-        var options = new List<ActionSheetPopupOption>
-        {
-            new(exportBackup, exportBackup),
-            new(importBackup, importBackup),
-            new(exportEncrypted, exportEncrypted),
-            new(importEncrypted, importEncrypted),
-            new(changePassword, changePassword)
-        };
-
-        var popup = new ActionSheetPopup("Aktionen", options, cancelText: "Abbrechen");
-        var selection = await this.ShowPopupAsync(popup) as string;
-
-        switch (selection)
-        {
-            case exportBackup:
-                OnExportBackupClicked(sender, EventArgs.Empty);
-                break;
-            case importBackup:
-                OnImportBackupClicked(sender, EventArgs.Empty);
-                break;
-            case exportEncrypted:
-                OnExportEncryptedClicked(sender, EventArgs.Empty);
-                break;
-            case importEncrypted:
-                OnImportEncryptedClicked(sender, EventArgs.Empty);
-                break;
-            case changePassword:
-                OnChangePasswordMenuItemClicked(sender, EventArgs.Empty);
-                break;
-        }
-#endif
+        await Shell.Current.GoToAsync("//settings");
     }
 
     private async void OnCategoryFilterTapped(object? sender, TappedEventArgs e)
@@ -445,26 +402,6 @@ public partial class VaultPage : ContentPage
             }
         }
     }
-
-#if WINDOWS
-    private Microsoft.UI.Xaml.Controls.MenuFlyout CreateVaultActionsFlyout()
-    {
-        var flyout = new Microsoft.UI.Xaml.Controls.MenuFlyout();
-        flyout.Items.Add(CreateMenuFlyoutItem("Backup exportieren", () => OnExportBackupClicked(this, EventArgs.Empty)));
-        flyout.Items.Add(CreateMenuFlyoutItem("Backup importieren", () => OnImportBackupClicked(this, EventArgs.Empty)));
-        flyout.Items.Add(CreateMenuFlyoutItem("Verschlüsselten Tresor exportieren", () => OnExportEncryptedClicked(this, EventArgs.Empty)));
-        flyout.Items.Add(CreateMenuFlyoutItem("Verschlüsselten Tresor importieren", () => OnImportEncryptedClicked(this, EventArgs.Empty)));
-        flyout.Items.Add(CreateMenuFlyoutItem("Master-Passwort ändern", () => OnChangePasswordMenuItemClicked(this, EventArgs.Empty)));
-        return flyout;
-    }
-
-    private static Microsoft.UI.Xaml.Controls.MenuFlyoutItem CreateMenuFlyoutItem(string text, Action onClick)
-    {
-        var item = new Microsoft.UI.Xaml.Controls.MenuFlyoutItem { Text = text };
-        item.Click += (_, _) => onClick();
-        return item;
-    }
-#endif
 
     private async void OnExportBackupClicked(object? sender, EventArgs e)
         => await ExecuteVaultActionAsync(ExportBackupAsync);


### PR DESCRIPTION
## Summary
- add a dedicated settings page for configuring synchronisation, backups, and master password management
- refactor the vault page to point to the new settings experience and keep settings accessible while locked
- introduce a vault settings view model to encapsulate sync, backup, and password change logic

## Testing
- not run (dotnet CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911e898b500832a8bfae35d3d863da8)