### PR TITLE
Allow vault reload during password unlock so entries appear immediately

### DIFF
--- a/Password Phrase Producer/ViewModels/VaultPageViewModel.cs
+++ b/Password Phrase Producer/ViewModels/VaultPageViewModel.cs
@@ -227,9 +227,9 @@ public class VaultPageViewModel : INotifyPropertyChanged
         }
     }
 
-    public async Task ReloadAsync(CancellationToken cancellationToken = default)
+    public async Task ReloadAsync(CancellationToken cancellationToken = default, bool allowWhileBusy = false)
     {
-        if (IsBusy || !IsUnlocked)
+        if ((!allowWhileBusy && IsBusy) || !IsUnlocked)
         {
             return;
         }
@@ -414,7 +414,7 @@ public class VaultPageViewModel : INotifyPropertyChanged
         IsUnlocked = true;
         IsNewVault = false;
         _hasAttemptedAutoBiometric = false;
-        await ReloadAsync(cancellationToken);
+        await ReloadAsync(cancellationToken, allowWhileBusy: true);
     }
 
     private void UpdateEntries(IEnumerable<PasswordVaultEntry> entries)


### PR DESCRIPTION
### Motivation
- Fix a bug where unlocking the vault with a password did not immediately display existing entries until a new entry was created. 
- The reload was skipped because `ReloadAsync` returned early when `IsBusy` was set during the unlock flow. 
- Ensure the vault UI refreshes right after a successful password unlock without changing existing busy semantics for other flows. 

### Description
- Add an `allowWhileBusy` parameter to `ReloadAsync` and update its guard to `if ((!allowWhileBusy && IsBusy) || !IsUnlocked)` so reload can be forced while busy. 
- Call `ReloadAsync(cancellationToken, allowWhileBusy: true)` from `OnUnlockedAsync` to ensure entries are reloaded immediately after unlocking. 
- No other behavioral changes to locking/unlocking or biometric flows were introduced. 

### Testing
- No automated tests were executed as part of this change. 
- A local build/commit was performed to apply the code modifications.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aa83c0028832a951e5f560386a8c7)