### PR TITLE
Fix null-coalescing of snapshot entries in remote sync test

### DIFF
--- a/Password Phrase Producer.Tests/Remote/RemoteVaultSyncFlowTests.cs
+++ b/Password Phrase Producer.Tests/Remote/RemoteVaultSyncFlowTests.cs
@@ -98,6 +98,6 @@ public class RemoteVaultSyncFlowTests
     private static void ApplyPackage(IList<PasswordVaultEntry> localEntries, byte[] package, string password, int iterations, int keySizeBytes)
     {
         var snapshot = RemoteVaultPackageHelper.DecryptPackage(package, password, iterations, keySizeBytes, JsonOptions);
-        RemoteVaultEntryMerger.MergeInPlace(localEntries, snapshot.Entries ?? Array.Empty<PasswordVaultEntryDto>());
+        RemoteVaultEntryMerger.MergeInPlace(localEntries, snapshot.Entries ?? Enumerable.Empty<PasswordVaultEntryDto>());
     }
 }


### PR DESCRIPTION
## Summary
- coalesce decrypted snapshot entries to Enumerable.Empty to match the merger's expected type and avoid Android build failure

## Testing
- dotnet test "Password Phrase Producer.Tests/PasswordPhraseProducer.Tests.csproj" *(fails: dotnet CLI not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cba86d438832a97f6544928666725)