### PR TITLE
Fix Android LaunchMode namespace resolution

### DIFF
--- a/Password Phrase Producer/Platforms/Android/Services/WebAuthenticatorIntermediateActivity.cs
+++ b/Password Phrase Producer/Platforms/Android/Services/WebAuthenticatorIntermediateActivity.cs
@@ -1,10 +1,11 @@
 using Android.App;
 using Android.Content;
+using Android.Content.PM;
 using Android.OS;
 
 namespace Password_Phrase_Producer.Platforms.Android.Services;
 
-[Activity(NoHistory = true, LaunchMode = Android.Content.PM.LaunchMode.SingleTop)]
+[Activity(NoHistory = true, LaunchMode = LaunchMode.SingleTop)]
 public class WebAuthenticatorIntermediateActivity : Activity
 {
     public static Action<string?>? Callback;


### PR DESCRIPTION
### Motivation
- Resolve a compile error where the `LaunchMode` enum reference caused a namespace resolution issue during Android builds.
- Ensure the `WebAuthenticatorIntermediateActivity` attribute uses the correct `LaunchMode` symbol to allow successful compilation for `net9.0-android`.

### Description
- Added an explicit `using Android.Content.PM;` import to the file `Platforms/Android/Services/WebAuthenticatorIntermediateActivity.cs`.
- Replaced the fully-qualified attribute value `Android.Content.PM.LaunchMode.SingleTop` with the direct `LaunchMode.SingleTop` reference.
- Small whitespace/formatting cleanup around the activity attribute.

### Testing
- No automated tests were executed after this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952d7ee3d98832ab23c351598a08cca)