### PR TITLE
Disable snap points on vault lists to fix Android scroll stutter

### DIFF
--- a/Password Phrase Producer/Views/DataVaultPage.xaml
+++ b/Password Phrase Producer/Views/DataVaultPage.xaml
@@ -211,7 +211,10 @@
                 VerticalScrollBarVisibility="Never"
                 IsGrouped="True">
             <CollectionView.ItemsLayout>
-                <LinearItemsLayout Orientation="Vertical" ItemSpacing="12" />
+                <LinearItemsLayout
+                    Orientation="Vertical"
+                    ItemSpacing="12"
+                    SnapPointsType="None" />
             </CollectionView.ItemsLayout>
             <CollectionView.GroupHeaderTemplate>
                 <DataTemplate x:DataType="viewmodels:VaultEntryGroup">

--- a/Password Phrase Producer/Views/VaultPage.xaml
+++ b/Password Phrase Producer/Views/VaultPage.xaml
@@ -211,7 +211,10 @@
                 VerticalScrollBarVisibility="Never"
                 IsGrouped="True">
             <CollectionView.ItemsLayout>
-                <LinearItemsLayout Orientation="Vertical" ItemSpacing="12" />
+                <LinearItemsLayout
+                    Orientation="Vertical"
+                    ItemSpacing="12"
+                    SnapPointsType="None" />
             </CollectionView.ItemsLayout>
             <CollectionView.GroupHeaderTemplate>
                 <DataTemplate x:DataType="viewmodels:VaultEntryGroup">


### PR DESCRIPTION
### Motivation
- Android users reported heavy stuttering when slowly scrolling the `Vault` and `DataVault` lists due to the UI snapping to individual cards. 
- The per-card snapping makes slow drags jump or “hang” at the top/bottom edge of each card instead of allowing smooth continuous scroll. 
- The goal is to disable that snap behavior while preserving the existing layout and spacing. 

### Description
- Set `SnapPointsType="None"` on the `LinearItemsLayout` used by the vault `CollectionView` in `Views/VaultPage.xaml`. 
- Apply the same `SnapPointsType="None"` change to the `LinearItemsLayout` in `Views/DataVaultPage.xaml`. 
- Kept existing `Orientation` and `ItemSpacing` values (no other visual or layout changes). 

### Testing
- No automated tests were executed for this change. 
- Changes were limited to XAML layout properties in `VaultPage.xaml` and `DataVaultPage.xaml` and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951139c17cc832a9b98467540241048)