### PR TITLE
Add load-only sync and remove connection actions

### DIFF
--- a/Password Phrase Producer/Views/SettingsPage.xaml
+++ b/Password Phrase Producer/Views/SettingsPage.xaml
@@ -247,6 +247,38 @@
                             </Button.Triggers>
                         </Button>
 
+                        <Button
+                            Text="Nur laden (kein Upload)"
+                            Clicked="OnLoadSyncClicked"
+                            BackgroundColor="#2D324A"
+                            TextColor="White"
+                            FontSize="13"
+                            Padding="12,8"
+                            CornerRadius="12"
+                            Margin="0,0,0,0">
+                            <Button.Triggers>
+                                <DataTrigger TargetType="Button" Binding="{Binding IsSyncBusy}" Value="True">
+                                    <Setter Property="IsEnabled" Value="False" />
+                                </DataTrigger>
+                            </Button.Triggers>
+                        </Button>
+
+                        <Button
+                            Text="Sync-Verbindung löschen"
+                            Clicked="OnRemoveSyncClicked"
+                            BackgroundColor="#FF4444"
+                            TextColor="White"
+                            FontSize="13"
+                            Padding="12,8"
+                            CornerRadius="12"
+                            Margin="0,8,0,0">
+                            <Button.Triggers>
+                                <DataTrigger TargetType="Button" Binding="{Binding IsSyncBusy}" Value="True">
+                                    <Setter Property="IsEnabled" Value="False" />
+                                </DataTrigger>
+                            </Button.Triggers>
+                        </Button>
+
                         <VerticalStackLayout Spacing="4" Margin="0,8,0,0">
                              <Label Text="Letzte Synchronisation:" FontSize="12" TextColor="#9EA3C4" FontAttributes="Bold"/>
                              <Label Text="{Binding PasswordVaultSyncTime, StringFormat='Passwörter: {0:g}'}" FontSize="11" TextColor="#7F85B2"/>


### PR DESCRIPTION
### Motivation

- Some remote storage backends (particularly on Android) cannot be written to from the app; users need a way to load remote data without attempting uploads and a way to remove a configured remote connection to stop future loads/uploads.

### Description

- Add read-only merge APIs to the synchronization layer: `ClearConfigurationAsync`, `GetMergedPasswordVaultReadOnlyAsync`, `GetMergedDataVaultReadOnlyAsync` and `GetMergedAuthenticatorReadOnlyAsync` in `SynchronizationService` to support pull-only operations and clearing the stored sync configuration.
- Allow unlocking vaults without triggering automatic sync by introducing `UnlockWithoutSyncAsync` and an internal `UnlockInternalAsync` on `PasswordVaultService` and `DataVaultService`, and add `LoadFromSyncAsync` methods to load (merge) remote-only data into local vaults without writing back to the remote file.
- Add `LoadFromSyncAsync` to `TotpService` to allow read-only loading for authenticator data, and update view model `VaultSettingsViewModel` with `Unlock*WithoutSyncAsync`, `LoadFromSyncAsync` and `RemoveSyncConfigurationAsync` to drive the new flows.
- Update settings UI (`Views/SettingsPage.xaml`) to add two buttons: `Nur laden (kein Upload)` (Load only) and `Sync-Verbindung löschen` (Delete sync connection), and implement handlers (`OnLoadSyncClicked`, `OnRemoveSyncClicked`) and helper unlock methods in `SettingsPage.xaml.cs` to coordinate unlocking without sync and showing confirmation dialogs.

### Testing

- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973d2028a54832a8e8327a12d3138de)