### PR TITLE
Fix Android build errors

### DIFF
--- a/Password Phrase Producer.Tests/PasswordPhraseProducer.Tests.csproj
+++ b/Password Phrase Producer.Tests/PasswordPhraseProducer.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0-windows10.0.19041.0</TargetFramework>
+    <TargetFrameworks>net9.0-windows10.0.19041.0;net9.0-android</TargetFrameworks>
     <UseWindowsForms>false</UseWindowsForms>
     <UseWPF>false</UseWPF>
     <IsPackable>false</IsPackable>
@@ -10,8 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0-windows10.0.19041.0'">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
   </ItemGroup>

--- a/Password Phrase Producer/Services/Vault/PasswordVaultService.cs
+++ b/Password Phrase Producer/Services/Vault/PasswordVaultService.cs
@@ -427,12 +427,12 @@ public class PasswordVaultService
 
                 MessagingCenter.Send(this, VaultMessages.EntriesChanged);
 
-                var (_, refreshedState) = await PrepareSyncPayloadAsync(configuration, cancellationToken).ConfigureAwait(false);
+                var (_, downloadedState) = await PrepareSyncPayloadAsync(configuration, cancellationToken).ConfigureAwait(false);
                 var downloadedCount = await TryGetLocalEntryCountAsync(cancellationToken).ConfigureAwait(false);
                 var downloadResult = new VaultSyncResult
                 {
                     Operation = VaultSyncOperation.Downloaded,
-                    LocalState = refreshedState,
+                    LocalState = downloadedState,
                     RemoteState = download.RemoteState,
                     DownloadedEntries = downloadedCount
                 };

--- a/Password Phrase Producer/Services/Vault/Remote/RemoteVaultPackageHelper.cs
+++ b/Password Phrase Producer/Services/Vault/Remote/RemoteVaultPackageHelper.cs
@@ -144,7 +144,7 @@ internal static class RemoteVaultPackageHelper
     {
         try
         {
-            using var document = JsonDocument.Parse(plain);
+            using var document = JsonDocument.Parse(plain.ToArray());
             var root = document.RootElement;
             if (root.ValueKind != JsonValueKind.Object)
             {

--- a/Password Phrase Producer/Services/Vault/RemoteVaultSnapshotDto.cs
+++ b/Password Phrase Producer/Services/Vault/RemoteVaultSnapshotDto.cs
@@ -10,5 +10,5 @@ public sealed class RemoteVaultSnapshotDto
 
     public DateTimeOffset ExportedAt { get; init; } = DateTimeOffset.UtcNow;
 
-    public List<PasswordVaultEntryDto> Entries { get; init; } = new();
+    public List<PasswordVaultEntryDto> Entries { get; set; } = new();
 }


### PR DESCRIPTION
## Summary
- allow the test project to multi-target Android while scoping Windows-only test tooling to the Windows target
- make remote vault snapshot entries mutable and adjust legacy detection parsing for Android compatibility
- resolve a variable shadowing conflict in vault synchronization download handling

## Testing
- dotnet build 'Password Phrase Producer/Password Phrase Producer.sln' -f net9.0-android -c Release *(fails: dotnet command unavailable in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c5f05a27c832a9a1c8dad3421fe85)