### PR TITLE
Fix Android stream conversion for file descriptors

### DIFF
--- a/Password Phrase Producer/Platforms/Android/Services/AndroidSyncFileService.cs
+++ b/Password Phrase Producer/Platforms/Android/Services/AndroidSyncFileService.cs
@@ -5,6 +5,7 @@ using Android.Content;
 using Android.Database;
 using Android.OS;
 using Android.Provider;
+using Android.Runtime;
 using Password_Phrase_Producer.Services.Storage;
 using Application = Android.App.Application;
 using AndroidUri = Android.Net.Uri;
@@ -129,7 +130,7 @@ public class AndroidSyncFileService : ISyncFileService
             var fileDescriptor = contentResolver.OpenFileDescriptor(uri, "rw");
             if (fileDescriptor != null)
             {
-                return new ParcelFileDescriptor.AutoCloseOutputStream(fileDescriptor);
+                return new OutputStreamInvoker(new ParcelFileDescriptor.AutoCloseOutputStream(fileDescriptor));
             }
         }
         catch (Exception)
@@ -142,7 +143,7 @@ public class AndroidSyncFileService : ISyncFileService
             var fileDescriptor = contentResolver.OpenFileDescriptor(uri, "rwt");
             if (fileDescriptor != null)
             {
-                return new ParcelFileDescriptor.AutoCloseOutputStream(fileDescriptor);
+                return new OutputStreamInvoker(new ParcelFileDescriptor.AutoCloseOutputStream(fileDescriptor));
             }
         }
         catch (Exception)


### PR DESCRIPTION
### Motivation
- Resolve the Android publish/build error `Cannot implicitly convert type 'Android.OS.ParcelFileDescriptor.AutoCloseOutputStream' to 'System.IO.Stream'` by adapting Java output streams to `System.IO.Stream`.

### Description
- Added `using Android.Runtime;` and wrapped `ParcelFileDescriptor.AutoCloseOutputStream` with `OutputStreamInvoker(...)` in `Platforms/Android/Services/AndroidSyncFileService.cs` so `TryOpenOutputStream` returns a `System.IO.Stream`.

### Testing
- No automated tests or CI build were run after the change; the fix was implemented and committed but `dotnet publish`/CI was not re-executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ff4ac1d84832aa493a2c694ae8a27)