### PR TITLE
Adjust test project target framework to fix Android publish

### DIFF
--- a/Password Phrase Producer.Tests/PasswordPhraseProducer.Tests.csproj
+++ b/Password Phrase Producer.Tests/PasswordPhraseProducer.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0-windows10.0.19041.0;net9.0-android</TargetFrameworks>
+    <TargetFramework>net9.0-windows10.0.19041.0</TargetFramework>
     <UseWindowsForms>false</UseWindowsForms>
     <UseWPF>false</UseWPF>
     <IsPackable>false</IsPackable>
@@ -13,7 +13,7 @@
     <PackageReference Include="xunit" Version="2.5.3" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0-windows10.0.19041.0'">
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />


### PR DESCRIPTION
## Summary
- restrict test project to the Windows target framework
- remove conditional test package references now that only one target is used

## Testing
- not run (dotnet SDK unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ce83c42cc832aa2fa45e9bd176f31)