### PR TITLE
Fix Android output stream handling in sync service

### DIFF
--- a/Password Phrase Producer/Platforms/Android/Services/AndroidSyncFileService.cs
+++ b/Password Phrase Producer/Platforms/Android/Services/AndroidSyncFileService.cs
@@ -90,10 +90,8 @@ public class AndroidSyncFileService : ISyncFileService
     {
         var uri = AndroidUri.Parse(path);
         // "w" for write, "wt" for write + truncate
-        var pfd = Application.Context.ContentResolver?.OpenFileDescriptor(uri, "wt");
-        if (pfd == null) throw new FileNotFoundException("Could not open file descriptor for URI", path);
-        
-        var stream = new System.IO.FileStream(pfd.FileDescriptor, FileAccess.Write);
+        var stream = Application.Context.ContentResolver?.OpenOutputStream(uri, "wt");
+        if (stream == null) throw new FileNotFoundException("Could not open stream for URI", path);
         return Task.FromResult<Stream>(stream);
     }
 


### PR DESCRIPTION
### Motivation
- Avoid using a `FileDescriptor`-backed `FileStream` which can be incompatible with newer runtimes such as .NET 9.
- Ensure the Android sync service opens writable streams using the platform `ContentResolver` API.
- Preserve the intended write+truncate semantics signaled by the mode string `"wt"`.

### Description
- Replace `OpenFileDescriptor(...)` + `new FileStream(pfd.FileDescriptor, ...)` with `ContentResolver.OpenOutputStream(uri, "wt")` to obtain a writable `Stream`.
- Add a null check and throw `FileNotFoundException` if the output stream cannot be opened.
- Keep the existing `OpenReadAsync` behavior and overall API surface of the sync file service unchanged.

### Testing
- No automated tests were run for this change.
- Compilation and runtime verification were not executed as part of this PR.
- Manual testing (if any) is not recorded in automated test results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952e3ee48ac832aa9a80755c1ab94a7)