### PR TITLE
Fix android build net9 compatibility

### DIFF
--- a/Password Phrase Producer.Tests/PasswordPhraseProducer.Tests.csproj
+++ b/Password Phrase Producer.Tests/PasswordPhraseProducer.Tests.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net9.0-windows10.0.19041.0</TargetFramework>
+    <UseWindowsForms>false</UseWindowsForms>
+    <UseWPF>false</UseWPF>
     <IsPackable>false</IsPackable>
     <RootNamespace>Password_Phrase_Producer.Tests</RootNamespace>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Update test project target framework to `net9.0-windows10.0.19041.0` to resolve NU1201 compatibility error with the main MAUI project.

The `PasswordPhraseProducer.Tests.csproj` was failing to restore due to a `NU1201` error, indicating incompatibility with the `PasswordPhraseProducer` project. The main project targets specific platforms like `net9.0-windows10.0.19041`, while the test project targeted a generic `net9.0`. Aligning the test project's target framework with the main project's Windows target resolves this incompatibility. Explicitly disabling `UseWindowsForms` and `UseWPF` ensures the test project remains a pure unit test assembly.

---
<a href="https://cursor.com/background-agent?bcId=bc-0a628562-c698-4488-b932-2b93908fe6d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0a628562-c698-4488-b932-2b93908fe6d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

