### PR TITLE
Add global sync access mode toggle and honor read-only sync

### DIFF
--- a/Password Phrase Producer/Views/SettingsPage.xaml
+++ b/Password Phrase Producer/Views/SettingsPage.xaml
@@ -214,6 +214,27 @@
                             FontSize="13"
                             HeightRequest="38" />
 
+                        <Grid
+                            ColumnDefinitions="Auto,*"
+                            ColumnSpacing="10"
+                            Margin="0,6,0,2">
+                            <Switch
+                                IsToggled="{Binding IsSyncReadOnly}"
+                                Toggled="OnSyncAccessModeToggled"
+                                VerticalOptions="Center" />
+                            <VerticalStackLayout Grid.Column="1" Spacing="2">
+                                <Label
+                                    Text="Nur lesen &amp; zusammenführen"
+                                    FontSize="12"
+                                    TextColor="White"
+                                    FontAttributes="Bold" />
+                                <Label
+                                    Text="Aktiviert: Sync liest nur und schreibt nie in die Datei."
+                                    FontSize="11"
+                                    TextColor="#9EA3C4" />
+                            </VerticalStackLayout>
+                        </Grid>
+
                         <Button
                             Text="Synchronisation einrichten"
                             Command="{Binding ConfigureSyncCommand}"

--- a/Password Phrase Producer/Views/SettingsPage.xaml.cs
+++ b/Password Phrase Producer/Views/SettingsPage.xaml.cs
@@ -748,6 +748,12 @@ public partial class SettingsPage : ContentPage
             await this.ShowPopupAsync(successPopup);
         });
     }
+
+    private async void OnSyncAccessModeToggled(object sender, ToggledEventArgs e)
+    {
+        await _viewModel.SetSyncAccessModeAsync(e.Value);
+    }
+
     private async void OnManualSyncClicked(object sender, EventArgs e)
     {
         if (!_viewModel.IsSyncConfigured)


### PR DESCRIPTION
### Motivation
- Provide a global setting to control whether the external sync file is used in full read/write mode or in read-only+merge mode so users can avoid writes when the file is mounted read-only. 
- Ensure the chosen access mode is persisted and applied across the app (unlock, manual sync, add/update/delete operations). 
- Always perform a read/merge operation when a vault is unlocked so UI data reflects the latest remote state even when writes are disabled.

### Description
- Added a persisted `SyncAccessMode` and corresponding enum plus API methods `GetAccessModeAsync` / `SetAccessModeAsync` to `ISynchronizationService` and implemented them in `SynchronizationService` using a `SyncAccessMode` preference key. 
- Updated `PasswordVaultService`, `DataVaultService`, and `TotpService` to detect the access mode via `IsReadOnlySyncAsync` and to perform `GetMerged*ReadOnlyAsync` (implemented as `MergeFromSyncReadOnlyAsync`) on unlock and sync entry flows when read-only mode is enabled; when read-only the services skip remote writes and suppress write-error alerts. 
- Added UI control and wiring: a `Switch` labeled "Nur lesen & zusammenführen" in `Views/SettingsPage.xaml`, a handler `OnSyncAccessModeToggled` in the page code-behind, and a `SetSyncAccessModeAsync` method plus `IsSyncReadOnly` property in `VaultSettingsViewModel` that updates `SyncStatusMessage`/`SyncStatusColor` and persists the mode. 
- Minor behavior: `ClearConfigurationAsync` clears the access-mode preference and sync flows now respect the configured mode everywhere (unlock, manual sync, add/update/delete, LoadFromSync). 

### Testing
- Attempted an automated build with `dotnet build "Password Phrase Producer.sln"`, but the environment does not have `dotnet` installed so the build could not be executed (failed). 
- No unit/integration tests were run in this environment; changes were validated via repository-wide static searches and local code edits to ensure the new mode is checked in all sync paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69749db332fc832aa3850826b5778c9f)