### PR TITLE
Update Windows runtime identifier to win-x64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,7 @@ jobs:
           dotnet publish "./Password Phrase Producer/Password Phrase Producer.sln" `
             -c Release `
             -f net9.0-windows10.0.19041.0 `
-            -p:RuntimeIdentifier=win10-x64 `
+            -p:RuntimeIdentifier=win-x64 `
             -p:WindowsPackageType=None `
             -p:SelfContained=true `
             -p:PublishSingleFile=false `
@@ -159,7 +159,7 @@ jobs:
         shell: pwsh
         run: |
           $workspace = "${{ github.workspace }}"
-          $publishDir = Join-Path $workspace "Password Phrase Producer\bin\Release\net9.0-windows10.0.19041.0\win10-x64\publish"
+          $publishDir = Join-Path $workspace "Password Phrase Producer\bin\Release\net9.0-windows10.0.19041.0\win-x64\publish"
           if (-not (Test-Path $publishDir)) {
             throw "Windows publish directory not found."
           }

--- a/Password Phrase Producer/PasswordPhraseProducer.csproj
+++ b/Password Phrase Producer/PasswordPhraseProducer.csproj
@@ -40,7 +40,7 @@
 		<DefaultLanguage>EN</DefaultLanguage>
         </PropertyGroup>
 
-        <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'win10-x64'">
+        <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'win10-x64' or '$(RuntimeIdentifier)' == 'win-x64'">
                 <TargetFrameworks>net9.0-windows10.0.19041.0</TargetFrameworks>
         </PropertyGroup>
 


### PR DESCRIPTION
## Summary
- allow Windows builds to use the win-x64 runtime identifier in the MAUI project
- update the CI workflow to publish and package Windows artifacts under the win-x64 runtime path

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cc35100f8832a8f87ba62c3968969)