### PR TITLE
Add App password management to Settings (ViewModel + UI)

### DIFF
--- a/Password Phrase Producer/Views/SettingsPage.xaml
+++ b/Password Phrase Producer/Views/SettingsPage.xaml
@@ -144,6 +144,117 @@
                     </Border.Shadow>
                     <VerticalStackLayout Spacing="10">
                         <Label
+                            Text="App-Passwort"
+                            FontSize="16"
+                            FontAttributes="Bold"
+                            TextColor="White" />
+                        <Label
+                            Text="Ändere dein App-Passwort, das den Zugriff auf die App schützt."
+                            TextColor="#9EA3C4"
+                            FontSize="12" />
+
+                        <Label
+                            Text="Aktuelles App-Passwort"
+                            TextColor="#9EA3C4"
+                            FontSize="12">
+                            <Label.Triggers>
+                                <DataTrigger TargetType="Label" Binding="{Binding HasAppPassword}" Value="False">
+                                    <Setter Property="IsVisible" Value="False" />
+                                </DataTrigger>
+                            </Label.Triggers>
+                        </Label>
+                        <Entry
+                            Text="{Binding CurrentAppPassword}"
+                            Placeholder="Aktuelles App-Passwort"
+                            PlaceholderColor="#7F85B2"
+                            TextColor="White"
+                            BackgroundColor="#1F2338"
+                            IsPassword="True"
+                            FontSize="13"
+                            HeightRequest="38">
+                            <Entry.Triggers>
+                                <DataTrigger TargetType="Entry" Binding="{Binding HasAppPassword}" Value="False">
+                                    <Setter Property="IsVisible" Value="False" />
+                                </DataTrigger>
+                            </Entry.Triggers>
+                        </Entry>
+
+                        <Entry
+                            Text="{Binding NewAppPassword}"
+                            Placeholder="Neues App-Passwort"
+                            PlaceholderColor="#7F85B2"
+                            TextColor="White"
+                            BackgroundColor="#1F2338"
+                            IsPassword="True"
+                            FontSize="13"
+                            HeightRequest="38" />
+                        <Entry
+                            Text="{Binding ConfirmAppPassword}"
+                            Placeholder="Passwort bestätigen"
+                            PlaceholderColor="#7F85B2"
+                            TextColor="White"
+                            BackgroundColor="#1F2338"
+                            IsPassword="True"
+                            FontSize="13"
+                            HeightRequest="38" />
+
+                        <Grid ColumnDefinitions="Auto,*" IsVisible="{Binding CanUseAppBiometric}">
+                            <Switch
+                                Grid.Column="0"
+                                IsToggled="{Binding EnableAppBiometric}" />
+                            <Label
+                                Grid.Column="1"
+                                Text="Biometrische Anmeldung speichern"
+                                FontSize="11"
+                                TextColor="#E8EBFF"
+                                Margin="10,0,0,0"
+                                VerticalOptions="Center"
+                                LineBreakMode="WordWrap" />
+                        </Grid>
+
+                        <Label
+                            Text="{Binding ChangeAppPasswordError}"
+                            TextColor="#FF7474"
+                            FontSize="11"
+                            IsVisible="{Binding ChangeAppPasswordError, Converter={StaticResource StringNotNullOrWhiteSpaceConverter}}" />
+                        <Label
+                            Text="{Binding ChangeAppPasswordSuccess}"
+                            TextColor="#63F5A8"
+                            FontSize="11"
+                            IsVisible="{Binding ChangeAppPasswordSuccess, Converter={StaticResource StringNotNullOrWhiteSpaceConverter}}" />
+
+                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12" VerticalOptions="Center">
+                            <Button
+                                Text="App-Passwort aktualisieren"
+                                Command="{Binding ChangeAppPasswordCommand}"
+                                BackgroundColor="#4A5CFF"
+                                TextColor="White"
+                                FontSize="13"
+                                CornerRadius="12"
+                                Padding="12,8" />
+                            <ActivityIndicator
+                                Grid.Column="1"
+                                IsRunning="{Binding IsAppPasswordChangeBusy}"
+                                IsVisible="{Binding IsAppPasswordChangeBusy}"
+                                Color="#63F5A8"
+                                WidthRequest="24"
+                                HeightRequest="24" />
+                        </Grid>
+                    </VerticalStackLayout>
+                </Border>
+
+                <Border
+                    BackgroundColor="#1B2036"
+                    Padding="14"
+                    StrokeThickness="0">
+                    <Border.StrokeShape>
+                        <RoundRectangle CornerRadius="16" />
+                    </Border.StrokeShape>
+                    <Border.Shadow>
+                        <Shadow Brush="#25000000" Radius="12" Offset="0,6" />
+                    </Border.Shadow>
+                    <VerticalStackLayout Spacing="10">
+                        <Label
                             Text="Passwort-Tresor-Passwort"
                             FontSize="16"
                             FontAttributes="Bold"


### PR DESCRIPTION
### Motivation
- Provide a settings UI to set/change the App-level password that protects the whole application and to optionally enable biometric unlocking. 
- Ensure the app-lock/secure-file encryption flows can be configured from Settings alongside existing vault passwords. 
- Surface state and validation in the settings page so users can create or change the App password without needing separate screens. 

### Description
- Injected `IAppLockService` into `VaultSettingsViewModel` and added state, bindings and a `ChangeAppPasswordCommand` to manage current/new/confirm passwords, biometric toggle and busy/error/success feedback. 
- Implemented `RefreshAppLockStateAsync`, `ChangeAppPasswordAsync`, `UpdateAppPasswordCommandState` and `ClearAppPasswordFeedback` in `VaultSettingsViewModel` to initialize, validate and perform setup/change of the app password via `IAppLockService`. 
- Added an `App-Passwort` section to `SettingsPage.xaml` with entries bound to `CurrentAppPassword`, `NewAppPassword`, `ConfirmAppPassword`, biometric switch and the `ChangeAppPasswordCommand` plus activity/error/success UI. 
- Kept behavior consistent with other vault password flows: validate current password if configured, support first-time setup, enable/disable biometric keys via `IAppLockService` and refresh UI state on completion using `MainThread`. 

### Testing
- No automated tests were executed for this change (UI and integration flow changes only). 
- Changes were implemented to reuse existing services (`IAppLockService`, `IBiometricAuthenticationService`) already registered in DI and follow existing patterns used by other password flows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695092ecc920832aa9139bec4ef08aa8)