### PR TITLE
Fix Android Google Drive stream wrappers

### DIFF
--- a/Password Phrase Producer/Services/Vault/Sync/GoogleDriveVaultSyncProvider.cs
+++ b/Password Phrase Producer/Services/Vault/Sync/GoogleDriveVaultSyncProvider.cs
@@ -189,7 +189,8 @@ public sealed class GoogleDriveVaultSyncProvider : IVaultSyncProvider
             return null;
         }
 
-        return new AndroidParcelFileDescriptor.AutoCloseInputStream(descriptor);
+        var javaStream = new AndroidParcelFileDescriptor.AutoCloseInputStream(descriptor);
+        return new global::Android.Runtime.InputStreamInvoker(javaStream);
     }
 
     private static Stream OpenOutputStream(AndroidContentResolver resolver, AndroidUri uri)
@@ -206,7 +207,8 @@ public sealed class GoogleDriveVaultSyncProvider : IVaultSyncProvider
             throw new InvalidOperationException("Die Google-Drive-Datei konnte nicht geschrieben werden.");
         }
 
-        return new AndroidParcelFileDescriptor.AutoCloseOutputStream(descriptor);
+        var javaStream = new AndroidParcelFileDescriptor.AutoCloseOutputStream(descriptor);
+        return new global::Android.Runtime.OutputStreamInvoker(javaStream);
     }
 
     private static DocumentMetadata QueryDocumentMetadata(AndroidContentResolver resolver, AndroidUri uri)


### PR DESCRIPTION
## Summary
- wrap Android ParcelFileDescriptor streams with .NET stream wrappers in the Google Drive sync provider
- ensure file descriptor streams satisfy the expected System.IO.Stream return types during Android builds

## Testing
- dotnet build 'Password Phrase Producer/PasswordPhraseProducer.csproj' -f net9.0-android *(fails: `dotnet` not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69165c9184bc832a971158e51f85e9c8)