### PR TITLE
Fix Android crashes: vault detail binding and authenticator add/QR camera flow

### DIFF
--- a/Password Phrase Producer/App.xaml
+++ b/Password Phrase Producer/App.xaml
@@ -2,6 +2,7 @@
 <Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:Password_Phrase_Producer"
+             xmlns:converters="clr-namespace:Password_Phrase_Producer.Converters"
              x:Class="Password_Phrase_Producer.App">
     <Application.Resources>
         <ResourceDictionary>
@@ -9,6 +10,7 @@
                 <ResourceDictionary Source="Resources/Styles/Colors.xaml" />
                 <ResourceDictionary Source="Resources/Styles/Styles.xaml" />
             </ResourceDictionary.MergedDictionaries>
+            <converters:StringNotNullOrWhiteSpaceConverter x:Key="StringNotNullOrWhiteSpaceConverter" />
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/Password Phrase Producer/Platforms/Android/AndroidManifest.xml
+++ b/Password Phrase Producer/Platforms/Android/AndroidManifest.xml
@@ -5,5 +5,6 @@
         <uses-permission android:name="android.permission.INTERNET" />
         <uses-permission android:name="android.permission.USE_BIOMETRIC" />
         <uses-permission android:name="android.permission.USE_FINGERPRINT" />
+        <uses-permission android:name="android.permission.CAMERA" />
         <uses-feature android:name="android.hardware.fingerprint" android:required="false" />
 </manifest>

--- a/Password Phrase Producer/ViewModels/AuthenticatorViewModel.cs
+++ b/Password Phrase Producer/ViewModels/AuthenticatorViewModel.cs
@@ -137,10 +137,19 @@ public class AuthenticatorViewModel : INotifyPropertyChanged
     {
         // Use custom AddEntryPage modal
         var page = Application.Current?.MainPage?.Handler?.MauiContext?.Services.GetService<AddEntryPage>();
-        if (page != null)
+        if (page is null)
         {
-            await Application.Current!.MainPage!.Navigation.PushModalAsync(page);
+            return;
         }
+
+        var currentPage = GetCurrentPage();
+        var navigation = currentPage?.Navigation;
+        if (navigation is null)
+        {
+            return;
+        }
+
+        await navigation.PushModalAsync(page);
     }
 
     private async void DeleteEntryAsync(TotpViewModelItem? item)


### PR DESCRIPTION
### Motivation
- The app crashed on Android when opening a vault entry detail due to missing shared converter resource resolution in XAML bindings.
- The Authenticator add flow could trigger navigation failures when using the global main page navigation stack on Android.
- Starting the camera for QR scanning on Android could fail because the `CAMERA` permission was not declared or requested at runtime.

### Description
- Registered the `StringNotNullOrWhiteSpaceConverter` in `App.xaml` resources so XAML bindings in the vault detail page can resolve the converter.
- Added `android.permission.CAMERA` to `Platforms/Android/AndroidManifest.xml` and implemented runtime permission checks via `Permissions` in `AddEntryPage` with a new `EnsureCameraPermissionAsync` helper.
- Changed `StartCameraAsync` in `AddEntryPage` to return `bool` and added UI fallback handling when the camera cannot be started or permission is denied.
- Hardened the authenticator add-entry flow in `AuthenticatorViewModel` to resolve the active page via `GetCurrentPage()` and push the `AddEntryPage` onto that page's `Navigation` stack instead of using `Application.Current.MainPage` directly.

### Testing
- No automated tests were executed for this change.
- Local code inspection and compilation were performed as part of the edit and commit steps.
- Manual runtime verification was not recorded in automated form.
- Changes were committed: updated files include `App.xaml`, `Platforms/Android/AndroidManifest.xml`, `Views/AddEntryPage.xaml.cs`, and `ViewModels/AuthenticatorViewModel.cs`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bdab45fa8832aa3c5aeb7f4ac4ad9)