### PR TITLE
Move Datentresor settings into main Settings page

### DIFF
--- a/Password Phrase Producer/AppShell.xaml
+++ b/Password Phrase Producer/AppShell.xaml
@@ -137,6 +137,16 @@
             ContentTemplate="{DataTemplate views:VaultPage}" />
     </FlyoutItem>
 
+    <!-- Datentresor -->
+    <FlyoutItem Title="Datentresor"
+                Route="data-vault"
+                FlyoutIcon="D"
+                FlyoutDisplayOptions="AsSingleItem">
+        <ShellContent
+            Title="Datentresor"
+            ContentTemplate="{DataTemplate views:DataVaultPage}" />
+    </FlyoutItem>
+
     <!-- Passwort erstellen -->
     <FlyoutItem Title="Passwort erstellen"
                 Route="generate"
@@ -166,5 +176,6 @@
             Title="Einstellungen"
             ContentTemplate="{DataTemplate views:SettingsPage}" />
     </FlyoutItem>
+
 
 </Shell>

--- a/Password Phrase Producer/MauiProgram.cs
+++ b/Password Phrase Producer/MauiProgram.cs
@@ -28,12 +28,15 @@ public static class MauiProgram
 #endif
 
         builder.Services.AddSingleton<PasswordVaultService>();
+        builder.Services.AddSingleton<DataVaultService>();
         builder.Services.AddSingleton<TotpEncryptionService>();
         builder.Services.AddSingleton<TotpService>();
         builder.Services.AddSingleton<IBiometricAuthenticationService, BiometricAuthenticationService>();
         builder.Services.AddTransient<VaultPageViewModel>();
+        builder.Services.AddTransient<DataVaultPageViewModel>();
         builder.Services.AddTransient<VaultSettingsViewModel>();
         builder.Services.AddTransient<VaultPage>();
+        builder.Services.AddTransient<DataVaultPage>();
         builder.Services.AddTransient<SettingsPage>();
         builder.Services.AddTransient<VaultEntryEditorPage>();
         builder.Services.AddTransient<AuthenticatorViewModel>();

--- a/Password Phrase Producer/Services/Vault/DataVaultService.cs
+++ b/Password Phrase Producer/Services/Vault/DataVaultService.cs
@@ -1,0 +1,776 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Storage;
+using Password_Phrase_Producer.Models;
+
+namespace Password_Phrase_Producer.Services.Vault;
+
+public static class DataVaultMessages
+{
+    public const string EntriesChanged = nameof(EntriesChanged);
+}
+
+public class DataVaultService
+{
+    private const string VaultFileName = "data-vault.json.enc";
+    private const string PasswordSaltStorageKey = "DataVaultMasterPasswordSalt";
+    private const string PasswordVerifierStorageKey = "DataVaultMasterPasswordVerifier";
+    private const string PasswordIterationsStorageKey = "DataVaultMasterPasswordIterations";
+    private const string BiometricKeyStorageKey = "DataVaultBiometricKey";
+    private const int KeySizeBytes = 32;
+    private const int SaltSizeBytes = 16;
+    private const int Pbkdf2Iterations = 200_000;
+    private const int VaultFileFormatVersion = 1;
+
+    private const string LastEntryCountStorageKey = "DataVaultLastEntryCount";
+
+    private readonly SemaphoreSlim _syncLock = new(1, 1);
+    private readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true
+    };
+
+    private readonly string _vaultFilePath;
+    private byte[]? _encryptionKey;
+
+    public DataVaultService()
+    {
+        _vaultFilePath = Path.Combine(FileSystem.AppDataDirectory, VaultFileName);
+    }
+
+    public bool IsUnlocked => _encryptionKey is not null;
+
+    public async Task<bool> HasMasterPasswordAsync(CancellationToken cancellationToken = default)
+    {
+        var metadata = await GetPasswordMetadataAsync(cancellationToken).ConfigureAwait(false);
+        return !string.IsNullOrEmpty(metadata.Salt);
+    }
+
+    public async Task<bool> HasBiometricKeyAsync(CancellationToken cancellationToken = default)
+    {
+        var stored = await SecureStorage.Default.GetAsync(BiometricKeyStorageKey).ConfigureAwait(false);
+        return !string.IsNullOrEmpty(stored);
+    }
+
+    public void Lock()
+    {
+        if (_encryptionKey is null)
+        {
+            return;
+        }
+
+        Array.Clear(_encryptionKey);
+        _encryptionKey = null;
+    }
+
+    public async Task SetMasterPasswordAsync(string password, bool enableBiometrics, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(password);
+
+        var salt = RandomNumberGenerator.GetBytes(SaltSizeBytes);
+        var key = DeriveKey(password, salt, Pbkdf2Iterations);
+        var verifier = CreateVerifier(key);
+
+        await SecureStorage.Default.SetAsync(PasswordSaltStorageKey, Convert.ToBase64String(salt)).ConfigureAwait(false);
+        await SecureStorage.Default.SetAsync(PasswordVerifierStorageKey, Convert.ToBase64String(verifier)).ConfigureAwait(false);
+        await SetStoredPbkdf2IterationsAsync(Pbkdf2Iterations).ConfigureAwait(false);
+
+        _encryptionKey = key;
+        UpdateStoredEntryCount(0);
+
+        if (enableBiometrics)
+        {
+            await SecureStorage.Default.SetAsync(BiometricKeyStorageKey, Convert.ToBase64String(key)).ConfigureAwait(false);
+        }
+        else
+        {
+            SecureStorage.Default.Remove(BiometricKeyStorageKey);
+        }
+    }
+
+    public async Task<bool> UnlockAsync(string password, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(password);
+
+        var metadata = await GetPasswordMetadataAsync(cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrEmpty(metadata.Salt) || string.IsNullOrEmpty(metadata.Verifier))
+        {
+            return false;
+        }
+
+        var salt = Convert.FromBase64String(metadata.Salt);
+        var iterations = metadata.Iterations;
+        var key = DeriveKey(password, salt, iterations);
+        var expectedVerifier = Convert.FromBase64String(metadata.Verifier);
+        var actualVerifier = CreateVerifier(key);
+
+        if (!CryptographicOperations.FixedTimeEquals(expectedVerifier, actualVerifier))
+        {
+            Array.Clear(key);
+            return false;
+        }
+
+        _encryptionKey = key;
+        return true;
+    }
+
+    public async Task ChangeMasterPasswordAsync(string newPassword, bool enableBiometrics, CancellationToken cancellationToken = default)
+    {
+        EnsureUnlocked();
+        ArgumentException.ThrowIfNullOrWhiteSpace(newPassword);
+
+        await _syncLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var entries = await LoadEntriesInternalAsync(cancellationToken).ConfigureAwait(false);
+
+            var newSalt = RandomNumberGenerator.GetBytes(SaltSizeBytes);
+            var newKey = DeriveKey(newPassword, newSalt, Pbkdf2Iterations);
+            var newVerifier = CreateVerifier(newKey);
+
+            var previousKey = _encryptionKey;
+            _encryptionKey = newKey;
+
+            try
+            {
+                await SaveEntriesInternalAsync(entries, cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                _encryptionKey = previousKey;
+                Array.Clear(newKey);
+                throw;
+            }
+
+            await SecureStorage.Default.SetAsync(PasswordSaltStorageKey, Convert.ToBase64String(newSalt)).ConfigureAwait(false);
+            await SecureStorage.Default.SetAsync(PasswordVerifierStorageKey, Convert.ToBase64String(newVerifier)).ConfigureAwait(false);
+            await SetStoredPbkdf2IterationsAsync(Pbkdf2Iterations).ConfigureAwait(false);
+
+            if (enableBiometrics)
+            {
+                await SecureStorage.Default.SetAsync(BiometricKeyStorageKey, Convert.ToBase64String(newKey)).ConfigureAwait(false);
+            }
+            else
+            {
+                SecureStorage.Default.Remove(BiometricKeyStorageKey);
+            }
+
+            if (previousKey is not null)
+            {
+                Array.Clear(previousKey);
+            }
+        }
+        finally
+        {
+            _syncLock.Release();
+        }
+    }
+
+    public async Task<bool> TryUnlockWithStoredKeyAsync(CancellationToken cancellationToken = default)
+    {
+        var storedKeyBase64 = await SecureStorage.Default.GetAsync(BiometricKeyStorageKey).ConfigureAwait(false);
+        var metadata = await GetPasswordMetadataAsync(cancellationToken).ConfigureAwait(false);
+
+        if (string.IsNullOrEmpty(storedKeyBase64) || string.IsNullOrEmpty(metadata.Verifier))
+        {
+            return false;
+        }
+
+        var key = Convert.FromBase64String(storedKeyBase64);
+        var expectedVerifier = Convert.FromBase64String(metadata.Verifier);
+        var actualVerifier = CreateVerifier(key);
+
+        if (!CryptographicOperations.FixedTimeEquals(expectedVerifier, actualVerifier))
+        {
+            SecureStorage.Default.Remove(BiometricKeyStorageKey);
+            Array.Clear(key);
+            return false;
+        }
+
+        _encryptionKey = key;
+        return true;
+    }
+
+    public async Task SetBiometricUnlockAsync(bool enabled, CancellationToken cancellationToken = default)
+    {
+        if (!IsUnlocked)
+        {
+            throw new InvalidOperationException("Der Datentresor ist gesperrt.");
+        }
+
+        if (enabled)
+        {
+            await SecureStorage.Default.SetAsync(BiometricKeyStorageKey, Convert.ToBase64String(_encryptionKey!)).ConfigureAwait(false);
+        }
+        else
+        {
+            SecureStorage.Default.Remove(BiometricKeyStorageKey);
+        }
+    }
+
+    public async Task<IReadOnlyList<PasswordVaultEntry>> GetEntriesAsync(CancellationToken cancellationToken = default)
+    {
+        EnsureUnlocked();
+
+        await _syncLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var entries = await LoadEntriesInternalAsync(cancellationToken).ConfigureAwait(false);
+            return entries
+                .OrderBy(e => e.DisplayCategory, StringComparer.CurrentCultureIgnoreCase)
+                .ThenBy(e => e.Label, StringComparer.CurrentCultureIgnoreCase)
+                .ToList();
+        }
+        finally
+        {
+            _syncLock.Release();
+        }
+    }
+
+    public async Task AddOrUpdateEntryAsync(PasswordVaultEntry entry, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        EnsureUnlocked();
+
+        await _syncLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var entries = await LoadEntriesInternalAsync(cancellationToken).ConfigureAwait(false);
+            var existingIndex = entries.FindIndex(e => e.Id == entry.Id);
+
+            if (entry.Id == Guid.Empty)
+            {
+                entry.Id = Guid.NewGuid();
+            }
+
+            entry.ModifiedAt = DateTimeOffset.UtcNow;
+
+            if (existingIndex >= 0)
+            {
+                entries[existingIndex] = entry.Clone();
+            }
+            else
+            {
+                entries.Add(entry.Clone());
+            }
+
+            await SaveEntriesInternalAsync(entries, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _syncLock.Release();
+        }
+
+        MessagingCenter.Send(this, DataVaultMessages.EntriesChanged);
+    }
+
+    public async Task DeleteEntryAsync(Guid entryId, CancellationToken cancellationToken = default)
+    {
+        EnsureUnlocked();
+
+        await _syncLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var entries = await LoadEntriesInternalAsync(cancellationToken).ConfigureAwait(false);
+            var removed = entries.RemoveAll(e => e.Id == entryId);
+
+            if (removed > 0)
+            {
+                await SaveEntriesInternalAsync(entries, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            _syncLock.Release();
+        }
+
+        MessagingCenter.Send(this, DataVaultMessages.EntriesChanged);
+    }
+
+    public async Task<byte[]> CreateBackupAsync(CancellationToken cancellationToken = default)
+    {
+        EnsureUnlocked();
+
+        await _syncLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var vaultFile = await ReadVaultFileAsync(cancellationToken).ConfigureAwait(false);
+            var encryptedPayload = vaultFile.Cipher;
+            var iterations = await GetStoredPbkdf2IterationsAsync().ConfigureAwait(false);
+            var salt = await SecureStorage.Default.GetAsync(PasswordSaltStorageKey).ConfigureAwait(false)
+                       ?? throw new InvalidOperationException("Kein Master-Passwort konfiguriert.");
+            var verifier = await SecureStorage.Default.GetAsync(PasswordVerifierStorageKey).ConfigureAwait(false)
+                          ?? throw new InvalidOperationException("Kein Master-Passwort konfiguriert.");
+
+            var backup = new PasswordVaultBackupDto
+            {
+                CipherText = Convert.ToBase64String(encryptedPayload),
+                PasswordSalt = salt,
+                PasswordVerifier = verifier,
+                Pbkdf2Iterations = iterations,
+                CreatedAt = DateTimeOffset.UtcNow
+            };
+
+            var json = JsonSerializer.Serialize(backup, _jsonOptions);
+            return Encoding.UTF8.GetBytes(json);
+        }
+        finally
+        {
+            _syncLock.Release();
+        }
+    }
+
+    public async Task RestoreBackupAsync(Stream backupStream, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(backupStream);
+
+        using var reader = new StreamReader(backupStream, Encoding.UTF8, leaveOpen: true);
+        var json = await reader.ReadToEndAsync().ConfigureAwait(false);
+        var dto = JsonSerializer.Deserialize<PasswordVaultBackupDto>(json, _jsonOptions)
+                  ?? throw new InvalidOperationException("Ungültiges Backup-Format.");
+
+        var cipher = Convert.FromBase64String(dto.CipherText);
+
+        var iterations = dto.Pbkdf2Iterations > 0 ? dto.Pbkdf2Iterations : Pbkdf2Iterations;
+        await SecureStorage.Default.SetAsync(PasswordSaltStorageKey, dto.PasswordSalt).ConfigureAwait(false);
+        await SecureStorage.Default.SetAsync(PasswordVerifierStorageKey, dto.PasswordVerifier).ConfigureAwait(false);
+        await SetStoredPbkdf2IterationsAsync(iterations).ConfigureAwait(false);
+        SecureStorage.Default.Remove(BiometricKeyStorageKey);
+        _encryptionKey = null;
+
+        var vaultFile = await CreateVaultFileContentAsync(cipher, cancellationToken).ConfigureAwait(false);
+
+        await _syncLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await WriteVaultFileInternalAsync(vaultFile.RawContent, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _syncLock.Release();
+        }
+
+        ClearStoredEntryCount();
+        MessagingCenter.Send(this, DataVaultMessages.EntriesChanged);
+    }
+
+    public async Task<byte[]> ExportEncryptedVaultAsync(CancellationToken cancellationToken = default)
+    {
+        EnsureUnlocked();
+
+        await _syncLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            return await ReadEncryptedFileAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _syncLock.Release();
+        }
+    }
+
+    public async Task ImportEncryptedVaultAsync(Stream encryptedStream, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(encryptedStream);
+        EnsureUnlocked();
+
+        using var memoryStream = new MemoryStream();
+        await encryptedStream.CopyToAsync(memoryStream, cancellationToken).ConfigureAwait(false);
+        var payload = memoryStream.ToArray();
+
+        var importedContent = ParseVaultFile(payload);
+
+        await _syncLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await WriteVaultFileInternalAsync(payload, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _syncLock.Release();
+        }
+
+        if (importedContent.Cipher.Length == 0)
+        {
+            UpdateStoredEntryCount(0);
+        }
+        else
+        {
+            _ = await TryGetEntryCountAsync(importedContent, cancellationToken).ConfigureAwait(false);
+        }
+
+        await UpdatePasswordMetadataAsync(importedContent).ConfigureAwait(false);
+        MessagingCenter.Send(this, DataVaultMessages.EntriesChanged);
+    }
+
+    private async Task<List<PasswordVaultEntry>> LoadEntriesInternalAsync(CancellationToken cancellationToken)
+    {
+        var vaultFile = await ReadVaultFileAsync(cancellationToken).ConfigureAwait(false);
+        if (vaultFile.Cipher.Length == 0)
+        {
+            UpdateStoredEntryCount(0);
+            return new List<PasswordVaultEntry>();
+        }
+
+        var decryptedBytes = await DecryptAsync(vaultFile.Cipher, cancellationToken).ConfigureAwait(false);
+        if (decryptedBytes.Length == 0)
+        {
+            UpdateStoredEntryCount(0);
+            return new List<PasswordVaultEntry>();
+        }
+
+        var json = Encoding.UTF8.GetString(decryptedBytes);
+        var snapshot = JsonSerializer.Deserialize<PasswordVaultSnapshotDto>(json, _jsonOptions);
+
+        if (snapshot?.Entries is null)
+        {
+            UpdateStoredEntryCount(0);
+            return new List<PasswordVaultEntry>();
+        }
+
+        var entries = snapshot.Entries
+            .Select(dto => dto.ToModel())
+            .ToList();
+
+        UpdateStoredEntryCount(entries.Count);
+        return entries;
+    }
+
+    private async Task SaveEntriesInternalAsync(IList<PasswordVaultEntry> entries, CancellationToken cancellationToken)
+    {
+        var ordered = entries
+            .OrderBy(e => e.DisplayCategory, StringComparer.CurrentCultureIgnoreCase)
+            .ThenBy(e => e.Label, StringComparer.CurrentCultureIgnoreCase)
+            .Select(PasswordVaultEntryDto.FromModel)
+            .ToList();
+
+        var snapshot = new PasswordVaultSnapshotDto
+        {
+            Entries = ordered,
+            ExportedAt = DateTimeOffset.UtcNow
+        };
+
+        var json = JsonSerializer.Serialize(snapshot, _jsonOptions);
+        var encrypted = await EncryptAsync(Encoding.UTF8.GetBytes(json), cancellationToken).ConfigureAwait(false);
+        var vaultFile = await CreateVaultFileContentAsync(encrypted, cancellationToken).ConfigureAwait(false);
+
+        await WriteVaultFileInternalAsync(vaultFile.RawContent, cancellationToken).ConfigureAwait(false);
+        UpdateStoredEntryCount(ordered.Count);
+    }
+
+    private Task<byte[]> EncryptAsync(byte[] data, CancellationToken cancellationToken)
+    {
+        var key = GetUnlockedKey();
+        var result = EncryptWithKey(data, key);
+        return Task.FromResult(result);
+    }
+
+    private Task<byte[]> DecryptAsync(byte[] data, CancellationToken cancellationToken)
+    {
+        var key = GetUnlockedKey();
+        var result = DecryptWithKey(data, key);
+        return Task.FromResult(result);
+    }
+
+    private async Task<byte[]> ReadEncryptedFileAsync(CancellationToken cancellationToken)
+    {
+        var vaultFile = await ReadVaultFileAsync(cancellationToken).ConfigureAwait(false);
+        if (vaultFile.RawContent.Length == 0)
+        {
+            return Array.Empty<byte>();
+        }
+
+        if (!string.IsNullOrWhiteSpace(vaultFile.PasswordSalt) && !string.IsNullOrWhiteSpace(vaultFile.PasswordVerifier))
+        {
+            return vaultFile.RawContent;
+        }
+
+        var salt = await SecureStorage.Default.GetAsync(PasswordSaltStorageKey).ConfigureAwait(false);
+        var verifier = await SecureStorage.Default.GetAsync(PasswordVerifierStorageKey).ConfigureAwait(false);
+
+        if (string.IsNullOrEmpty(salt) || string.IsNullOrEmpty(verifier))
+        {
+            return vaultFile.RawContent;
+        }
+
+        var updatedContent = await CreateVaultFileContentAsync(vaultFile.Cipher, cancellationToken).ConfigureAwait(false);
+        await WriteVaultFileInternalAsync(updatedContent.RawContent, cancellationToken).ConfigureAwait(false);
+        return updatedContent.RawContent;
+    }
+
+    private async Task<VaultFileContent> ReadVaultFileAsync(CancellationToken cancellationToken)
+    {
+        if (!File.Exists(_vaultFilePath))
+        {
+            return VaultFileContent.Empty;
+        }
+
+        var rawContent = await File.ReadAllBytesAsync(_vaultFilePath, cancellationToken).ConfigureAwait(false);
+        return ParseVaultFile(rawContent);
+    }
+
+    private VaultFileContent ParseVaultFile(byte[] rawContent)
+    {
+        if (rawContent.Length == 0)
+        {
+            return VaultFileContent.Empty;
+        }
+
+        try
+        {
+            var json = Encoding.UTF8.GetString(rawContent);
+            if (!string.IsNullOrWhiteSpace(json) && json.TrimStart().StartsWith("{", StringComparison.Ordinal))
+            {
+                var dto = JsonSerializer.Deserialize<EncryptedVaultFileDto>(json, _jsonOptions);
+                if (dto is not null && !string.IsNullOrWhiteSpace(dto.CipherText))
+                {
+                    var cipher = Convert.FromBase64String(dto.CipherText);
+                    return new VaultFileContent(cipher, dto.PasswordSalt, dto.PasswordVerifier, dto.Pbkdf2Iterations, rawContent);
+                }
+
+                return new VaultFileContent(Array.Empty<byte>(), dto?.PasswordSalt, dto?.PasswordVerifier, dto?.Pbkdf2Iterations, rawContent);
+            }
+        }
+        catch (DecoderFallbackException)
+        {
+            // Nicht im JSON-Format gespeichert.
+        }
+        catch (JsonException)
+        {
+            // Nicht im JSON-Format gespeichert.
+        }
+        catch (FormatException)
+        {
+            // Ungültiges Cipher-Format.
+        }
+
+        return new VaultFileContent(rawContent, null, null, null, rawContent);
+    }
+
+    private async Task<VaultFileContent> CreateVaultFileContentAsync(byte[] cipher, CancellationToken cancellationToken)
+    {
+        var salt = await SecureStorage.Default.GetAsync(PasswordSaltStorageKey).ConfigureAwait(false)
+                   ?? throw new InvalidOperationException("Kein Master-Passwort konfiguriert.");
+        var verifier = await SecureStorage.Default.GetAsync(PasswordVerifierStorageKey).ConfigureAwait(false)
+                      ?? throw new InvalidOperationException("Kein Master-Passwort konfiguriert.");
+        var iterations = await GetStoredPbkdf2IterationsAsync().ConfigureAwait(false);
+
+        var dto = new EncryptedVaultFileDto
+        {
+            Version = VaultFileFormatVersion,
+            CipherText = Convert.ToBase64String(cipher),
+            PasswordSalt = salt,
+            PasswordVerifier = verifier,
+            Pbkdf2Iterations = iterations
+        };
+
+        var rawContent = JsonSerializer.SerializeToUtf8Bytes(dto, _jsonOptions);
+        return new VaultFileContent(cipher, salt, verifier, iterations, rawContent);
+    }
+
+    private async Task WriteVaultFileInternalAsync(byte[] rawContent, CancellationToken cancellationToken)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(_vaultFilePath)!);
+        await File.WriteAllBytesAsync(_vaultFilePath, rawContent, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<int?> TryGetEntryCountAsync(VaultFileContent content, CancellationToken cancellationToken)
+    {
+        if (content.Cipher.Length == 0)
+        {
+            UpdateStoredEntryCount(0);
+            return 0;
+        }
+
+        try
+        {
+            var decrypted = await DecryptAsync(content.Cipher, cancellationToken).ConfigureAwait(false);
+            if (decrypted.Length == 0)
+            {
+                UpdateStoredEntryCount(0);
+                return 0;
+            }
+
+            var snapshot = JsonSerializer.Deserialize<PasswordVaultSnapshotDto>(decrypted, _jsonOptions);
+            var count = snapshot?.Entries?.Count ?? 0;
+            UpdateStoredEntryCount(count);
+            return count;
+        }
+        catch (InvalidOperationException)
+        {
+            return GetStoredEntryCount();
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            return GetStoredEntryCount();
+        }
+    }
+
+    private void UpdateStoredEntryCount(int count)
+    {
+        Preferences.Default.Set(LastEntryCountStorageKey, Math.Max(0, count));
+    }
+
+    private int? GetStoredEntryCount()
+    {
+        var stored = Preferences.Default.Get(LastEntryCountStorageKey, -1);
+        return stored >= 0 ? stored : null;
+    }
+
+    private void ClearStoredEntryCount()
+    {
+        Preferences.Default.Remove(LastEntryCountStorageKey);
+    }
+
+    private async Task<PasswordMetadata> GetPasswordMetadataAsync(CancellationToken cancellationToken)
+    {
+        var salt = await SecureStorage.Default.GetAsync(PasswordSaltStorageKey).ConfigureAwait(false);
+        var verifier = await SecureStorage.Default.GetAsync(PasswordVerifierStorageKey).ConfigureAwait(false);
+        var iterations = await GetStoredPbkdf2IterationsAsync().ConfigureAwait(false);
+
+        if (!string.IsNullOrEmpty(salt) && !string.IsNullOrEmpty(verifier))
+        {
+            return new PasswordMetadata(salt, verifier, iterations);
+        }
+
+        var vaultFile = await ReadVaultFileAsync(cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrWhiteSpace(vaultFile.PasswordSalt) && !string.IsNullOrWhiteSpace(vaultFile.PasswordVerifier))
+        {
+            var vaultIterations = vaultFile.Pbkdf2Iterations.HasValue && vaultFile.Pbkdf2Iterations.Value > 0
+                ? vaultFile.Pbkdf2Iterations.Value
+                : Pbkdf2Iterations;
+            return new PasswordMetadata(vaultFile.PasswordSalt, vaultFile.PasswordVerifier, vaultIterations);
+        }
+
+        return new PasswordMetadata(null, null, iterations);
+    }
+
+    private sealed record PasswordMetadata(string? Salt, string? Verifier, int Iterations);
+
+    private async Task UpdatePasswordMetadataAsync(VaultFileContent content)
+    {
+        if (string.IsNullOrWhiteSpace(content.PasswordSalt) || string.IsNullOrWhiteSpace(content.PasswordVerifier))
+        {
+            return;
+        }
+
+        await SecureStorage.Default.SetAsync(PasswordSaltStorageKey, content.PasswordSalt).ConfigureAwait(false);
+        await SecureStorage.Default.SetAsync(PasswordVerifierStorageKey, content.PasswordVerifier).ConfigureAwait(false);
+        var iterations = content.Pbkdf2Iterations.HasValue && content.Pbkdf2Iterations.Value > 0
+            ? content.Pbkdf2Iterations.Value
+            : Pbkdf2Iterations;
+        await SetStoredPbkdf2IterationsAsync(iterations).ConfigureAwait(false);
+        SecureStorage.Default.Remove(BiometricKeyStorageKey);
+    }
+
+    private sealed record VaultFileContent(byte[] Cipher, string? PasswordSalt, string? PasswordVerifier, int? Pbkdf2Iterations, byte[] RawContent)
+    {
+        public static VaultFileContent Empty { get; } = new(Array.Empty<byte>(), null, null, null, Array.Empty<byte>());
+    }
+
+    internal byte[] GetUnlockedKey()
+    {
+        if (_encryptionKey is null)
+        {
+            throw new InvalidOperationException("Der Datentresor ist gesperrt.");
+        }
+
+        return _encryptionKey;
+    }
+
+    private void EnsureUnlocked()
+    {
+        if (!IsUnlocked)
+        {
+            throw new InvalidOperationException("Der Datentresor ist gesperrt.");
+        }
+    }
+
+    private async Task<int> GetStoredPbkdf2IterationsAsync()
+    {
+        var storedValue = await SecureStorage.Default.GetAsync(PasswordIterationsStorageKey).ConfigureAwait(false);
+        if (int.TryParse(storedValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var iterations) && iterations > 0)
+        {
+            return iterations;
+        }
+
+        return Pbkdf2Iterations;
+    }
+
+    private static Task SetStoredPbkdf2IterationsAsync(int iterations)
+    {
+        var effective = iterations > 0 ? iterations : Pbkdf2Iterations;
+        return SecureStorage.Default.SetAsync(PasswordIterationsStorageKey, effective.ToString(CultureInfo.InvariantCulture));
+    }
+
+    private static byte[] DeriveKey(string password, byte[] salt, int iterations)
+    {
+        using var pbkdf2 = new Rfc2898DeriveBytes(password, salt, iterations, HashAlgorithmName.SHA256);
+        return pbkdf2.GetBytes(KeySizeBytes);
+    }
+
+    private static byte[] CreateVerifier(byte[] key)
+    {
+        using var sha = SHA256.Create();
+        return sha.ComputeHash(key);
+    }
+
+    internal static byte[] EncryptWithKey(byte[] data, byte[] key)
+    {
+        var nonce = RandomNumberGenerator.GetBytes(12);
+        var cipher = new byte[data.Length];
+        var tag = new byte[16];
+
+        using var aes = new AesGcm(key, tag.Length);
+        aes.Encrypt(nonce, data, cipher, tag);
+
+        var result = new byte[nonce.Length + cipher.Length + tag.Length];
+        Buffer.BlockCopy(nonce, 0, result, 0, nonce.Length);
+        Buffer.BlockCopy(cipher, 0, result, nonce.Length, cipher.Length);
+        Buffer.BlockCopy(tag, 0, result, nonce.Length + cipher.Length, tag.Length);
+        return result;
+    }
+
+    internal static byte[] DecryptWithKey(byte[] data, byte[] key)
+    {
+        const int nonceLength = 12;
+        const int tagLength = 16;
+
+        if (data.Length < nonceLength + tagLength)
+        {
+            return Array.Empty<byte>();
+        }
+
+        var cipherLength = data.Length - nonceLength - tagLength;
+        if (cipherLength < 0)
+        {
+            throw new InvalidOperationException("Ungültiges verschlüsseltes Format.");
+        }
+
+        var nonce = new byte[nonceLength];
+        var cipher = new byte[cipherLength];
+        var tag = new byte[tagLength];
+
+        Buffer.BlockCopy(data, 0, nonce, 0, nonceLength);
+        Buffer.BlockCopy(data, nonceLength, cipher, 0, cipherLength);
+        Buffer.BlockCopy(data, nonceLength + cipherLength, tag, 0, tagLength);
+
+        var plain = new byte[cipherLength];
+        using var aes = new AesGcm(key, tagLength);
+        aes.Decrypt(nonce, cipher, tag, plain);
+        return plain;
+    }
+}

--- a/Password Phrase Producer/StartPage.xaml
+++ b/Password Phrase Producer/StartPage.xaml
@@ -108,6 +108,49 @@
                     </Grid>
                 </Border>
 
+                <!-- Data Vault Option -->
+                <Border StrokeThickness="0"
+                        HeightRequest="70"
+                        BackgroundColor="Transparent">
+                    <Border.StrokeShape>
+                        <RoundRectangle CornerRadius="16" />
+                    </Border.StrokeShape>
+                    <Border.Background>
+                        <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
+                            <GradientStop Color="#1F2540" Offset="0" />
+                            <GradientStop Color="#1B2036" Offset="1" />
+                        </LinearGradientBrush>
+                    </Border.Background>
+                    <Border.Shadow>
+                        <Shadow Brush="#25000000" Radius="12" Offset="0,6" />
+                    </Border.Shadow>
+                    <Border.GestureRecognizers>
+                        <TapGestureRecognizer Command="{Binding NavigateToDataVaultCommand}" />
+                    </Border.GestureRecognizers>
+
+                    <Grid Padding="16" ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto" RowSpacing="4">
+                        <!-- Text -->
+                        <Label Grid.Row="0"
+                               Text="Datentresor öffnen"
+                               FontSize="16"
+                               FontAttributes="Bold"
+                               TextColor="White"/>
+                        <Label Grid.Row="1"
+                               Text="WLAN, Lizenzen, SSH-Keys, Recovery-Codes &amp; Secure Notes."
+                               FontSize="12"
+                               TextColor="#9EA3C4"
+                               LineBreakMode="WordWrap"/>
+
+                        <!-- Arrow -->
+                        <Image Grid.Column="1"
+                               Grid.RowSpan="2"
+                               Source="chevronright.png"
+                               WidthRequest="16"
+                               HeightRequest="16"
+                               VerticalOptions="Center"/>
+                    </Grid>
+                </Border>
+
                 <!-- Generate Option -->
                 <Border StrokeThickness="0"
                         HeightRequest="70"

--- a/Password Phrase Producer/ViewModels/DataVaultPageViewModel.cs
+++ b/Password Phrase Producer/ViewModels/DataVaultPageViewModel.cs
@@ -1,0 +1,562 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls;
+using Password_Phrase_Producer.Models;
+using Password_Phrase_Producer.Services.Security;
+using Password_Phrase_Producer.Services.Vault;
+
+namespace Password_Phrase_Producer.ViewModels;
+
+public class DataVaultPageViewModel : INotifyPropertyChanged
+{
+    private const string AllCategoriesFilter = "Alle Kategorien";
+
+    private readonly DataVaultService _vaultService;
+    private readonly IBiometricAuthenticationService _biometricAuthenticationService;
+    private bool _isBusy;
+    private bool _isListening;
+    private bool _isUnlocked;
+    private bool _isNewVault;
+    private bool _canUseBiometric;
+    private bool _isBiometricConfigured;
+    private bool _enableBiometric;
+    private string _password = string.Empty;
+    private string _confirmPassword = string.Empty;
+    private string? _unlockError;
+    private bool _hasAttemptedAutoBiometric;
+    private string _searchQuery = string.Empty;
+    private string _selectedCategory = AllCategoriesFilter;
+    private readonly List<PasswordVaultEntry> _allEntries = new();
+    private readonly List<string> _availableCategories = new();
+
+    public DataVaultPageViewModel(DataVaultService vaultService, IBiometricAuthenticationService biometricAuthenticationService)
+    {
+        _vaultService = vaultService;
+        _biometricAuthenticationService = biometricAuthenticationService;
+        _entryGroups = new ObservableCollection<VaultEntryGroup>();
+        CategoryFilterOptions = new ObservableCollection<string> { AllCategoriesFilter };
+
+        UnlockCommand = new Command(async () => await UnlockAsync(), () => !IsBusy);
+        UnlockWithBiometricCommand = new Command(async () => await UnlockWithBiometricAsync(), () => !IsBusy && CanUseBiometric && IsBiometricConfigured);
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private ObservableCollection<VaultEntryGroup> _entryGroups;
+    public ObservableCollection<VaultEntryGroup> EntryGroups
+    {
+        get => _entryGroups;
+        private set
+        {
+            if (_entryGroups != value)
+            {
+                _entryGroups = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    public ObservableCollection<string> CategoryFilterOptions { get; }
+
+    public IReadOnlyList<string> AvailableCategories => _availableCategories;
+
+    public string SearchQuery
+    {
+        get => _searchQuery;
+        set
+        {
+            if (SetProperty(ref _searchQuery, value))
+            {
+                ApplyFilters();
+            }
+        }
+    }
+
+    public string SelectedCategory
+    {
+        get => _selectedCategory;
+        set
+        {
+            if (SetProperty(ref _selectedCategory, value))
+            {
+                ApplyFilters();
+            }
+        }
+    }
+
+    public bool IsBusy
+    {
+        get => _isBusy;
+        private set
+        {
+            if (SetProperty(ref _isBusy, value))
+            {
+                UpdateCommandStates();
+            }
+        }
+    }
+
+    public bool IsUnlocked
+    {
+        get => _isUnlocked;
+        private set
+        {
+            if (SetProperty(ref _isUnlocked, value))
+            {
+                OnPropertyChanged(nameof(IsLocked));
+            }
+        }
+    }
+
+    public bool IsLocked => !IsUnlocked;
+
+    public bool IsNewVault
+    {
+        get => _isNewVault;
+        private set => SetProperty(ref _isNewVault, value);
+    }
+
+    public bool CanUseBiometric
+    {
+        get => _canUseBiometric;
+        private set
+        {
+            if (SetProperty(ref _canUseBiometric, value))
+            {
+                UpdateCommandStates();
+            }
+        }
+    }
+
+    public bool IsBiometricConfigured
+    {
+        get => _isBiometricConfigured;
+        private set
+        {
+            if (SetProperty(ref _isBiometricConfigured, value))
+            {
+                if (!value && EnableBiometric)
+                {
+                    EnableBiometric = false;
+                }
+
+                UpdateCommandStates();
+            }
+        }
+    }
+
+    public bool EnableBiometric
+    {
+        get => _enableBiometric;
+        set => SetProperty(ref _enableBiometric, value);
+    }
+
+    public string Password
+    {
+        get => _password;
+        set
+        {
+            if (SetProperty(ref _password, value) && !string.IsNullOrEmpty(_unlockError))
+            {
+                UnlockError = null;
+            }
+        }
+    }
+
+    public string ConfirmPassword
+    {
+        get => _confirmPassword;
+        set
+        {
+            if (SetProperty(ref _confirmPassword, value) && !string.IsNullOrEmpty(_unlockError))
+            {
+                UnlockError = null;
+            }
+        }
+    }
+
+    public string? UnlockError
+    {
+        get => _unlockError;
+        private set => SetProperty(ref _unlockError, value);
+    }
+
+    public ICommand UnlockCommand { get; }
+
+    public ICommand UnlockWithBiometricCommand { get; }
+
+    public void Activate()
+    {
+        if (_isListening)
+        {
+            return;
+        }
+
+        MessagingCenter.Subscribe<DataVaultService>(this, DataVaultMessages.EntriesChanged, OnVaultEntriesChanged);
+        _isListening = true;
+    }
+
+    public void Deactivate()
+    {
+        if (_isListening)
+        {
+            MessagingCenter.Unsubscribe<DataVaultService>(this, DataVaultMessages.EntriesChanged);
+            _isListening = false;
+        }
+
+        _vaultService.Lock();
+        IsUnlocked = false;
+        _hasAttemptedAutoBiometric = false;
+        _allEntries.Clear();
+        _availableCategories.Clear();
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            EntryGroups = new ObservableCollection<VaultEntryGroup>();
+            CategoryFilterOptions.Clear();
+            CategoryFilterOptions.Add(AllCategoriesFilter);
+            _selectedCategory = AllCategoriesFilter;
+            OnPropertyChanged(nameof(SelectedCategory));
+        });
+    }
+
+    public async Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        await EnsureAccessStateAsync(cancellationToken);
+
+        if (IsUnlocked)
+        {
+            await ReloadAsync(cancellationToken);
+        }
+    }
+
+    public async Task ReloadAsync(CancellationToken cancellationToken = default, bool allowWhileBusy = false)
+    {
+        if ((!allowWhileBusy && IsBusy) || !IsUnlocked)
+        {
+            return;
+        }
+
+        try
+        {
+            IsBusy = true;
+            var entries = await _vaultService.GetEntriesAsync(cancellationToken);
+            UpdateEntries(entries);
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    public async Task SaveEntryAsync(PasswordVaultEntry entry, CancellationToken cancellationToken = default)
+    {
+        await _vaultService.AddOrUpdateEntryAsync(entry, cancellationToken);
+    }
+
+    public async Task DeleteEntryAsync(PasswordVaultEntry entry, CancellationToken cancellationToken = default)
+    {
+        if (entry is null)
+        {
+            return;
+        }
+
+        await _vaultService.DeleteEntryAsync(entry.Id, cancellationToken);
+    }
+
+    public async Task ChangeMasterPasswordAsync(string newPassword, bool enableBiometric, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(newPassword);
+
+        await _vaultService.ChangeMasterPasswordAsync(newPassword, enableBiometric && CanUseBiometric, cancellationToken);
+
+        EnableBiometric = enableBiometric && CanUseBiometric;
+        IsBiometricConfigured = EnableBiometric;
+    }
+
+    public Task<byte[]> CreateBackupAsync(CancellationToken cancellationToken = default)
+        => _vaultService.CreateBackupAsync(cancellationToken);
+
+    public Task RestoreBackupAsync(Stream backupStream, CancellationToken cancellationToken = default)
+        => _vaultService.RestoreBackupAsync(backupStream, cancellationToken);
+
+    public Task<byte[]> ExportEncryptedVaultAsync(CancellationToken cancellationToken = default)
+        => _vaultService.ExportEncryptedVaultAsync(cancellationToken);
+
+    public Task ImportEncryptedVaultAsync(Stream encryptedStream, CancellationToken cancellationToken = default)
+        => _vaultService.ImportEncryptedVaultAsync(encryptedStream, cancellationToken);
+
+    public async Task EnsureAccessStateAsync(CancellationToken cancellationToken = default)
+    {
+        IsUnlocked = _vaultService.IsUnlocked;
+        IsNewVault = !await _vaultService.HasMasterPasswordAsync(cancellationToken);
+        CanUseBiometric = await _biometricAuthenticationService.IsAvailableAsync(cancellationToken);
+        IsBiometricConfigured = CanUseBiometric && await _vaultService.HasBiometricKeyAsync(cancellationToken);
+        EnableBiometric = IsBiometricConfigured;
+        UnlockError = null;
+
+        if (!IsUnlocked)
+        {
+            _allEntries.Clear();
+            _availableCategories.Clear();
+            MainThread.BeginInvokeOnMainThread(() =>
+            {
+                EntryGroups = new ObservableCollection<VaultEntryGroup>();
+                CategoryFilterOptions.Clear();
+                CategoryFilterOptions.Add(AllCategoriesFilter);
+                _selectedCategory = AllCategoriesFilter;
+                OnPropertyChanged(nameof(SelectedCategory));
+            });
+
+            if (CanUseBiometric && IsBiometricConfigured && !_hasAttemptedAutoBiometric)
+            {
+                _hasAttemptedAutoBiometric = true;
+                await UnlockWithBiometricAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private async Task UnlockAsync(CancellationToken cancellationToken = default)
+    {
+        if (IsBusy)
+        {
+            return;
+        }
+
+        try
+        {
+            IsBusy = true;
+            UnlockError = null;
+
+            if (string.IsNullOrWhiteSpace(Password))
+            {
+                UnlockError = "Bitte gib ein Passwort ein.";
+                return;
+            }
+
+            if (IsNewVault)
+            {
+                if (!string.Equals(Password, ConfirmPassword, StringComparison.Ordinal))
+                {
+                    UnlockError = "Die Passwörter stimmen nicht überein.";
+                    return;
+                }
+
+                await _vaultService.SetMasterPasswordAsync(Password, EnableBiometric && CanUseBiometric, cancellationToken);
+                IsBiometricConfigured = EnableBiometric && CanUseBiometric;
+                await OnUnlockedAsync(cancellationToken);
+            }
+            else
+            {
+                var unlocked = await _vaultService.UnlockAsync(Password, cancellationToken);
+                if (!unlocked)
+                {
+                    UnlockError = "Das eingegebene Passwort ist ungültig.";
+                    return;
+                }
+
+                if (CanUseBiometric)
+                {
+                    await _vaultService.SetBiometricUnlockAsync(EnableBiometric, cancellationToken);
+                    IsBiometricConfigured = EnableBiometric;
+                }
+
+                await OnUnlockedAsync(cancellationToken);
+            }
+        }
+        finally
+        {
+            IsBusy = false;
+            UpdateCommandStates();
+        }
+    }
+
+    private async Task UnlockWithBiometricAsync(CancellationToken cancellationToken = default)
+    {
+        if (IsBusy || !CanUseBiometric || !IsBiometricConfigured)
+        {
+            return;
+        }
+
+        try
+        {
+            IsBusy = true;
+            UnlockError = null;
+
+            var authenticated = await _biometricAuthenticationService.AuthenticateAsync("Authentifiziere dich, um den Datentresor zu entsperren.", cancellationToken);
+            if (!authenticated)
+            {
+                UnlockError = "Die biometrische Authentifizierung wurde abgebrochen.";
+                return;
+            }
+
+            var unlocked = await _vaultService.TryUnlockWithStoredKeyAsync(cancellationToken);
+            if (!unlocked)
+            {
+                UnlockError = "Der gespeicherte biometrische Schlüssel ist nicht mehr gültig. Bitte gib dein Passwort ein.";
+                IsBiometricConfigured = false;
+                return;
+            }
+
+            EnableBiometric = true;
+            IsBiometricConfigured = true;
+            await OnUnlockedAsync(cancellationToken);
+        }
+        finally
+        {
+            IsBusy = false;
+            UpdateCommandStates();
+        }
+    }
+
+    private async Task OnUnlockedAsync(CancellationToken cancellationToken)
+    {
+        Password = string.Empty;
+        ConfirmPassword = string.Empty;
+        UnlockError = null;
+        IsUnlocked = true;
+        IsNewVault = false;
+        _hasAttemptedAutoBiometric = false;
+        await ReloadAsync(cancellationToken, allowWhileBusy: true);
+    }
+
+    private void UpdateEntries(IEnumerable<PasswordVaultEntry> entries)
+    {
+        var ordered = entries
+            .OrderBy(e => e.DisplayCategory, StringComparer.CurrentCultureIgnoreCase)
+            .ThenBy(e => e.Label, StringComparer.CurrentCultureIgnoreCase)
+            .ToList();
+
+        foreach (var entry in ordered)
+        {
+            entry.IsPasswordVisible = false;
+        }
+
+        _allEntries.Clear();
+        _allEntries.AddRange(ordered);
+
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            UpdateCategoryFiltersOnMainThread();
+            ApplyFiltersOnMainThread();
+        });
+    }
+
+    private async void OnVaultEntriesChanged(DataVaultService sender)
+    {
+        try
+        {
+            await EnsureAccessStateAsync();
+            if (IsUnlocked)
+            {
+                await ReloadAsync();
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Fehler beim Aktualisieren des Datentresors: {ex}");
+        }
+    }
+
+    private void UpdateCommandStates()
+    {
+        if (UnlockCommand is Command unlockCommand)
+        {
+            MainThread.BeginInvokeOnMainThread(unlockCommand.ChangeCanExecute);
+        }
+
+        if (UnlockWithBiometricCommand is Command biometricCommand)
+        {
+            MainThread.BeginInvokeOnMainThread(biometricCommand.ChangeCanExecute);
+        }
+    }
+
+    private void ApplyFilters()
+        => MainThread.BeginInvokeOnMainThread(ApplyFiltersOnMainThread);
+
+    private void ApplyFiltersOnMainThread()
+    {
+        var query = SearchQuery?.Trim();
+        var selectedCategory = SelectedCategory;
+
+        IEnumerable<PasswordVaultEntry> filtered = _allEntries;
+
+        if (!string.IsNullOrWhiteSpace(query))
+        {
+            filtered = filtered.Where(entry =>
+                entry.Label.Contains(query, StringComparison.CurrentCultureIgnoreCase) ||
+                entry.Username.Contains(query, StringComparison.CurrentCultureIgnoreCase) ||
+                entry.Url.Contains(query, StringComparison.CurrentCultureIgnoreCase) ||
+                entry.Notes.Contains(query, StringComparison.CurrentCultureIgnoreCase) ||
+                entry.FreeText.Contains(query, StringComparison.CurrentCultureIgnoreCase) ||
+                entry.DisplayCategory.Contains(query, StringComparison.CurrentCultureIgnoreCase));
+        }
+
+        if (!string.IsNullOrWhiteSpace(selectedCategory) &&
+            !string.Equals(selectedCategory, AllCategoriesFilter, StringComparison.CurrentCultureIgnoreCase))
+        {
+            filtered = filtered.Where(entry => string.Equals(entry.DisplayCategory, selectedCategory, StringComparison.CurrentCultureIgnoreCase));
+        }
+
+        var grouped = filtered
+            .GroupBy(entry => entry.DisplayCategory, StringComparer.CurrentCultureIgnoreCase)
+            .OrderBy(group => group.Key, StringComparer.CurrentCultureIgnoreCase)
+            .Select(group => new VaultEntryGroup(group.Key, group.OrderBy(entry => entry.Label, StringComparer.CurrentCultureIgnoreCase).ToList()))
+            .ToList();
+
+        // Replace entire collection instead of Clear/Add to avoid MAUI CollectionView grouping bug
+        EntryGroups = new ObservableCollection<VaultEntryGroup>(grouped);
+    }
+
+    private void UpdateCategoryFiltersOnMainThread()
+    {
+        var categories = _allEntries
+            .Select(entry => entry.DisplayCategory)
+            .Distinct(StringComparer.CurrentCultureIgnoreCase)
+            .OrderBy(category => category, StringComparer.CurrentCultureIgnoreCase)
+            .ToList();
+
+        _availableCategories.Clear();
+        _availableCategories.AddRange(categories);
+
+        CategoryFilterOptions.Clear();
+        CategoryFilterOptions.Add(AllCategoriesFilter);
+
+        foreach (var category in categories)
+        {
+            CategoryFilterOptions.Add(category);
+        }
+
+        var hasSelectedCategory = categories.Any(category => string.Equals(category, SelectedCategory, StringComparison.CurrentCultureIgnoreCase));
+        if (string.IsNullOrWhiteSpace(SelectedCategory) ||
+            (!string.Equals(SelectedCategory, AllCategoriesFilter, StringComparison.CurrentCultureIgnoreCase) && !hasSelectedCategory))
+        {
+            _selectedCategory = AllCategoriesFilter;
+            OnPropertyChanged(nameof(SelectedCategory));
+        }
+    }
+
+    private bool SetProperty<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value))
+        {
+            return false;
+        }
+
+        field = value;
+        OnPropertyChanged(propertyName);
+        return true;
+    }
+
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+}

--- a/Password Phrase Producer/ViewModels/StartPageViewModel.cs
+++ b/Password Phrase Producer/ViewModels/StartPageViewModel.cs
@@ -15,6 +15,7 @@ public class StartPageViewModel
         FeaturedMode = ModeOptions.FirstOrDefault();
         NavigateToModeCommand = new Command<PasswordModeOption>(NavigateToMode);
         NavigateToVaultCommand = new Command(NavigateToVault);
+        NavigateToDataVaultCommand = new Command(NavigateToDataVault);
         NavigateToGenerationCommand = new Command(NavigateToGeneration);
         NavigateToAuthenticatorCommand = new Command(NavigateToAuthenticator);
     }
@@ -25,6 +26,7 @@ public class StartPageViewModel
 
     public ICommand NavigateToModeCommand { get; }
     public ICommand NavigateToVaultCommand { get; }
+    public ICommand NavigateToDataVaultCommand { get; }
     public ICommand NavigateToGenerationCommand { get; }
     public ICommand NavigateToAuthenticatorCommand { get; }
 
@@ -42,6 +44,12 @@ public class StartPageViewModel
     {
         // Navigate to the Vault page (defined in AppShell with route 'vault')
         await Shell.Current.GoToAsync("//vault");
+    }
+
+    private async void NavigateToDataVault()
+    {
+        // Navigate to the Data Vault page (defined in AppShell with route 'data-vault')
+        await Shell.Current.GoToAsync("//data-vault");
     }
 
     private async void NavigateToGeneration()

--- a/Password Phrase Producer/Views/DataVaultPage.xaml
+++ b/Password Phrase Producer/Views/DataVaultPage.xaml
@@ -1,0 +1,692 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    x:Class="Password_Phrase_Producer.Views.DataVaultPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:converters="clr-namespace:Password_Phrase_Producer.Converters"
+    xmlns:models="clr-namespace:Password_Phrase_Producer.Models"
+    xmlns:viewmodels="clr-namespace:Password_Phrase_Producer.ViewModels"
+    Padding="0"
+    Shell.NavBarIsVisible="False">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <converters:PasswordMaskConverter x:Key="PasswordMaskConverter" />
+            <converters:StringNotNullOrWhiteSpaceConverter x:Key="StringNotNullOrWhiteSpaceConverter" />
+        </ResourceDictionary>
+    </ContentPage.Resources>
+
+    <ContentPage.Background>
+        <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
+            <GradientStop Color="#101018" Offset="0" />
+            <GradientStop Color="#141426" Offset="0.6" />
+            <GradientStop Color="#0F111A" Offset="1" />
+        </LinearGradientBrush>
+    </ContentPage.Background>
+
+    <Grid>
+        <Grid RowDefinitions="Auto,*">
+            <!-- Header Area -->
+            <Grid
+                Padding="16,16,16,10"
+                RowSpacing="10"
+                RowDefinitions="Auto,Auto">
+                
+                <!-- Top Bar: Menu, Title, Actions, Back -->
+                <Grid
+                    ColumnDefinitions="Auto,*,Auto,Auto"
+                    ColumnSpacing="10"
+                    VerticalOptions="Center">
+                    
+                    <!-- Menu Button -->
+                    <Border
+                        WidthRequest="34"
+                        HeightRequest="34"
+                        BackgroundColor="#1F2338"
+                        StrokeThickness="0"
+                        VerticalOptions="Center">
+                        <Border.StrokeShape>
+                            <RoundRectangle CornerRadius="10" />
+                        </Border.StrokeShape>
+                        <Border.Shadow>
+                            <Shadow Brush="#25000000" Radius="6" Offset="0,3" />
+                        </Border.Shadow>
+                        <Border.GestureRecognizers>
+                            <TapGestureRecognizer Tapped="OnOpenMenuTapped" />
+                        </Border.GestureRecognizers>
+                        <Image
+                            Source="menu.png"
+                            WidthRequest="18"
+                            HeightRequest="18"
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center" />
+                    </Border>
+
+                    <Label
+                        Grid.Column="1"
+                        Text="Datentresor"
+                        FontSize="18"
+                        FontAttributes="Bold"
+                        VerticalOptions="Center"
+                        TextColor="White" />
+
+                    <!-- Add Button -->
+                    <Border
+                        Grid.Column="2"
+                        WidthRequest="34"
+                        HeightRequest="34"
+                        BackgroundColor="#4A5CFF"
+                        StrokeThickness="0"
+                        VerticalOptions="Center"
+                        IsVisible="{Binding IsUnlocked}">
+                        <Border.StrokeShape>
+                            <RoundRectangle CornerRadius="10" />
+                        </Border.StrokeShape>
+                        <Border.Shadow>
+                            <Shadow Brush="#25000000" Radius="6" Offset="0,3" />
+                        </Border.Shadow>
+                        <Border.GestureRecognizers>
+                            <TapGestureRecognizer Tapped="OnAddEntryClicked" />
+                        </Border.GestureRecognizers>
+                        <Image
+                            Source="plus.png"
+                            WidthRequest="18"
+                            HeightRequest="18"
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center" />
+                    </Border>
+
+                    <!-- Back Button -->
+                    <Border
+                        Grid.Column="3"
+                        WidthRequest="34"
+                        HeightRequest="34"
+                        BackgroundColor="#1F2338"
+                        StrokeThickness="0"
+                        HorizontalOptions="End"
+                        VerticalOptions="Center">
+                        <Border.StrokeShape>
+                            <RoundRectangle CornerRadius="10" />
+                        </Border.StrokeShape>
+                        <Border.Shadow>
+                            <Shadow Brush="#25000000" Radius="6" Offset="0,3" />
+                        </Border.Shadow>
+                        <Border.GestureRecognizers>
+                            <TapGestureRecognizer Tapped="OnBackTapped" />
+                        </Border.GestureRecognizers>
+                        <Image
+                            Source="chevronright.png"
+                            WidthRequest="18"
+                            HeightRequest="18"
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center"
+                            Rotation="180" />
+                    </Border>
+                </Grid>
+
+                <!-- Search and Filter Bar -->
+                <Grid Grid.Row="1" ColumnDefinitions="*,Auto" ColumnSpacing="10">
+                    <Border
+                        BackgroundColor="#1F2338"
+                        StrokeThickness="0"
+                        Padding="10,3"
+                        HeightRequest="36"
+                        HorizontalOptions="Fill"
+                        VerticalOptions="Center">
+                        <Border.StrokeShape>
+                            <RoundRectangle CornerRadius="10" />
+                        </Border.StrokeShape>
+                        <Grid ColumnDefinitions="Auto,*" ColumnSpacing="8">
+                            <Image
+                                Source="search.png"
+                                WidthRequest="14"
+                                HeightRequest="14"
+                                VerticalOptions="Center" />
+                            <Entry
+                                Grid.Column="1"
+                                Text="{Binding SearchQuery}"
+                                Placeholder="Suche"
+                                PlaceholderColor="#7F85B2"
+                                TextColor="White"
+                                FontSize="12"
+                                BackgroundColor="Transparent"
+                                HeightRequest="32"
+                                ClearButtonVisibility="WhileEditing" />
+                        </Grid>
+                    </Border>
+
+                    <Border
+                        Grid.Column="1"
+                        WidthRequest="36"
+                        HeightRequest="36"
+                        StrokeThickness="0"
+                        BackgroundColor="#1F2338"
+                        HorizontalOptions="End"
+                        VerticalOptions="Center">
+                        <Border.StrokeShape>
+                            <RoundRectangle CornerRadius="10" />
+                        </Border.StrokeShape>
+                        <Border.GestureRecognizers>
+                            <TapGestureRecognizer Tapped="OnCategoryFilterTapped" />
+                        </Border.GestureRecognizers>
+                        <Grid>
+                            <Image
+                                Source="funnel.png"
+                                WidthRequest="18"
+                                HeightRequest="18"
+                                HorizontalOptions="Center"
+                                VerticalOptions="Center" />
+                            <Border
+                                WidthRequest="7"
+                                HeightRequest="7"
+                                BackgroundColor="#63F5A8"
+                                StrokeThickness="0"
+                                HorizontalOptions="End"
+                                VerticalOptions="Start"
+                                Margin="0,5,5,0">
+                                <Border.StrokeShape>
+                                    <Ellipse />
+                                </Border.StrokeShape>
+                                <Border.Triggers>
+                                    <DataTrigger TargetType="Border"
+                                                 Binding="{Binding SelectedCategory}"
+                                                 Value="Alle Kategorien">
+                                        <Setter Property="IsVisible" Value="False" />
+                                    </DataTrigger>
+                                </Border.Triggers>
+                            </Border>
+                        </Grid>
+                    </Border>
+                </Grid>
+            </Grid>
+
+            <!-- Entries List -->
+            <CollectionView
+                x:Name="VaultCollectionView"
+                Grid.Row="1"
+                Margin="16,0,16,16"
+                ItemsSource="{Binding EntryGroups}"
+                SelectionMode="None"
+                ItemSizingStrategy="MeasureAllItems"
+                VerticalOptions="FillAndExpand"
+                VerticalScrollBarVisibility="Never"
+                IsGrouped="True">
+            <CollectionView.ItemsLayout>
+                <LinearItemsLayout Orientation="Vertical" ItemSpacing="12" />
+            </CollectionView.ItemsLayout>
+            <CollectionView.GroupHeaderTemplate>
+                <DataTemplate x:DataType="viewmodels:VaultEntryGroup">
+                    <Label
+                        Text="{Binding Category}"
+                        FontSize="12"
+                        FontAttributes="Bold"
+                        TextColor="#E8EBFF"
+                        Margin="0,12,0,6" />
+                </DataTemplate>
+            </CollectionView.GroupHeaderTemplate>
+            <CollectionView.EmptyView>
+                <VerticalStackLayout
+                    Padding="20"
+                    Spacing="10"
+                    HorizontalOptions="Center"
+                    VerticalOptions="Center">
+                    <Border
+                        WidthRequest="52"
+                        HeightRequest="52"
+                        BackgroundColor="#1F2338"
+                        StrokeThickness="0">
+                        <Border.StrokeShape>
+                            <RoundRectangle CornerRadius="16" />
+                        </Border.StrokeShape>
+                        <Label
+                            Text="D"
+                            FontSize="22"
+                            FontAttributes="Bold"
+                            TextColor="#CFD3FF"
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center" />
+                    </Border>
+                    <Label
+                        Text="Keine Einträge"
+                        FontSize="14"
+                        FontAttributes="Bold"
+                        HorizontalTextAlignment="Center"
+                        TextColor="#E8EBFF" />
+                    <Label
+                        Text="Füge deinen ersten sicheren Datensatz hinzu."
+                        FontSize="12"
+                        HorizontalTextAlignment="Center"
+                        TextColor="#9EA3C4" />
+                </VerticalStackLayout>
+            </CollectionView.EmptyView>
+
+            <CollectionView.ItemTemplate>
+                <DataTemplate x:DataType="models:PasswordVaultEntry">
+                    <Border
+                        Padding="12"
+                        StrokeThickness="0"
+                        BackgroundColor="#1B2036">
+                        <Border.StrokeShape>
+                            <RoundRectangle CornerRadius="14" />
+                        </Border.StrokeShape>
+                        <Border.Shadow>
+                            <Shadow Brush="#25000000" Radius="10" Offset="0,4" />
+                        </Border.Shadow>
+                        <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto" RowSpacing="8">
+                            <!-- Title Row -->
+                            <Grid ColumnDefinitions="*,Auto" RowSpacing="0">
+                                <VerticalStackLayout Spacing="3">
+                                    <Label
+                                        Text="{Binding Label}"
+                                        FontSize="14"
+                                        FontAttributes="Bold"
+                                        TextColor="White" />
+                                    <Border
+                                        Padding="6,2"
+                                        BackgroundColor="#2A2F4A"
+                                        StrokeThickness="0"
+                                        HorizontalOptions="Start">
+                                        <Border.StrokeShape>
+                                            <RoundRectangle CornerRadius="6" />
+                                        </Border.StrokeShape>
+                                        <Label
+                                            Text="{Binding DisplayCategory}"
+                                            FontSize="10"
+                                            TextColor="#9EA3C4" />
+                                    </Border>
+                                </VerticalStackLayout>
+
+                                <!-- Action Buttons -->
+                                <HorizontalStackLayout
+                                    Grid.Column="1"
+                                    Spacing="6"
+                                    VerticalOptions="Start"
+                                    HorizontalOptions="End">
+                                    <Border
+                                        WidthRequest="30"
+                                        HeightRequest="30"
+                                        BackgroundColor="#2A2F4A"
+                                        StrokeThickness="0"
+                                        VerticalOptions="Center">
+                                        <Border.StrokeShape>
+                                            <RoundRectangle CornerRadius="8" />
+                                        </Border.StrokeShape>
+                                        <Border.GestureRecognizers>
+                                            <TapGestureRecognizer
+                                                Tapped="OnShowDetailTapped"
+                                                CommandParameter="{Binding .}" />
+                                        </Border.GestureRecognizers>
+                                        <Image
+                                            Source="maximize.png"
+                                            WidthRequest="16"
+                                            HeightRequest="16"
+                                            HorizontalOptions="Center"
+                                            VerticalOptions="Center" />
+                                    </Border>
+                                    <Border
+                                        WidthRequest="30"
+                                        HeightRequest="30"
+                                        BackgroundColor="#2A2F4A"
+                                        StrokeThickness="0"
+                                        VerticalOptions="Center">
+                                        <Border.StrokeShape>
+                                            <RoundRectangle CornerRadius="8" />
+                                        </Border.StrokeShape>
+                                        <Border.GestureRecognizers>
+                                            <TapGestureRecognizer
+                                                Tapped="OnEditEntryTapped"
+                                                CommandParameter="{Binding .}" />
+                                        </Border.GestureRecognizers>
+                                        <Image
+                                            Source="pencil.png"
+                                            WidthRequest="14"
+                                            HeightRequest="14"
+                                            HorizontalOptions="Center"
+                                            VerticalOptions="Center" />
+                                    </Border>
+                                    <Border
+                                        WidthRequest="30"
+                                        HeightRequest="30"
+                                        BackgroundColor="#3B2232"
+                                        StrokeThickness="0"
+                                        VerticalOptions="Center">
+                                        <Border.StrokeShape>
+                                            <RoundRectangle CornerRadius="8" />
+                                        </Border.StrokeShape>
+                                        <Border.GestureRecognizers>
+                                            <TapGestureRecognizer
+                                                Tapped="OnDeleteEntryTapped"
+                                                CommandParameter="{Binding .}" />
+                                        </Border.GestureRecognizers>
+                                        <Image
+                                            Source="trash.png"
+                                            WidthRequest="14"
+                                            HeightRequest="14"
+                                            HorizontalOptions="Center"
+                                            VerticalOptions="Center" />
+                                    </Border>
+                                </HorizontalStackLayout>
+                            </Grid>
+
+                            <!-- Username Row -->
+                            <Grid
+                                Grid.Row="1"
+                                ColumnDefinitions="Auto,*,Auto"
+                                ColumnSpacing="10"
+                                IsVisible="{Binding Username, Converter={StaticResource StringNotNullOrWhiteSpaceConverter}}">
+                                <Label
+                                    Text="Benutzer"
+                                    FontSize="11"
+                                    TextColor="#9EA3C4"
+                                    FontAttributes="Bold"
+                                    VerticalOptions="Center" />
+                                <Label
+                                    Grid.Column="1"
+                                    Text="{Binding Username}"
+                                    FontSize="12"
+                                    TextColor="#E8EBFF"
+                                    LineBreakMode="TailTruncation"
+                                    VerticalOptions="Center" />
+                                <Border
+                                    Grid.Column="2"
+                                    WidthRequest="30"
+                                    HeightRequest="30"
+                                    BackgroundColor="#2A2F4A"
+                                    StrokeThickness="0"
+                                    VerticalOptions="Center">
+                                    <Border.StrokeShape>
+                                        <RoundRectangle CornerRadius="8" />
+                                    </Border.StrokeShape>
+                                    <Border.GestureRecognizers>
+                                        <TapGestureRecognizer
+                                            Tapped="OnCopyUsernameTapped"
+                                            CommandParameter="{Binding .}" />
+                                    </Border.GestureRecognizers>
+                                    <Image
+                                        Source="copy.png"
+                                        WidthRequest="14"
+                                        HeightRequest="14"
+                                        HorizontalOptions="Center"
+                                        VerticalOptions="Center" />
+                                </Border>
+                            </Grid>
+
+                            <!-- Password Row -->
+                            <Grid
+                                Grid.Row="2"
+                                ColumnDefinitions="Auto,*"
+                                ColumnSpacing="10"
+                                IsVisible="{Binding Password, Converter={StaticResource StringNotNullOrWhiteSpaceConverter}}">
+                                <Label
+                                    Text="Passwort"
+                                    FontSize="11"
+                                    TextColor="#9EA3C4"
+                                    FontAttributes="Bold"
+                                    VerticalOptions="Center" />
+                                <Grid Grid.Column="1" ColumnDefinitions="*,Auto,Auto" ColumnSpacing="6">
+                                    <Label
+                                        FontSize="12"
+                                        TextColor="#E8EBFF"
+                                        LineBreakMode="NoWrap"
+                                        VerticalOptions="Center">
+                                        <Label.Triggers>
+                                            <DataTrigger TargetType="Label" Binding="{Binding IsPasswordVisible}" Value="True">
+                                                <Setter Property="Text" Value="{Binding Password}" />
+                                            </DataTrigger>
+                                            <DataTrigger TargetType="Label" Binding="{Binding IsPasswordVisible}" Value="False">
+                                                <Setter Property="Text" Value="{Binding Password, Converter={StaticResource PasswordMaskConverter}}" />
+                                            </DataTrigger>
+                                        </Label.Triggers>
+                                    </Label>
+                                    <Border
+                                        Grid.Column="1"
+                                        WidthRequest="30"
+                                        HeightRequest="30"
+                                        BackgroundColor="#2A2F4A"
+                                        StrokeThickness="0"
+                                        VerticalOptions="Center">
+                                        <Border.StrokeShape>
+                                            <RoundRectangle CornerRadius="8" />
+                                        </Border.StrokeShape>
+                                        <Border.GestureRecognizers>
+                                            <TapGestureRecognizer
+                                                Tapped="OnTogglePasswordVisibilityTapped"
+                                                CommandParameter="{Binding .}" />
+                                        </Border.GestureRecognizers>
+                                        <Image
+                                            Source="eyeoff.png"
+                                            WidthRequest="14"
+                                            HeightRequest="14"
+                                            HorizontalOptions="Center"
+                                            VerticalOptions="Center">
+                                            <Image.Triggers>
+                                                <DataTrigger TargetType="Image" Binding="{Binding IsPasswordVisible}" Value="True">
+                                                    <Setter Property="Source" Value="eye.png" />
+                                                </DataTrigger>
+                                            </Image.Triggers>
+                                        </Image>
+                                    </Border>
+                                    <Border
+                                        Grid.Column="2"
+                                        WidthRequest="30"
+                                        HeightRequest="30"
+                                        BackgroundColor="#2A2F4A"
+                                        StrokeThickness="0"
+                                        VerticalOptions="Center">
+                                        <Border.StrokeShape>
+                                            <RoundRectangle CornerRadius="8" />
+                                        </Border.StrokeShape>
+                                        <Border.GestureRecognizers>
+                                            <TapGestureRecognizer
+                                                Tapped="OnCopyPasswordTapped"
+                                                CommandParameter="{Binding .}" />
+                                        </Border.GestureRecognizers>
+                                        <Image
+                                            Source="copy.png"
+                                            WidthRequest="14"
+                                            HeightRequest="14"
+                                            HorizontalOptions="Center"
+                                            VerticalOptions="Center" />
+                                    </Border>
+                                </Grid>
+                            </Grid>
+
+                            <!-- URL Row -->
+                            <Grid
+                                Grid.Row="3"
+                                ColumnDefinitions="Auto,*"
+                                ColumnSpacing="10"
+                                IsVisible="{Binding Url, Converter={StaticResource StringNotNullOrWhiteSpaceConverter}}">
+                                <Label
+                                    Text="URL"
+                                    FontSize="11"
+                                    TextColor="#9EA3C4"
+                                    FontAttributes="Bold"
+                                    VerticalOptions="Center" />
+                                <Label
+                                    Grid.Column="1"
+                                    Text="{Binding Url}"
+                                    FontSize="12"
+                                    TextColor="#58A7FF"
+                                    TextDecorations="Underline">
+                                    <Label.GestureRecognizers>
+                                        <TapGestureRecognizer
+                                            CommandParameter="{Binding Url}"
+                                            Tapped="OnOpenUrl" />
+                                    </Label.GestureRecognizers>
+                                </Label>
+                            </Grid>
+
+                            <!-- Notes -->
+                            <VerticalStackLayout Grid.Row="4" Spacing="4">
+                                <Label
+                                    Text="{Binding Notes}"
+                                    FontSize="11"
+                                    TextColor="#9EA3C4"
+                                    LineBreakMode="WordWrap">
+                                    <Label.Triggers>
+                                        <Trigger TargetType="Label" Property="Text" Value="">
+                                            <Setter Property="IsVisible" Value="False" />
+                                        </Trigger>
+                                        <Trigger TargetType="Label" Property="Text" Value="{x:Null}">
+                                            <Setter Property="IsVisible" Value="False" />
+                                        </Trigger>
+                                    </Label.Triggers>
+                                </Label>
+
+                                <Label
+                                    Text="{Binding FreeText}"
+                                    FontSize="11"
+                                    TextColor="#9EA3C4"
+                                    LineBreakMode="WordWrap">
+                                    <Label.Triggers>
+                                        <Trigger TargetType="Label" Property="Text" Value="">
+                                            <Setter Property="IsVisible" Value="False" />
+                                        </Trigger>
+                                        <Trigger TargetType="Label" Property="Text" Value="{x:Null}">
+                                            <Setter Property="IsVisible" Value="False" />
+                                        </Trigger>
+                                    </Label.Triggers>
+                                </Label>
+
+                                <Label
+                                    Text="{Binding LocalModifiedAt, StringFormat='Aktualisiert: {0:d}'}"
+                                    FontSize="9"
+                                    TextColor="#5A6080"
+                                    HorizontalOptions="End" />
+                            </VerticalStackLayout>
+                        </Grid>
+                    </Border>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+            </CollectionView>
+        </Grid>
+
+        <!-- Lock Screen / Access -->
+        <Grid
+            IsVisible="{Binding IsLocked}"
+            BackgroundColor="#CC0B0D1A"
+            HorizontalOptions="Fill"
+            VerticalOptions="Fill">
+            <ScrollView HorizontalOptions="Fill" VerticalOptions="Fill">
+                <Grid HorizontalOptions="Fill" VerticalOptions="Center" MinimumHeightRequest="400">
+                    <VerticalStackLayout Spacing="16" HorizontalOptions="Center" VerticalOptions="Center" MaximumWidthRequest="360" Padding="18">
+                    <Border
+                        Padding="10,6"
+                        StrokeThickness="0"
+                        BackgroundColor="#1F2338"
+                        HorizontalOptions="Start">
+                        <Border.StrokeShape>
+                            <RoundRectangle CornerRadius="10" />
+                        </Border.StrokeShape>
+                        <Border.GestureRecognizers>
+                            <TapGestureRecognizer Tapped="OnBackTapped" />
+                        </Border.GestureRecognizers>
+                        <HorizontalStackLayout Spacing="5" VerticalOptions="Center">
+                            <Image
+                                Source="chevronright.png"
+                                WidthRequest="12"
+                                HeightRequest="12"
+                                VerticalOptions="Center"
+                                Rotation="180" />
+                            <Label
+                                Text="Zurück"
+                                FontSize="12"
+                                TextColor="#CFD3FF" />
+                        </HorizontalStackLayout>
+                    </Border>
+
+                    <VerticalStackLayout Spacing="6" HorizontalOptions="Center" VerticalOptions="Center">
+                        <Label
+                            Text="Datentresor gesperrt"
+                            FontSize="18"
+                            FontAttributes="Bold"
+                            TextColor="White"
+                            HorizontalTextAlignment="Center" />
+                        <Label
+                            Text="Bitte gib dein Master-Passwort ein."
+                            FontSize="12"
+                            TextColor="#9EA3C4"
+                            HorizontalTextAlignment="Center" />
+                        <Button
+                            Text="Einstellungen öffnen"
+                            Clicked="OnSettingsButtonClicked"
+                            BackgroundColor="#1F2338"
+                            TextColor="#E8EBFF"
+                            CornerRadius="10"
+                            HeightRequest="36"
+                            Padding="14,6"
+                            FontSize="12"
+                            Margin="0,6,0,0" />
+                    </VerticalStackLayout>
+
+                    <VerticalStackLayout Spacing="10">
+                        <Entry
+                            Text="{Binding Password}"
+                            IsPassword="True"
+                            Placeholder="Master-Passwort"
+                            PlaceholderColor="#7F85B2"
+                            TextColor="White"
+                            BackgroundColor="#1F2338"
+                            HeightRequest="40"
+                            Margin="0,3"
+                            HorizontalOptions="Fill" />
+                        <Entry
+                            Text="{Binding ConfirmPassword}"
+                            IsVisible="{Binding IsNewVault}"
+                            IsPassword="True"
+                            Placeholder="Passwort bestätigen"
+                            PlaceholderColor="#7F85B2"
+                            TextColor="White"
+                            BackgroundColor="#1F2338"
+                            HeightRequest="40"
+                            Margin="0,3"
+                            HorizontalOptions="Fill" />
+
+                        <Label
+                            Text="{Binding UnlockError}"
+                            TextColor="#FF7474"
+                            FontSize="11"
+                            IsVisible="{Binding UnlockError, Converter={StaticResource StringNotNullOrWhiteSpaceConverter}}"
+                            HorizontalTextAlignment="Center" />
+                    </VerticalStackLayout>
+
+                    <VerticalStackLayout Spacing="8">
+                        <Grid ColumnDefinitions="Auto,*" IsVisible="{Binding CanUseBiometric}">
+                            <Switch
+                                Grid.Column="0"
+                                IsToggled="{Binding EnableBiometric}" />
+                            <Label
+                                Grid.Column="1"
+                                Text="Biometrisch entsperren"
+                                FontSize="12"
+                                TextColor="#E8EBFF"
+                                Margin="10,0,0,0"
+                                VerticalOptions="Center" />
+                        </Grid>
+
+                        <Button
+                            Text="Entsperren"
+                            Command="{Binding UnlockCommand}"
+                            HeightRequest="40"
+                            FontAttributes="Bold"
+                            BackgroundColor="#4A5CFF"
+                            TextColor="White"
+                            CornerRadius="10" />
+
+                        <Button
+                            Text="Fingerabdruck"
+                            Command="{Binding UnlockWithBiometricCommand}"
+                            HeightRequest="40"
+                            CornerRadius="10"
+                            BackgroundColor="#1F2338"
+                            TextColor="#E8EBFF"
+                            BorderColor="#4A5CFF"
+                            BorderWidth="1"
+                            IsVisible="{Binding CanUseBiometric}" />
+                    </VerticalStackLayout>
+                </VerticalStackLayout>
+                </Grid>
+            </ScrollView>
+        </Grid>
+    </Grid>
+</ContentPage>

--- a/Password Phrase Producer/Views/DataVaultPage.xaml.cs
+++ b/Password Phrase Producer/Views/DataVaultPage.xaml.cs
@@ -1,0 +1,637 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using CommunityToolkit.Maui.Views;
+using CommunityToolkit.Maui.Storage;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.ApplicationModel.DataTransfer;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Storage;
+using Password_Phrase_Producer.Models;
+using Password_Phrase_Producer.ViewModels;
+using Password_Phrase_Producer.Services;
+using Password_Phrase_Producer.Views.Dialogs;
+
+namespace Password_Phrase_Producer.Views;
+
+public partial class DataVaultPage : ContentPage
+{
+    private readonly DataVaultPageViewModel _viewModel;
+    private int _modalDepth;
+
+    public DataVaultPage(DataVaultPageViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = _viewModel = viewModel;
+    }
+
+    protected override async void OnAppearing()
+    {
+        base.OnAppearing();
+
+        if (_modalDepth > 0)
+        {
+            return;
+        }
+
+        _viewModel.Activate();
+        await _viewModel.InitializeAsync();
+    }
+
+    protected override void OnDisappearing()
+    {
+        base.OnDisappearing();
+
+        if (_modalDepth > 0)
+        {
+            return;
+        }
+
+        _viewModel.Deactivate();
+    }
+
+    private async void OnAddEntryClicked(object? sender, EventArgs e)
+    {
+        if (!_viewModel.IsUnlocked)
+        {
+            await DisplayAlert("Datentresor gesperrt", "Bitte entsperre den Datentresor, bevor du neue Einträge hinzufügst.", "OK");
+            return;
+        }
+
+        var entry = new PasswordVaultEntry();
+        await ShowEditorAsync(entry, "Neuer Datentresor-Eintrag");
+    }
+
+    private async void OnShowDetailTapped(object? sender, TappedEventArgs e)
+    {
+        if (e.Parameter is not PasswordVaultEntry entry)
+        {
+            return;
+        }
+
+        BeginModalInteraction();
+        try
+        {
+            var editRequested = await VaultEntryDetailPage.ShowAsync(Navigation, entry);
+            if (editRequested)
+            {
+                var editable = entry.Clone();
+                await ShowEditorAsync(editable, "Eintrag bearbeiten");
+            }
+        }
+        finally
+        {
+            EndModalInteraction();
+        }
+    }
+
+    private async void OnEditEntryTapped(object? sender, TappedEventArgs e)
+    {
+        if (e.Parameter is not PasswordVaultEntry entry)
+        {
+            return;
+        }
+
+        var editable = entry.Clone();
+        await ShowEditorAsync(editable, "Eintrag bearbeiten");
+    }
+
+    private async void OnDeleteEntryTapped(object? sender, TappedEventArgs e)
+    {
+        if (e.Parameter is not PasswordVaultEntry entry)
+        {
+            return;
+        }
+
+        var popup = new ConfirmationPopup("Eintrag löschen", $"Soll der Eintrag '{entry.Label}' gelöscht werden?", "Löschen", "Abbrechen", true);
+        var result = await this.ShowPopupAsync(popup);
+        if (result is not bool confirm || !confirm)
+        {
+            return;
+        }
+
+        await _viewModel.DeleteEntryAsync(entry);
+    }
+
+    private async void OnOpenUrl(object? sender, TappedEventArgs e)
+    {
+        var url = e.Parameter as string;
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return;
+        }
+
+        url = url.Trim();
+        if (!url.StartsWith("http://", StringComparison.OrdinalIgnoreCase) &&
+            !url.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+        {
+            url = $"https://{url}";
+        }
+
+        try
+        {
+            await Launcher.OpenAsync(url);
+        }
+        catch (Exception ex)
+        {
+            await DisplayAlert("Fehler", $"Die URL konnte nicht geöffnet werden: {ex.Message}", "OK");
+        }
+    }
+
+    private async void OnBackTapped(object? sender, TappedEventArgs e)
+    {
+        if (Shell.Current is not null)
+        {
+            await Shell.Current.GoToAsync("//home");
+        }
+    }
+
+    private async Task ShowEditorAsync(PasswordVaultEntry entry, string title)
+    {
+        BeginModalInteraction();
+        try
+        {
+            PasswordVaultEntry? result;
+            try
+            {
+                result = await VaultEntryEditorPage.ShowAsync(Navigation, entry, title, _viewModel.AvailableCategories);
+            }
+            catch (InvalidOperationException ex)
+            {
+                Debug.WriteLine($"[DataVaultPage] Editor konnte nicht geöffnet werden: {ex}");
+
+                var message = BuildEditorErrorMessage("Der Editor konnte nicht geöffnet werden.", ex);
+                await DisplayAlert("Editor nicht verfügbar", message, "OK");
+                return;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[DataVaultPage] Unerwarteter Fehler beim Öffnen des Editors: {ex}");
+
+                var message = BuildEditorErrorMessage("Beim Öffnen des Editors ist ein unerwarteter Fehler aufgetreten.", ex);
+                await DisplayAlert("Fehler", message, "OK");
+                return;
+            }
+
+            if (result is null)
+            {
+                return;
+            }
+
+            try
+            {
+                await _viewModel.SaveEntryAsync(result);
+            }
+            catch (Exception ex)
+            {
+                await DisplayAlert("Fehler", $"Der Eintrag konnte nicht gespeichert werden: {ex.Message}", "OK");
+            }
+        }
+        finally
+        {
+            EndModalInteraction();
+        }
+    }
+
+    private static string BuildEditorErrorMessage(string headline, Exception exception)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine(headline);
+        builder.AppendLine();
+        builder.Append("Fehlertyp: ")
+            .AppendLine(exception.GetType().FullName);
+        builder.Append("Fehlermeldung: ")
+            .AppendLine(exception.Message);
+
+        if (exception.InnerException is not null)
+        {
+            builder.AppendLine()
+                .AppendLine("Innere Ausnahme:")
+                .AppendLine(exception.InnerException.ToString());
+        }
+
+        if (exception.Data is { Count: > 0 } && exception.Data.Contains("NavigationDiagnostics"))
+        {
+            if (exception.Data["NavigationDiagnostics"] is string diagnostics && !string.IsNullOrWhiteSpace(diagnostics))
+            {
+                builder.AppendLine()
+                    .AppendLine("Navigationsdiagnose:")
+                    .AppendLine(diagnostics);
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(exception.StackTrace))
+        {
+            builder.AppendLine()
+                .AppendLine("Stacktrace:")
+                .AppendLine(TrimStackTrace(exception.StackTrace));
+        }
+
+        return builder.ToString();
+    }
+
+    private static string TrimStackTrace(string? stackTrace)
+    {
+        if (string.IsNullOrWhiteSpace(stackTrace))
+        {
+            return string.Empty;
+        }
+
+        var lines = stackTrace.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+        const int maxLines = 12;
+
+        if (lines.Length <= maxLines)
+        {
+            return string.Join(Environment.NewLine, lines);
+        }
+
+        var trimmed = lines.Take(maxLines).ToList();
+        trimmed.Add("…");
+        return string.Join(Environment.NewLine, trimmed);
+    }
+
+    private async void OnCopyPasswordTapped(object? sender, TappedEventArgs e)
+    {
+        if (e.Parameter is not PasswordVaultEntry entry)
+        {
+            return;
+        }
+
+        if (string.IsNullOrEmpty(entry.Password))
+        {
+            return;
+        }
+
+        // Visual feedback - find the Border element
+        Border? border = null;
+        if (sender is TapGestureRecognizer tapRecognizer && tapRecognizer.Parent is Border b)
+        {
+            border = b;
+        }
+        else if (sender is Border borderDirect)
+        {
+            border = borderDirect;
+        }
+
+        if (border is not null)
+        {
+            await AnimateCopyButton(border);
+        }
+
+        await Clipboard.Default.SetTextAsync(entry.Password);
+        await ToastService.ShowCopiedAsync("Passwort");
+    }
+
+    private async void OnCopyUsernameTapped(object? sender, TappedEventArgs e)
+    {
+        if (e.Parameter is not PasswordVaultEntry entry)
+        {
+            return;
+        }
+
+        if (string.IsNullOrEmpty(entry.Username))
+        {
+            return;
+        }
+
+        // Visual feedback - find the Border element
+        Border? border = null;
+        if (sender is TapGestureRecognizer tapRecognizer && tapRecognizer.Parent is Border b)
+        {
+            border = b;
+        }
+        else if (sender is Border borderDirect)
+        {
+            border = borderDirect;
+        }
+
+        if (border is not null)
+        {
+            await AnimateCopyButton(border);
+        }
+
+        await Clipboard.Default.SetTextAsync(entry.Username);
+        await ToastService.ShowCopiedAsync("Benutzername");
+    }
+
+    private static async Task AnimateCopyButton(Border border)
+    {
+        var originalColor = border.BackgroundColor ?? Microsoft.Maui.Graphics.Color.FromArgb("#2A2F4A");
+        var highlightColor = Microsoft.Maui.Graphics.Color.FromArgb("#4A5CFF");
+
+        // Cancel any existing animations
+        border.AbortAnimation("CopyButtonAnimation1");
+        border.AbortAnimation("CopyButtonAnimation2");
+
+        // Animate to highlight color
+        var animation1 = new Animation(
+            value => border.BackgroundColor = LerpColor(originalColor, highlightColor, value),
+            0, 1, Easing.CubicOut);
+        animation1.Commit(border, "CopyButtonAnimation1", 16, 150, Easing.CubicOut, (v, c) =>
+        {
+            // Ensure we're at highlight color when animation completes
+            border.BackgroundColor = highlightColor;
+        });
+
+        await Task.Delay(150);
+
+        // Animate back to original color
+        var animation2 = new Animation(
+            value => border.BackgroundColor = LerpColor(highlightColor, originalColor, value),
+            0, 1, Easing.CubicIn);
+        animation2.Commit(border, "CopyButtonAnimation2", 16, 200, Easing.CubicIn, (v, c) =>
+        {
+            // Ensure we're back to original color when animation completes
+            border.BackgroundColor = originalColor;
+        });
+
+        await Task.Delay(200);
+        
+        // Final safety check - ensure original color is set
+        border.BackgroundColor = originalColor;
+    }
+
+    private static Microsoft.Maui.Graphics.Color LerpColor(
+        Microsoft.Maui.Graphics.Color from,
+        Microsoft.Maui.Graphics.Color to,
+        double t)
+    {
+        var r = (int)(from.Red + (to.Red - from.Red) * t);
+        var g = (int)(from.Green + (to.Green - from.Green) * t);
+        var b = (int)(from.Blue + (to.Blue - from.Blue) * t);
+        var a = (int)(from.Alpha + (to.Alpha - from.Alpha) * t);
+        return Microsoft.Maui.Graphics.Color.FromRgba(r, g, b, a);
+    }
+
+    private void OnTogglePasswordVisibilityTapped(object? sender, TappedEventArgs e)
+    {
+        if (e.Parameter is not PasswordVaultEntry entry)
+        {
+            return;
+        }
+
+        entry.IsPasswordVisible = !entry.IsPasswordVisible;
+    }
+
+    private void OnOpenMenuTapped(object? sender, TappedEventArgs e)
+    {
+        if (Shell.Current is not null)
+        {
+            Shell.Current.FlyoutIsPresented = true;
+        }
+    }
+
+    private async void OnSettingsTapped(object? sender, TappedEventArgs e)
+        => await NavigateToSettingsAsync();
+
+    private async void OnSettingsButtonClicked(object? sender, EventArgs e)
+        => await NavigateToSettingsAsync();
+
+    private static async Task NavigateToSettingsAsync()
+    {
+        if (Shell.Current is null)
+        {
+            return;
+        }
+
+        await Shell.Current.GoToAsync("//settings");
+    }
+
+    private async void OnCategoryFilterTapped(object? sender, TappedEventArgs e)
+    {
+        if (_viewModel.CategoryFilterOptions.Count == 0)
+        {
+            return;
+        }
+
+        var options = new List<ActionSheetPopupOption>();
+        foreach (var category in _viewModel.CategoryFilterOptions)
+        {
+            var isSelected = string.Equals(category, _viewModel.SelectedCategory, StringComparison.CurrentCultureIgnoreCase);
+            options.Add(new ActionSheetPopupOption(category, category, IsSelected: isSelected));
+        }
+
+        var popup = new ActionSheetPopup("Kategorie wählen", options, cancelText: "Abbrechen");
+        var selection = await this.ShowPopupAsync(popup) as string;
+
+        if (string.IsNullOrWhiteSpace(selection) || string.Equals(selection, _viewModel.SelectedCategory, StringComparison.CurrentCultureIgnoreCase))
+        {
+            return;
+        }
+
+        foreach (var category in _viewModel.CategoryFilterOptions)
+        {
+            if (string.Equals(category, selection, StringComparison.CurrentCultureIgnoreCase))
+            {
+                _viewModel.SelectedCategory = category;
+                break;
+            }
+        }
+    }
+
+    private async void OnExportBackupClicked(object? sender, EventArgs e)
+        => await ExecuteVaultActionAsync(ExportBackupAsync);
+
+    private async void OnImportBackupClicked(object? sender, EventArgs e)
+        => await ExecuteVaultActionAsync(async () =>
+        {
+            await ImportBackupAsync();
+            await _viewModel.EnsureAccessStateAsync();
+        });
+
+    private async void OnExportEncryptedClicked(object? sender, EventArgs e)
+        => await ExecuteVaultActionAsync(ExportEncryptedAsync);
+
+    private async void OnImportEncryptedClicked(object? sender, EventArgs e)
+        => await ExecuteVaultActionAsync(ImportEncryptedAsync);
+
+    private async void OnChangePasswordMenuItemClicked(object? sender, EventArgs e)
+    {
+        if (!_viewModel.IsUnlocked)
+        {
+            await DisplayAlert("Datentresor gesperrt", "Bitte entsperre den Datentresor, bevor du das Master-Passwort ändern kannst.", "OK");
+            return;
+        }
+
+        await ExecuteVaultActionAsync(ChangeMasterPasswordAsync);
+    }
+
+    private async Task ExportBackupAsync()
+    {
+        var backupBytes = await _viewModel.CreateBackupAsync();
+        await using var stream = new MemoryStream(backupBytes);
+        var result = await FileSaver.Default.SaveAsync("vault-backup.json", stream, CancellationToken.None);
+        if (!result.IsSuccessful && result.Exception is not null)
+        {
+            throw new InvalidOperationException(result.Exception.Message, result.Exception);
+        }
+    }
+
+    private async Task ImportBackupAsync()
+    {
+        var file = await FilePicker.Default.PickAsync(new PickOptions
+        {
+            PickerTitle = "Backup auswählen"
+        });
+
+        if (file is null)
+        {
+            return;
+        }
+
+        await using var stream = await file.OpenReadAsync();
+        await _viewModel.RestoreBackupAsync(stream);
+    }
+
+    private async Task ExportEncryptedAsync()
+    {
+        var bytes = await _viewModel.ExportEncryptedVaultAsync();
+        await using var stream = new MemoryStream(bytes);
+        var result = await FileSaver.Default.SaveAsync("vault.json.enc", stream, CancellationToken.None);
+        if (!result.IsSuccessful && result.Exception is not null)
+        {
+            throw new InvalidOperationException(result.Exception.Message, result.Exception);
+        }
+    }
+
+    private async Task ImportEncryptedAsync()
+    {
+        var file = await FilePicker.Default.PickAsync(new PickOptions
+        {
+            PickerTitle = "Verschlüsselte Datentresordatei auswählen"
+        });
+
+        if (file is null)
+        {
+            return;
+        }
+
+        await using var stream = await file.OpenReadAsync();
+        await _viewModel.ImportEncryptedVaultAsync(stream);
+    }
+
+    private async Task ChangeMasterPasswordAsync()
+    {
+        var newPassword = await DisplayPasswordPromptAsync(
+            "Master-Passwort ändern",
+            "Bitte gib das neue Master-Passwort ein.",
+            "Weiter",
+            "Abbrechen");
+
+        if (newPassword is null)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(newPassword))
+        {
+            await DisplayAlert("Fehler", "Das Master-Passwort darf nicht leer sein.", "OK");
+            return;
+        }
+
+        var confirmPassword = await DisplayPasswordPromptAsync(
+            "Master-Passwort bestätigen",
+            "Bitte gib das neue Master-Passwort erneut ein.",
+            "Ändern",
+            "Abbrechen");
+
+        if (confirmPassword is null)
+        {
+            return;
+        }
+
+        if (!string.Equals(newPassword, confirmPassword, StringComparison.Ordinal))
+        {
+            await DisplayAlert("Fehler", "Die Passwörter stimmen nicht überein.", "OK");
+            return;
+        }
+
+        bool enableBiometric = _viewModel.EnableBiometric;
+        if (_viewModel.CanUseBiometric)
+        {
+            enableBiometric = await DisplayAlert(
+                "Biometrische Anmeldung",
+                "Soll die biometrische Anmeldung weiterhin verfügbar sein?",
+                "Ja",
+                "Nein");
+        }
+
+        try
+        {
+            await _viewModel.ChangeMasterPasswordAsync(newPassword, enableBiometric);
+            await DisplayAlert("Erfolg", "Das Master-Passwort wurde aktualisiert.", "OK");
+        }
+        catch (Exception ex)
+        {
+            await DisplayAlert("Fehler", $"Das Master-Passwort konnte nicht geändert werden: {ex.Message}", "OK");
+        }
+    }
+
+    private async Task<string?> DisplayPasswordPromptAsync(string title, string message, string accept, string cancel)
+    {
+        var navigation = Navigation ?? Microsoft.Maui.Controls.Application.Current?.MainPage?.Navigation;
+        if (navigation is null)
+        {
+            throw new InvalidOperationException("Keine Navigationsinstanz verfügbar, um den Passwortdialog zu öffnen.");
+        }
+
+        var promptPage = new PasswordPromptPage(title, message, accept, cancel);
+
+        BeginModalInteraction();
+        try
+        {
+            await navigation.PushModalAsync(promptPage);
+            var result = await promptPage.WaitForResultAsync();
+
+            if (navigation.ModalStack.Contains(promptPage))
+            {
+                await navigation.PopModalAsync();
+            }
+
+            return result;
+        }
+        finally
+        {
+            EndModalInteraction();
+        }
+    }
+
+    private void BeginModalInteraction()
+        => _modalDepth++;
+
+    private void EndModalInteraction()
+    {
+        if (_modalDepth > 0)
+        {
+            _modalDepth--;
+        }
+    }
+
+    private async Task ExecuteVaultActionAsync(Func<Task> action)
+    {
+        try
+        {
+            await action();
+        }
+        catch (Exception ex)
+        {
+            await DisplayAlert("Fehler", ex.Message, "OK");
+        }
+    }
+
+    protected override bool OnBackButtonPressed()
+    {
+        Dispatcher.Dispatch(async () =>
+        {
+            if (Shell.Current is not null)
+            {
+                await Shell.Current.GoToAsync("//home");
+            }
+        });
+        return true;
+    }
+}

--- a/Password Phrase Producer/Views/SettingsPage.xaml
+++ b/Password Phrase Producer/Views/SettingsPage.xaml
@@ -163,6 +163,67 @@
                     </Border.Shadow>
                     <VerticalStackLayout Spacing="10">
                         <Label
+                            Text="Datentresor Datensicherung"
+                            FontSize="16"
+                            FontAttributes="Bold"
+                            TextColor="White" />
+                        <Label
+                            Text="Verwalte Backups und verschlüsselte Datentresor-Dateien."
+                            FontSize="12"
+                            TextColor="#9EA3C4" />
+                        <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="*,*" ColumnSpacing="10" RowSpacing="10">
+                            <Button
+                                Text="Datentresor-Backup exportieren"
+                                Clicked="OnExportDataVaultBackupClicked"
+                                BackgroundColor="#4A5CFF"
+                                TextColor="White"
+                                FontSize="11"
+                                Padding="8,6"
+                                CornerRadius="10" />
+                            <Button
+                                Grid.Column="1"
+                                Text="Datentresor-Backup importieren"
+                                Clicked="OnImportDataVaultBackupClicked"
+                                BackgroundColor="#1F2338"
+                                TextColor="White"
+                                FontSize="11"
+                                Padding="8,6"
+                                CornerRadius="10" />
+                            <Button
+                                Grid.Row="1"
+                                Text="Datentresor exportieren"
+                                Clicked="OnExportDataVaultEncryptedClicked"
+                                BackgroundColor="#4A5CFF"
+                                TextColor="White"
+                                FontSize="11"
+                                Padding="8,6"
+                                CornerRadius="10" />
+                            <Button
+                                Grid.Row="1"
+                                Grid.Column="1"
+                                Text="Datentresor importieren"
+                                Clicked="OnImportDataVaultEncryptedClicked"
+                                BackgroundColor="#1F2338"
+                                TextColor="White"
+                                FontSize="11"
+                                Padding="8,6"
+                                CornerRadius="10" />
+                        </Grid>
+                    </VerticalStackLayout>
+                </Border>
+
+                <Border
+                    BackgroundColor="#1B2036"
+                    Padding="14"
+                    StrokeThickness="0">
+                    <Border.StrokeShape>
+                        <RoundRectangle CornerRadius="16" />
+                    </Border.StrokeShape>
+                    <Border.Shadow>
+                        <Shadow Brush="#25000000" Radius="12" Offset="0,6" />
+                    </Border.Shadow>
+                    <VerticalStackLayout Spacing="10">
+                        <Label
                             Text="Master-Passwort"
                             FontSize="16"
                             FontAttributes="Bold"
@@ -238,6 +299,100 @@
                                 Grid.Column="1"
                                 IsRunning="{Binding IsPasswordChangeBusy}"
                                 IsVisible="{Binding IsPasswordChangeBusy}"
+                                Color="#63F5A8"
+                                WidthRequest="24"
+                                HeightRequest="24" />
+                        </Grid>
+                    </VerticalStackLayout>
+                </Border>
+
+                <Border
+                    BackgroundColor="#1B2036"
+                    Padding="14"
+                    StrokeThickness="0">
+                    <Border.StrokeShape>
+                        <RoundRectangle CornerRadius="16" />
+                    </Border.StrokeShape>
+                    <Border.Shadow>
+                        <Shadow Brush="#25000000" Radius="12" Offset="0,6" />
+                    </Border.Shadow>
+                    <VerticalStackLayout Spacing="10">
+                        <Label
+                            Text="Datentresor Master-Passwort"
+                            FontSize="16"
+                            FontAttributes="Bold"
+                            TextColor="White" />
+                        <Label
+                            Text="Der Datentresor muss entsperrt sein, um das Passwort zu ändern."
+                            TextColor="#9EA3C4"
+                            FontSize="12">
+                            <Label.Triggers>
+                                <DataTrigger TargetType="Label" Binding="{Binding IsDataVaultUnlocked}" Value="True">
+                                    <Setter Property="IsVisible" Value="False" />
+                                </DataTrigger>
+                            </Label.Triggers>
+                        </Label>
+
+                        <Entry
+                            Text="{Binding NewDataVaultMasterPassword}"
+                            Placeholder="Neues Master-Passwort"
+                            PlaceholderColor="#7F85B2"
+                            TextColor="White"
+                            BackgroundColor="#1F2338"
+                            IsPassword="True"
+                            IsEnabled="{Binding IsDataVaultUnlocked}"
+                            FontSize="13"
+                            HeightRequest="38" />
+                        <Entry
+                            Text="{Binding ConfirmDataVaultMasterPassword}"
+                            Placeholder="Passwort bestätigen"
+                            PlaceholderColor="#7F85B2"
+                            TextColor="White"
+                            BackgroundColor="#1F2338"
+                            IsPassword="True"
+                            IsEnabled="{Binding IsDataVaultUnlocked}"
+                            FontSize="13"
+                            HeightRequest="38" />
+
+                        <Grid ColumnDefinitions="Auto,*" IsVisible="{Binding CanUseDataVaultBiometric}">
+                            <Switch
+                                Grid.Column="0"
+                                IsToggled="{Binding EnableDataVaultBiometric}"
+                                IsEnabled="{Binding IsDataVaultUnlocked}" />
+                            <Label
+                                Grid.Column="1"
+                                Text="Biometrische Anmeldung speichern"
+                                FontSize="11"
+                                TextColor="#E8EBFF"
+                                Margin="10,0,0,0"
+                                VerticalOptions="Center"
+                                LineBreakMode="WordWrap" />
+                        </Grid>
+
+                        <Label
+                            Text="{Binding ChangeDataVaultPasswordError}"
+                            TextColor="#FF7474"
+                            FontSize="11"
+                            IsVisible="{Binding ChangeDataVaultPasswordError, Converter={StaticResource StringNotNullOrWhiteSpaceConverter}}" />
+                        <Label
+                            Text="{Binding ChangeDataVaultPasswordSuccess}"
+                            TextColor="#63F5A8"
+                            FontSize="11"
+                            IsVisible="{Binding ChangeDataVaultPasswordSuccess, Converter={StaticResource StringNotNullOrWhiteSpaceConverter}}" />
+
+                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12" VerticalOptions="Center">
+                            <Button
+                                Text="Passwort aktualisieren"
+                                Command="{Binding ChangeDataVaultPasswordCommand}"
+                                BackgroundColor="#4A5CFF"
+                                TextColor="White"
+                                FontSize="13"
+                                CornerRadius="12"
+                                Padding="12,8" />
+                            <ActivityIndicator
+                                Grid.Column="1"
+                                IsRunning="{Binding IsDataVaultPasswordChangeBusy}"
+                                IsVisible="{Binding IsDataVaultPasswordChangeBusy}"
                                 Color="#63F5A8"
                                 WidthRequest="24"
                                 HeightRequest="24" />


### PR DESCRIPTION
### Motivation
- Consolidate Datentresor (Data Vault) settings into the existing app `Settings` UI instead of a separate settings page per request. 
- Provide users with backup/export/import and master-password controls for the Datentresor alongside the existing Vault settings. 
- Keep Datentresor functionality available via its own page and service while centralizing configuration. 

### Description
- Removed the dedicated `DataVaultSettingsPage` and `DataVaultSettingsViewModel` and removed the hidden `data-vault-settings` route from `AppShell.xaml`.
- Added Datentresor controls into the main `SettingsPage.xaml` and wired actions in `SettingsPage.xaml.cs` to new methods on the consolidated `VaultSettingsViewModel`, which was extended to handle DataVault operations (backup/export/import and master-password change). 
- Introduced `DataVaultService`, plus the `DataVaultPage` and `DataVaultPageViewModel`, registered the `DataVaultService` and page/VM in `MauiProgram.cs`, and added navigation from the start page via `NavigateToDataVaultCommand`.
- Updated navigation in `DataVaultPage` to open the main settings (`//settings`) for Datentresor configuration and removed the separate DI registrations for the deleted settings view/VM.

### Testing
- No automated tests were executed for these changes.
- No CI or automated build verification was run as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c4daf6550832abafa10c3f52d21a8)