### PR TITLE
Improve sync setup UX and add auto-sync summary

### DIFF
--- a/Password Phrase Producer/Services/Vault/Sync/VaultSyncModels.cs
+++ b/Password Phrase Producer/Services/Vault/Sync/VaultSyncModels.cs
@@ -92,4 +92,6 @@ public sealed class VaultSyncStatus
     public string? LastError { get; set; }
 
     public VaultSyncRemoteState? RemoteState { get; set; }
+
+    public DateTimeOffset? NextAutoSyncUtc { get; set; }
 }

--- a/Password Phrase Producer/Views/SettingsPage.xaml
+++ b/Password Phrase Producer/Views/SettingsPage.xaml
@@ -105,75 +105,152 @@
                             FontSize="22"
                             FontAttributes="Bold"
                             TextColor="White" />
-                        <Label
-                            Text="{Binding SyncStatusMessage}"
-                            TextColor="#CFD3FF"
-                            FontSize="14" />
 
-                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16">
-                            <HorizontalStackLayout Spacing="10" VerticalOptions="Center">
-                                <Label Text="Sync aktiv" TextColor="#CFD3FF" />
-                                <Switch IsToggled="{Binding IsSyncEnabled}" />
-                            </HorizontalStackLayout>
-                            <HorizontalStackLayout Grid.Column="1" Spacing="10" VerticalOptions="Center">
-                                <Label Text="Auto-Sync" TextColor="#CFD3FF" />
-                                <Switch IsToggled="{Binding IsAutoSyncEnabled}" />
-                            </HorizontalStackLayout>
-                        </Grid>
-
-                        <Picker
-                            Title="Synchronisationsanbieter"
-                            ItemsSource="{Binding SyncProviders}"
-                            ItemDisplayBinding="{Binding DisplayName}"
-                            SelectedItem="{Binding SelectedSyncProvider}"
-                            TextColor="#CFD3FF"
-                            BackgroundColor="#242846" />
-
-                        <VerticalStackLayout IsVisible="{Binding IsFileProviderSelected}" Spacing="6">
-                            <Label Text="Zielpfad (z. B. Netzlaufwerk)" TextColor="#7F85B2" />
-                            <Entry
-                                Text="{Binding FileSyncPath}"
-                                Placeholder="\\\\Server\\Freigabe\\vault.json.enc"
-                                PlaceholderColor="#7F85B2"
-                                TextColor="#CFD3FF"
-                                BackgroundColor="#1B2036" />
-                        </VerticalStackLayout>
-
-                        <VerticalStackLayout IsVisible="{Binding IsGoogleDriveProviderSelected}" Spacing="6">
-                            <Label Text="Google Drive Synchronisation" TextColor="#7F85B2" />
+                        <VerticalStackLayout IsVisible="{Binding IsSyncSummaryVisible}" Spacing="12">
                             <Label
-                                Text="Erstelle eine neue Tresordatei oder verknüpfe eine bestehende Datei über das Android Storage Access Framework."
-                                FontSize="12"
-                                TextColor="#7F85B2" />
+                                Text="{Binding SyncSummaryProviderName}"
+                                FontSize="20"
+                                FontAttributes="Bold"
+                                TextColor="White" />
                             <Label
-                                Text="Nach der Auswahl kannst du den Tresor jederzeit über Google Drive auf anderen Geräten synchronisieren."
-                                FontSize="12"
-                                TextColor="#7F85B2" />
-                            <Entry
-                                Text="{Binding GoogleDriveDocumentUri}"
-                                Placeholder="Keine Datei ausgewählt"
-                                PlaceholderColor="#7F85B2"
+                                Text="{Binding SyncSummaryConnectionDetail}"
                                 TextColor="#CFD3FF"
-                                BackgroundColor="#1B2036"
-                                IsReadOnly="True" />
+                                FontSize="14" />
+                            <Label
+                                Text="{Binding SyncSummaryLastSync}"
+                                TextColor="#CFD3FF"
+                                FontSize="14" />
+                            <Label
+                                Text="{Binding SyncSummaryNextSync}"
+                                TextColor="#CFD3FF"
+                                FontSize="14" />
+                            <Label
+                                Text="{Binding SyncSummaryRemoteInfo}"
+                                TextColor="#9EA3C4"
+                                FontSize="12" />
+                            <Label
+                                Text="{Binding SyncStatusMessage}"
+                                TextColor="#9EA3C4"
+                                FontSize="12" />
                             <HorizontalStackLayout Spacing="12">
                                 <Button
-                                    Text="Datei auswählen"
-                                    Command="{Binding SelectGoogleDriveDocumentCommand}"
-                                    BackgroundColor="#3B4AD1"
-                                    TextColor="White" />
-                                <Button
-                                    Text="Auswahl zurücksetzen"
-                                    Command="{Binding ClearGoogleDriveDocumentCommand}"
+                                    Text="Jetzt synchronisieren"
+                                    Command="{Binding SyncNowCommand}"
                                     BackgroundColor="#2D3A7C"
                                     TextColor="White" />
+                                <Button
+                                    Text="Bearbeiten"
+                                    Command="{Binding EditSyncSettingsCommand}"
+                                    BackgroundColor="#3B4AD1"
+                                    TextColor="White" />
                             </HorizontalStackLayout>
-                            <VerticalStackLayout IsVisible="{Binding IsRemotePasswordRequired}" Spacing="6">
-                                <Label Text="Remote-Passwort" TextColor="#7F85B2" />
+                        </VerticalStackLayout>
+
+                        <VerticalStackLayout IsVisible="{Binding IsSyncSetupVisible}" Spacing="16">
+                            <Label
+                                Text="So richtest du die Synchronisation ein:"
+                                TextColor="#CFD3FF"
+                                FontSize="14" />
+
+                            <VerticalStackLayout Spacing="6">
                                 <Label
-                                    Text="Vergib ein separates Passwort für die verschlüsselten Cloud-Daten, um Verwechslungen mit dem lokalen Tresor zu vermeiden."
+                                    Text="Schritt 1: Synchronisation aktivieren"
+                                    TextColor="White"
+                                    FontAttributes="Bold" />
+                                <Label
+                                    Text="Schalte die Synchronisation ein und aktiviere bei Bedarf den Auto-Sync, damit dein Tresor alle 15 Minuten automatisch abgeglichen wird."
+                                    TextColor="#9EA3C4"
+                                    FontSize="12" />
+                                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16">
+                                    <HorizontalStackLayout Spacing="10" VerticalOptions="Center">
+                                        <Label Text="Sync aktiv" TextColor="#CFD3FF" />
+                                        <Switch IsToggled="{Binding IsSyncEnabled}" />
+                                    </HorizontalStackLayout>
+                                    <HorizontalStackLayout Grid.Column="1" Spacing="10" VerticalOptions="Center">
+                                        <Label Text="Auto-Sync" TextColor="#CFD3FF" />
+                                        <Switch IsToggled="{Binding IsAutoSyncEnabled}" />
+                                    </HorizontalStackLayout>
+                                </Grid>
+                            </VerticalStackLayout>
+
+                            <VerticalStackLayout Spacing="6">
+                                <Label
+                                    Text="Schritt 2: Anbieter auswählen"
+                                    TextColor="White"
+                                    FontAttributes="Bold" />
+                                <Label
+                                    Text="Wähle, wo die verschlüsselte Tresordatei gespeichert werden soll."
+                                    TextColor="#9EA3C4"
+                                    FontSize="12" />
+                                <Picker
+                                    Title="Synchronisationsanbieter"
+                                    ItemsSource="{Binding SyncProviders}"
+                                    ItemDisplayBinding="{Binding DisplayName}"
+                                    SelectedItem="{Binding SelectedSyncProvider}"
+                                    TextColor="#CFD3FF"
+                                    BackgroundColor="#242846" />
+                            </VerticalStackLayout>
+
+                            <VerticalStackLayout IsVisible="{Binding IsFileProviderSelected}" Spacing="6">
+                                <Label
+                                    Text="Schritt 3: Datei oder Ordner festlegen"
+                                    TextColor="White"
+                                    FontAttributes="Bold" />
+                                <Label
+                                    Text="Gib den Pfad zur Datei an, z. B. ein Netzlaufwerk oder eine lokale Datei."
+                                    TextColor="#9EA3C4"
+                                    FontSize="12" />
+                                <Entry
+                                    Text="{Binding FileSyncPath}"
+                                    Placeholder="\\\\Server\\Freigabe\\vault.json.enc"
+                                    PlaceholderColor="#7F85B2"
+                                    TextColor="#CFD3FF"
+                                    BackgroundColor="#1B2036" />
+                            </VerticalStackLayout>
+
+                            <VerticalStackLayout IsVisible="{Binding IsGoogleDriveProviderSelected}" Spacing="6">
+                                <Label
+                                    Text="Schritt 3: Google-Drive-Datei verknüpfen"
+                                    TextColor="White"
+                                    FontAttributes="Bold" />
+                                <Label
+                                    Text="Erstelle eine neue Tresordatei oder verknüpfe eine bestehende Datei über das Android Storage Access Framework."
                                     FontSize="12"
-                                    TextColor="#7F85B2" />
+                                    TextColor="#9EA3C4" />
+                                <Label
+                                    Text="Nach dem Speichern wird diese Datei automatisch mit deinen Geräten synchronisiert."
+                                    FontSize="12"
+                                    TextColor="#9EA3C4" />
+                                <Entry
+                                    Text="{Binding GoogleDriveDocumentUri}"
+                                    Placeholder="Keine Datei ausgewählt"
+                                    PlaceholderColor="#7F85B2"
+                                    TextColor="#CFD3FF"
+                                    BackgroundColor="#1B2036"
+                                    IsReadOnly="True" />
+                                <HorizontalStackLayout Spacing="12">
+                                    <Button
+                                        Text="Datei auswählen"
+                                        Command="{Binding SelectGoogleDriveDocumentCommand}"
+                                        BackgroundColor="#3B4AD1"
+                                        TextColor="White" />
+                                    <Button
+                                        Text="Auswahl zurücksetzen"
+                                        Command="{Binding ClearGoogleDriveDocumentCommand}"
+                                        BackgroundColor="#2D3A7C"
+                                        TextColor="White" />
+                                </HorizontalStackLayout>
+                            </VerticalStackLayout>
+
+                            <VerticalStackLayout IsVisible="{Binding IsRemotePasswordRequired}" Spacing="6">
+                                <Label
+                                    Text="Schritt 4: Remote-Passwort festlegen"
+                                    TextColor="White"
+                                    FontAttributes="Bold" />
+                                <Label
+                                    Text="Das Passwort schützt die Cloud-Datei zusätzlich und wird sicher gespeichert, damit du es nicht bei jeder Synchronisation neu eingeben musst."
+                                    FontSize="12"
+                                    TextColor="#9EA3C4" />
                                 <Entry
                                     Text="{Binding RemotePassword}"
                                     Placeholder="Remote-Passwort"
@@ -205,22 +282,37 @@
                                     TextColor="White"
                                     IsVisible="{Binding IsRemotePasswordConfigured}" />
                             </VerticalStackLayout>
-                        </VerticalStackLayout>
 
-                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16">
-                            <Button
-                                Text="Sync-Einstellungen speichern"
-                                Command="{Binding SaveSyncSettingsCommand}"
-                                IsEnabled="{Binding IsSyncSettingsDirty}"
-                                BackgroundColor="#3B4AD1"
-                                TextColor="White" />
-                            <Button
-                                Grid.Column="1"
-                                Text="Jetzt synchronisieren"
-                                Command="{Binding SyncNowCommand}"
-                                BackgroundColor="#2D3A7C"
-                                TextColor="White" />
-                        </Grid>
+                            <Label
+                                Text="Sobald du die Einstellungen speicherst, startet die Synchronisation automatisch. Den Button „Jetzt synchronisieren“ brauchst du nur, wenn du sofort einen Abgleich starten möchtest."
+                                TextColor="#9EA3C4"
+                                FontSize="12" />
+
+                            <Label
+                                Text="{Binding SyncStatusMessage}"
+                                TextColor="#CFD3FF"
+                                FontSize="12" />
+
+                            <HorizontalStackLayout Spacing="12">
+                                <Button
+                                    Text="Sync-Einstellungen speichern"
+                                    Command="{Binding SaveSyncSettingsCommand}"
+                                    IsEnabled="{Binding IsSyncSettingsDirty}"
+                                    BackgroundColor="#3B4AD1"
+                                    TextColor="White" />
+                                <Button
+                                    Text="Abbrechen"
+                                    Command="{Binding CancelSyncSettingsCommand}"
+                                    BackgroundColor="#2D3A7C"
+                                    TextColor="White"
+                                    IsVisible="{Binding IsCancelSyncEditVisible}" />
+                                <Button
+                                    Text="Jetzt synchronisieren"
+                                    Command="{Binding SyncNowCommand}"
+                                    BackgroundColor="#2D3A7C"
+                                    TextColor="White" />
+                            </HorizontalStackLayout>
+                        </VerticalStackLayout>
 
                         <ActivityIndicator
                             IsVisible="{Binding IsSyncBusy}"


### PR DESCRIPTION
## Summary
- record the next planned auto-sync time in the vault sync status and scheduler
- extend the vault settings view model with summary information plus edit/cancel commands for the sync card
- redesign the settings page sync section with a compact summary view and guided setup steps

## Testing
- dotnet build (fails: dotnet not found in PATH)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913a34a4608832a82feba5b08add983)