### PR TITLE
Decouple local and external vault data

### DIFF
--- a/Password Phrase Producer.Tests/PasswordPhraseProducer.Tests.csproj
+++ b/Password Phrase Producer.Tests/PasswordPhraseProducer.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Password_Phrase_Producer.Tests</RootNamespace>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Password Phrase Producer\PasswordPhraseProducer.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Password Phrase Producer.Tests/Remote/RemoteVaultEntryMergerTests.cs
+++ b/Password Phrase Producer.Tests/Remote/RemoteVaultEntryMergerTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using Password_Phrase_Producer.Models;
+using Password_Phrase_Producer.Services.Vault;
+using Xunit;
+
+namespace Password_Phrase_Producer.Tests.Remote;
+
+public class RemoteVaultEntryMergerTests
+{
+    [Fact]
+    public void MergeInPlace_PrefersNewerRemoteEntries()
+    {
+        var entryId = Guid.NewGuid();
+        var localEntries = new List<PasswordVaultEntry>
+        {
+            new()
+            {
+                Id = entryId,
+                Label = "Portal",
+                Username = "local",
+                Password = "old",
+                Category = "Apps",
+                ModifiedAt = DateTimeOffset.UtcNow.AddHours(-2)
+            }
+        };
+
+        var remoteEntries = new List<PasswordVaultEntryDto>
+        {
+            new()
+            {
+                Id = entryId,
+                Label = "Portal",
+                Username = "remote",
+                Password = "new",
+                Category = "Apps",
+                ModifiedAt = DateTimeOffset.UtcNow
+            },
+            new()
+            {
+                Id = Guid.NewGuid(),
+                Label = "Added",
+                Username = "fresh",
+                Password = "fresh-pass",
+                Category = "Misc",
+                ModifiedAt = DateTimeOffset.UtcNow
+            }
+        };
+
+        var changes = RemoteVaultEntryMerger.MergeInPlace(localEntries, remoteEntries);
+
+        Assert.Equal(2, changes);
+        Assert.Equal(2, localEntries.Count);
+        Assert.Equal("remote", localEntries[0].Username);
+        Assert.Equal("new", localEntries[0].Password);
+        Assert.Contains(localEntries, entry => entry.Label == "Added");
+    }
+}

--- a/Password Phrase Producer.Tests/Remote/RemoteVaultPackageHelperTests.cs
+++ b/Password Phrase Producer.Tests/Remote/RemoteVaultPackageHelperTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using Password_Phrase_Producer.Models;
+using Password_Phrase_Producer.Services.Vault;
+using Xunit;
+
+namespace Password_Phrase_Producer.Tests.Remote;
+
+public class RemoteVaultPackageHelperTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true
+    };
+
+    [Fact]
+    public void CreateAndDecryptPackage_RoundTripsSnapshot()
+    {
+        var snapshot = new RemoteVaultSnapshotDto
+        {
+            Entries = new List<PasswordVaultEntryDto>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Label = "Email",
+                    Username = "user@example.com",
+                    Password = "secret1",
+                    Category = "Work",
+                    ModifiedAt = DateTimeOffset.UtcNow.AddMinutes(-10)
+                },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Label = "Bank",
+                    Username = "acc01",
+                    Password = "secret2",
+                    Category = "Finance",
+                    ModifiedAt = DateTimeOffset.UtcNow.AddMinutes(-5)
+                }
+            }
+        };
+
+        var deterministicSalt = Enumerable.Range(0, 16).Select(i => (byte)i).ToArray();
+        var package = RemoteVaultPackageHelper.CreatePackage(snapshot, "remote-pass", iterations: 10_000, saltSizeBytes: 16, keySizeBytes: 32, JsonOptions, deterministicSalt);
+        var roundTripped = RemoteVaultPackageHelper.DecryptPackage(package, "remote-pass", defaultIterations: 10_000, keySizeBytes: 32, JsonOptions);
+
+        Assert.Equal(snapshot.Entries.Count, roundTripped.Entries.Count);
+
+        for (var i = 0; i < snapshot.Entries.Count; i++)
+        {
+            Assert.Equal(snapshot.Entries[i].Id, roundTripped.Entries[i].Id);
+            Assert.Equal(snapshot.Entries[i].Label, roundTripped.Entries[i].Label);
+            Assert.Equal(snapshot.Entries[i].Username, roundTripped.Entries[i].Username);
+            Assert.Equal(snapshot.Entries[i].Password, roundTripped.Entries[i].Password);
+            Assert.Equal(snapshot.Entries[i].Category, roundTripped.Entries[i].Category);
+            Assert.Equal(snapshot.Entries[i].ModifiedAt.ToUniversalTime(), roundTripped.Entries[i].ModifiedAt.ToUniversalTime());
+        }
+    }
+}

--- a/Password Phrase Producer.Tests/Remote/RemoteVaultSyncFlowTests.cs
+++ b/Password Phrase Producer.Tests/Remote/RemoteVaultSyncFlowTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using Password_Phrase_Producer.Models;
+using Password_Phrase_Producer.Services.Vault;
+using Xunit;
+
+namespace Password_Phrase_Producer.Tests.Remote;
+
+public class RemoteVaultSyncFlowTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true
+    };
+
+    [Fact]
+    public void SyncAcrossTwoDevices_MergesChangesBothWays()
+    {
+        const string remotePassword = "remote-sync-pass";
+        const int iterations = 12_000;
+        const int keySizeBytes = 32;
+
+        var deviceAEntries = new List<PasswordVaultEntry>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                Label = "Mail",
+                Username = "a@example.com",
+                Password = "mail-a",
+                Category = "Comms",
+                ModifiedAt = DateTimeOffset.UtcNow.AddMinutes(-30)
+            },
+            new()
+            {
+                Id = Guid.NewGuid(),
+                Label = "Cloud",
+                Username = "cloudA",
+                Password = "cloud-a",
+                Category = "Storage",
+                ModifiedAt = DateTimeOffset.UtcNow.AddMinutes(-20)
+            }
+        };
+
+        // Device A uploads
+        var packageFromA = CreatePackage(deviceAEntries, remotePassword, iterations, keySizeBytes, seed: 1);
+
+        // Device B downloads and merges
+        var deviceBEntries = new List<PasswordVaultEntry>();
+        ApplyPackage(deviceBEntries, packageFromA, remotePassword, iterations, keySizeBytes);
+
+        // Device B changes one entry and adds another
+        deviceBEntries[0].Password = "mail-a-updated";
+        deviceBEntries[0].ModifiedAt = DateTimeOffset.UtcNow.AddMinutes(-5);
+        deviceBEntries.Add(new PasswordVaultEntry
+        {
+            Id = Guid.NewGuid(),
+            Label = "Notes",
+            Username = "note-b",
+            Password = "notes-pass",
+            Category = "Productivity",
+            ModifiedAt = DateTimeOffset.UtcNow.AddMinutes(-2)
+        });
+
+        var packageFromB = CreatePackage(deviceBEntries, remotePassword, iterations, keySizeBytes, seed: 2);
+
+        // Device A downloads B's changes
+        ApplyPackage(deviceAEntries, packageFromB, remotePassword, iterations, keySizeBytes);
+
+        Assert.Equal(deviceBEntries.Count, deviceAEntries.Count);
+
+        foreach (var entry in deviceAEntries)
+        {
+            var counterpart = deviceBEntries.Single(e => e.Id == entry.Id);
+            Assert.Equal(counterpart.Label, entry.Label);
+            Assert.Equal(counterpart.Username, entry.Username);
+            Assert.Equal(counterpart.Password, entry.Password);
+            Assert.Equal(counterpart.Category, entry.Category);
+            Assert.Equal(counterpart.ModifiedAt.ToUniversalTime(), entry.ModifiedAt.ToUniversalTime());
+        }
+    }
+
+    private static byte[] CreatePackage(IEnumerable<PasswordVaultEntry> entries, string password, int iterations, int keySizeBytes, int seed)
+    {
+        var ordered = entries
+            .OrderBy(e => e.DisplayCategory, StringComparer.CurrentCultureIgnoreCase)
+            .ThenBy(e => e.Label, StringComparer.CurrentCultureIgnoreCase)
+            .Select(PasswordVaultEntryDto.FromModel)
+            .ToList();
+        var snapshot = new RemoteVaultSnapshotDto { Entries = ordered };
+        var salt = Enumerable.Range(0, 16).Select(i => (byte)(i + seed)).ToArray();
+        return RemoteVaultPackageHelper.CreatePackage(snapshot, password, iterations, salt.Length, keySizeBytes, JsonOptions, salt);
+    }
+
+    private static void ApplyPackage(IList<PasswordVaultEntry> localEntries, byte[] package, string password, int iterations, int keySizeBytes)
+    {
+        var snapshot = RemoteVaultPackageHelper.DecryptPackage(package, password, iterations, keySizeBytes, JsonOptions);
+        RemoteVaultEntryMerger.MergeInPlace(localEntries, snapshot.Entries ?? Array.Empty<PasswordVaultEntryDto>());
+    }
+}

--- a/Password Phrase Producer/Password Phrase Producer.sln
+++ b/Password Phrase Producer/Password Phrase Producer.sln
@@ -1,9 +1,11 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.10.35122.118
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PasswordPhraseProducer", "PasswordPhraseProducer.csproj", "{09E10F08-C8AE-4B4F-8271-BEF983FD11BD}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PasswordPhraseProducer.Tests", "..\Password Phrase Producer.Tests\PasswordPhraseProducer.Tests.csproj", "{1A9823E3-3D0F-4D0B-9D5D-2770C0FF2E0E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -17,6 +19,10 @@ Global
 		{09E10F08-C8AE-4B4F-8271-BEF983FD11BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{09E10F08-C8AE-4B4F-8271-BEF983FD11BD}.Release|Any CPU.Build.0 = Release|Any CPU
 		{09E10F08-C8AE-4B4F-8271-BEF983FD11BD}.Release|Any CPU.Deploy.0 = Release|Any CPU
+		{1A9823E3-3D0F-4D0B-9D5D-2770C0FF2E0E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1A9823E3-3D0F-4D0B-9D5D-2770C0FF2E0E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1A9823E3-3D0F-4D0B-9D5D-2770C0FF2E0E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1A9823E3-3D0F-4D0B-9D5D-2770C0FF2E0E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Password Phrase Producer/Properties/AssemblyInfo.cs
+++ b/Password Phrase Producer/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("PasswordPhraseProducer.Tests")]

--- a/Password Phrase Producer/Services/Vault/Remote/RemoteVaultEntryMerger.cs
+++ b/Password Phrase Producer/Services/Vault/Remote/RemoteVaultEntryMerger.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Password_Phrase_Producer.Models;
+
+namespace Password_Phrase_Producer.Services.Vault;
+
+internal static class RemoteVaultEntryMerger
+{
+    public static int MergeInPlace(IList<PasswordVaultEntry> localEntries, IEnumerable<PasswordVaultEntryDto> remoteEntries)
+    {
+        ArgumentNullException.ThrowIfNull(localEntries);
+        ArgumentNullException.ThrowIfNull(remoteEntries);
+
+        var indexById = localEntries
+            .Select((entry, index) => new { entry.Id, Index = index })
+            .ToDictionary(x => x.Id, x => x.Index);
+
+        var changes = 0;
+        foreach (var dto in remoteEntries)
+        {
+            if (dto is null)
+            {
+                continue;
+            }
+
+            var remoteModel = dto.ToModel();
+            if (indexById.TryGetValue(remoteModel.Id, out var existingIndex))
+            {
+                if (remoteModel.ModifiedAt > localEntries[existingIndex].ModifiedAt)
+                {
+                    localEntries[existingIndex] = remoteModel.Clone();
+                    changes++;
+                }
+            }
+            else
+            {
+                localEntries.Add(remoteModel.Clone());
+                indexById[remoteModel.Id] = localEntries.Count - 1;
+                changes++;
+            }
+        }
+
+        return changes;
+    }
+}

--- a/Password Phrase Producer/Services/Vault/Remote/RemoteVaultPackageHelper.cs
+++ b/Password Phrase Producer/Services/Vault/Remote/RemoteVaultPackageHelper.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Password_Phrase_Producer.Models;
+
+namespace Password_Phrase_Producer.Services.Vault;
+
+internal static class RemoteVaultPackageHelper
+{
+    private const int CurrentPackageVersion = 1;
+    private const int NonceSizeBytes = 12;
+    private const int TagSizeBytes = 16;
+
+    public static byte[] CreatePackage(
+        RemoteVaultSnapshotDto snapshot,
+        string password,
+        int iterations,
+        int saltSizeBytes,
+        int keySizeBytes,
+        JsonSerializerOptions options,
+        byte[]? saltOverride = null)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(password);
+        ArgumentNullException.ThrowIfNull(options);
+
+        var json = JsonSerializer.Serialize(snapshot, options);
+        var data = Encoding.UTF8.GetBytes(json);
+        var salt = saltOverride ?? RandomNumberGenerator.GetBytes(saltSizeBytes);
+        var key = DeriveKey(password, salt, iterations, keySizeBytes);
+
+        try
+        {
+            var encrypted = EncryptWithKey(data, key);
+            var dto = new RemoteVaultPackageDto
+            {
+                Version = CurrentPackageVersion,
+                Salt = Convert.ToBase64String(salt),
+                Pbkdf2Iterations = iterations,
+                CipherText = Convert.ToBase64String(encrypted)
+            };
+
+            return JsonSerializer.SerializeToUtf8Bytes(dto, options);
+        }
+        finally
+        {
+            Array.Clear(key);
+            Array.Clear(data);
+            if (saltOverride is null)
+            {
+                Array.Clear(salt);
+            }
+        }
+    }
+
+    public static RemoteVaultSnapshotDto DecryptPackage(
+        byte[] packageBytes,
+        string password,
+        int defaultIterations,
+        int keySizeBytes,
+        JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(packageBytes);
+        ArgumentException.ThrowIfNullOrWhiteSpace(password);
+        ArgumentNullException.ThrowIfNull(options);
+
+        var package = ParseRemotePackage(packageBytes, options);
+        if (string.IsNullOrWhiteSpace(package.CipherText))
+        {
+            return new RemoteVaultSnapshotDto();
+        }
+
+        if (string.IsNullOrWhiteSpace(package.Salt))
+        {
+            throw new InvalidOperationException("Das Remote-Tresorformat enthält keine Salt-Informationen.");
+        }
+
+        var salt = Convert.FromBase64String(package.Salt);
+        var encrypted = Convert.FromBase64String(package.CipherText);
+        var iterations = package.Pbkdf2Iterations.HasValue && package.Pbkdf2Iterations.Value > 0
+            ? package.Pbkdf2Iterations.Value
+            : defaultIterations;
+        var key = DeriveKey(password, salt, iterations, keySizeBytes);
+        byte[]? plain = null;
+
+        try
+        {
+            plain = DecryptWithKey(encrypted, key);
+            var snapshot = JsonSerializer.Deserialize<RemoteVaultSnapshotDto>(plain, options);
+            if (snapshot is null)
+            {
+                throw new InvalidOperationException("Der Remote-Snapshot konnte nicht gelesen werden.");
+            }
+
+            snapshot.Entries ??= new List<PasswordVaultEntryDto>();
+            return snapshot;
+        }
+        catch (JsonException ex)
+        {
+            if (plain is not null && LooksLikeLegacyRemoteVaultContent(plain))
+            {
+                throw new LegacyRemoteVaultFormatException("Die entfernte Datei verwendet ein älteres Tresorformat und kann nicht automatisch importiert werden. Bitte importiere die Datei lokal und exportiere sie anschließend erneut.", ex);
+            }
+
+            throw new InvalidOperationException("Der Remote-Snapshot ist beschädigt oder hat ein unbekanntes Format.", ex);
+        }
+        finally
+        {
+            if (plain is not null)
+            {
+                Array.Clear(plain);
+            }
+
+            Array.Clear(key);
+        }
+    }
+
+    private static RemoteVaultPackageDto ParseRemotePackage(byte[] payload, JsonSerializerOptions options)
+    {
+        try
+        {
+            var dto = JsonSerializer.Deserialize<RemoteVaultPackageDto>(payload, options);
+            if (dto is null || string.IsNullOrWhiteSpace(dto.CipherText))
+            {
+                throw new InvalidOperationException("Das Remote-Tresorformat ist ungültig.");
+            }
+
+            if (dto.Version != CurrentPackageVersion)
+            {
+                throw new InvalidOperationException("Das Remote-Tresorformat wird nicht unterstützt.");
+            }
+
+            return dto;
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidOperationException("Die entfernten Tresordaten konnten nicht interpretiert werden.", ex);
+        }
+    }
+
+    private static bool LooksLikeLegacyRemoteVaultContent(ReadOnlySpan<byte> plain)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(plain);
+            var root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                return false;
+            }
+
+            return root.TryGetProperty("passwordSalt", out _) && root.TryGetProperty("passwordVerifier", out _);
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    private static byte[] DeriveKey(string password, byte[] salt, int iterations, int keySizeBytes)
+    {
+        using var pbkdf2 = new Rfc2898DeriveBytes(password, salt, iterations, HashAlgorithmName.SHA256);
+        return pbkdf2.GetBytes(keySizeBytes);
+    }
+
+    private static byte[] EncryptWithKey(byte[] data, byte[] key)
+    {
+        var nonce = RandomNumberGenerator.GetBytes(NonceSizeBytes);
+        var cipher = new byte[data.Length];
+        var tag = new byte[TagSizeBytes];
+
+        using var aes = new AesGcm(key, TagSizeBytes);
+        aes.Encrypt(nonce, data, cipher, tag);
+
+        var result = new byte[nonce.Length + cipher.Length + tag.Length];
+        Buffer.BlockCopy(nonce, 0, result, 0, nonce.Length);
+        Buffer.BlockCopy(cipher, 0, result, nonce.Length, cipher.Length);
+        Buffer.BlockCopy(tag, 0, result, nonce.Length + cipher.Length, tag.Length);
+        return result;
+    }
+
+    private static byte[] DecryptWithKey(byte[] data, byte[] key)
+    {
+        if (data.Length < NonceSizeBytes + TagSizeBytes)
+        {
+            return Array.Empty<byte>();
+        }
+
+        var cipherLength = data.Length - NonceSizeBytes - TagSizeBytes;
+        var nonce = new byte[NonceSizeBytes];
+        var cipher = new byte[cipherLength];
+        var tag = new byte[TagSizeBytes];
+
+        Buffer.BlockCopy(data, 0, nonce, 0, NonceSizeBytes);
+        Buffer.BlockCopy(data, NonceSizeBytes, cipher, 0, cipherLength);
+        Buffer.BlockCopy(data, NonceSizeBytes + cipherLength, tag, 0, TagSizeBytes);
+
+        var plain = new byte[cipherLength];
+        using var aes = new AesGcm(key, TagSizeBytes);
+        aes.Decrypt(nonce, cipher, tag, plain);
+        return plain;
+    }
+
+    private sealed record RemoteVaultPackageDto
+    {
+        public int Version { get; init; }
+        public string? Salt { get; init; }
+        public int? Pbkdf2Iterations { get; init; }
+        public string CipherText { get; init; } = string.Empty;
+    }
+}
+
+internal sealed class LegacyRemoteVaultFormatException : InvalidOperationException
+{
+    public LegacyRemoteVaultFormatException(string message, Exception? innerException = null)
+        : base(message, innerException)
+    {
+    }
+}

--- a/Password Phrase Producer/Services/Vault/RemoteVaultSnapshotDto.cs
+++ b/Password Phrase Producer/Services/Vault/RemoteVaultSnapshotDto.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using Password_Phrase_Producer.Models;
+
+namespace Password_Phrase_Producer.Services.Vault;
+
+public sealed class RemoteVaultSnapshotDto
+{
+    public int Version { get; init; } = 1;
+
+    public DateTimeOffset ExportedAt { get; init; } = DateTimeOffset.UtcNow;
+
+    public List<PasswordVaultEntryDto> Entries { get; init; } = new();
+}


### PR DESCRIPTION
Decouple local and external vault synchronization by using a cleartext snapshot encrypted with a remote password.

The previous sync mechanism tightly coupled the remote vault to the local master password. This refactoring introduces a `RemoteVaultSnapshotDto` that is serialized as cleartext, then encrypted with a dedicated remote password, allowing external vault files to be imported and synchronized independently across devices without relying on the local master password. The `PasswordVaultService` now handles snapshot creation, package decryption, and merging downloaded snapshots into the local vault, with crypto and merge logic extracted into dedicated helper classes.

---
<a href="https://cursor.com/background-agent?bcId=bc-441c97d6-ca8c-445a-81b3-77296722fad9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-441c97d6-ca8c-445a-81b3-77296722fad9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

