### PR TITLE
Persist vault metadata for cross-device sync

### DIFF
--- a/Password Phrase Producer/Models/EncryptedVaultFileDto.cs
+++ b/Password Phrase Producer/Models/EncryptedVaultFileDto.cs
@@ -1,0 +1,23 @@
+using System.Text.Json.Serialization;
+
+namespace Password_Phrase_Producer.Models;
+
+public sealed class EncryptedVaultFileDto
+{
+    [JsonPropertyName("version")]
+    public int Version { get; set; } = 1;
+
+    [JsonPropertyName("cipherText")]
+    public string CipherText { get; set; } = string.Empty;
+
+    [JsonPropertyName("passwordSalt")]
+    public string? PasswordSalt { get; set; }
+        = string.Empty;
+
+    [JsonPropertyName("passwordVerifier")]
+    public string? PasswordVerifier { get; set; }
+        = string.Empty;
+
+    [JsonPropertyName("pbkdf2Iterations")]
+    public int? Pbkdf2Iterations { get; set; } = 200_000;
+}


### PR DESCRIPTION
## Summary
- embed master password metadata inside the encrypted vault file so it can travel with sync/download payloads
- hydrate secure storage from synced/imported vault metadata and convert legacy vault files on demand
- add a DTO for the encrypted vault container format used in storage and synchronization

## Testing
- dotnet build (fails: command not found)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911fd3b73a8832a8de7da9726211b4c)