### PR TITLE
Add Linux portable and Debian packaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build Android and Windows Packages
+name: Build Android, Windows, and Linux Packages
 
 on:
   push:
@@ -221,9 +221,77 @@ jobs:
           name: windows-installer
           path: '${{ env.RELEASE_DIRECTORY }}\\Password-Phrase-Producer_${{ env.APP_VERSION }}_windows_x64_installer.msix'
 
+  linux:
+    name: Build Linux Packages
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Install MAUI workload
+        run: dotnet workload install maui --ignore-failed-sources
+
+      - name: Compute version numbers
+        id: compute_versions
+        run: |
+          run_number="${{ github.run_number }}"
+          major=$((run_number / 100 + 1))
+          minor=$(((run_number % 100) / 10))
+          patch=$((run_number % 10))
+
+          app_version="${major}.${minor}.${patch}"
+          release_dir="${RUNNER_TEMP}/release"
+
+          mkdir -p "${release_dir}"
+
+          echo "APP_VERSION=${app_version}" >> "$GITHUB_ENV"
+          echo "RELEASE_DIRECTORY=${release_dir}" >> "$GITHUB_ENV"
+
+      - name: Restore dependencies
+        run: dotnet restore "./Password Phrase Producer/Password Phrase Producer.sln"
+
+      - name: Publish Linux portable build
+        run: |
+          dotnet publish "./Password Phrase Producer/Password Phrase Producer.sln" \
+            -c Release \
+            -f net9.0 \
+            -p:RuntimeIdentifier=linux-x64 \
+            -p:SelfContained=true \
+            -p:PublishSingleFile=false \
+            -p:ApplicationDisplayVersion="${APP_VERSION}" \
+            -p:ApplicationVersion="${{ github.run_number }}"
+
+      - name: Stage Linux artifacts
+        run: |
+          publish_dir="./Password Phrase Producer/bin/Release/net9.0/linux-x64/publish"
+          if [ ! -d "${publish_dir}" ]; then
+            echo "Linux publish directory not found."
+            exit 1
+          fi
+
+          ./build/linux/package-linux.sh "${APP_VERSION}" "${publish_dir}" "${RELEASE_DIRECTORY}" "amd64"
+
+      - name: Upload Linux portable artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-portable
+          path: '${{ env.RELEASE_DIRECTORY }}/Password-Phrase-Producer_${{ env.APP_VERSION }}_linux_amd64_portable.tar.gz'
+
+      - name: Upload Linux installer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-installer
+          path: '${{ env.RELEASE_DIRECTORY }}/Password-Phrase-Producer_${{ env.APP_VERSION }}_linux_amd64.deb'
+
   release:
     name: Release artifacts
-    needs: build
+    needs: [build, linux]
     runs-on: ubuntu-latest
     env:
       VERSION: ${{ needs.build.outputs.app-version }}
@@ -251,12 +319,26 @@ jobs:
           name: windows-installer
           path: release-assets
 
+      - name: Download Linux portable artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-portable
+          path: release-assets
+
+      - name: Download Linux installer artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-installer
+          path: release-assets
+
       - name: Generate SHA256 checksums
         working-directory: release-assets
         run: |
           sha256sum "Password-Phrase-Producer_${VERSION}_android_signed.apk" \
             "Password-Phrase-Producer_${VERSION}_windows_x64_portable.zip" \
             "Password-Phrase-Producer_${VERSION}_windows_x64_installer.msix" \
+            "Password-Phrase-Producer_${VERSION}_linux_amd64_portable.tar.gz" \
+            "Password-Phrase-Producer_${VERSION}_linux_amd64.deb" \
             > "Password-Phrase-Producer_${VERSION}_SHA256.txt"
 
       - name: Determine release metadata
@@ -284,4 +366,6 @@ jobs:
             release-assets/Password-Phrase-Producer_${{ env.VERSION }}_android_signed.apk
             release-assets/Password-Phrase-Producer_${{ env.VERSION }}_windows_x64_portable.zip
             release-assets/Password-Phrase-Producer_${{ env.VERSION }}_windows_x64_installer.msix
+            release-assets/Password-Phrase-Producer_${{ env.VERSION }}_linux_amd64_portable.tar.gz
+            release-assets/Password-Phrase-Producer_${{ env.VERSION }}_linux_amd64.deb
             release-assets/Password-Phrase-Producer_${{ env.VERSION }}_SHA256.txt

--- a/Password Phrase Producer/PasswordPhraseProducer.csproj
+++ b/Password Phrase Producer/PasswordPhraseProducer.csproj
@@ -3,6 +3,7 @@
         <PropertyGroup>
                 <TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
                 <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
+                <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('linux'))">$(TargetFrameworks);net9.0</TargetFrameworks>
                 <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
                 <!-- <TargetFrameworks>$(TargetFrameworks);net9.0-tizen</TargetFrameworks> -->
 

--- a/README.md
+++ b/README.md
@@ -107,13 +107,16 @@ DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet build "Password Phrase Producer/PasswordPhr
 
 # Windows (only on Windows hosts)
 DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet build "Password Phrase Producer/PasswordPhraseProducer.csproj" -f net9.0-windows10.0.19041.0
+
+# Linux (portable build on Linux hosts)
+DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet publish "Password Phrase Producer/PasswordPhraseProducer.csproj" -c Release -f net9.0 -p:RuntimeIdentifier=linux-x64 -p:SelfContained=true
 ```
 
 ---
 
 ## 📦 Continuous delivery packages
 
-The GitHub Actions workflow produces installable artifacts for **Android** and **Windows**.
+The GitHub Actions workflow produces installable artifacts for **Android**, **Windows**, and **Linux**.
 
 ### Android (APK)
 
@@ -131,6 +134,15 @@ The workflow restores the keystore, signs the APK during `dotnet publish`, and i
 ### Windows (portable ZIP)
 
 Windows builds are published as self-contained, portable bundles. The workflow zips the published output (`Password Phrase Producer.exe` plus all required dependencies) into a single archive named `Password-Phrase-Producer_<version>_windows_x64_portable.zip`. Users simply extract the ZIP and launch the executable—no installer or code-signing certificate is required.
+
+### Linux (portable TAR + Debian installer)
+
+Linux builds are published as self-contained, portable bundles and Debian installers. The workflow packages the published output into:
+
+- `Password-Phrase-Producer_<version>_linux_amd64_portable.tar.gz` for portable extraction.
+- `Password-Phrase-Producer_<version>_linux_amd64.deb` for Debian-based installers.
+
+The Debian package installs into `/opt/Password-Phrase-Producer` and places a launcher at `/usr/bin/password-phrase-producer`.
 
 ### Versioning
 

--- a/build/linux/package-linux.sh
+++ b/build/linux/package-linux.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 4 ]; then
+  echo "Usage: $0 <version> <publish_dir> <output_dir> <arch>" >&2
+  exit 1
+fi
+
+VERSION="$1"
+PUBLISH_DIR="$2"
+OUTPUT_DIR="$3"
+ARCH="$4"
+
+APP_NAME="Password Phrase Producer"
+APP_ID="password-phrase-producer"
+INSTALL_DIR="/opt/Password-Phrase-Producer"
+EXECUTABLE_NAME="${APP_NAME}"
+
+if [ ! -d "$PUBLISH_DIR" ]; then
+  echo "Publish directory not found: $PUBLISH_DIR" >&2
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+PORTABLE_STAGING="$(mktemp -d)"
+trap 'rm -rf "$PORTABLE_STAGING"' EXIT
+
+cp -R "$PUBLISH_DIR"/. "$PORTABLE_STAGING"/
+
+tarball_name="Password-Phrase-Producer_${VERSION}_linux_${ARCH}_portable.tar.gz"
+tar -czf "$OUTPUT_DIR/$tarball_name" -C "$PORTABLE_STAGING" .
+
+DEB_ROOT="$(mktemp -d)"
+mkdir -p "$DEB_ROOT/DEBIAN" \
+  "$DEB_ROOT$INSTALL_DIR" \
+  "$DEB_ROOT/usr/bin" \
+  "$DEB_ROOT/usr/share/applications" \
+  "$DEB_ROOT/usr/share/icons/hicolor/256x256/apps"
+
+cp -R "$PUBLISH_DIR"/. "$DEB_ROOT$INSTALL_DIR/"
+
+cat <<CONTROL > "$DEB_ROOT/DEBIAN/control"
+Package: $APP_ID
+Version: $VERSION
+Section: utils
+Priority: optional
+Architecture: $ARCH
+Maintainer: Password Phrase Producer Team
+Description: Password Phrase Producer
+ A cross-platform password and passphrase generator with vaults and TOTP.
+CONTROL
+
+cat <<'EOF_DESKTOP' > "$DEB_ROOT/usr/share/applications/${APP_ID}.desktop"
+[Desktop Entry]
+Name=Password Phrase Producer
+Comment=Password and passphrase generator with vaults and TOTP
+Exec=/usr/bin/password-phrase-producer
+Icon=password-phrase-producer
+Terminal=false
+Type=Application
+Categories=Utility;Security;
+EOF_DESKTOP
+
+cat <<'EOF_LAUNCHER' > "$DEB_ROOT/usr/bin/password-phrase-producer"
+#!/usr/bin/env bash
+exec "/opt/Password-Phrase-Producer/Password Phrase Producer" "$@"
+EOF_LAUNCHER
+
+chmod 0755 "$DEB_ROOT/usr/bin/password-phrase-producer"
+
+if [ -f "/workspace/Password-Phrase-Producer/Password Phrase Producer/Resources/AppIcon/iconkeyconfig.png" ]; then
+  cp "/workspace/Password-Phrase-Producer/Password Phrase Producer/Resources/AppIcon/iconkeyconfig.png" \
+    "$DEB_ROOT/usr/share/icons/hicolor/256x256/apps/password-phrase-producer.png"
+fi
+
+DEB_NAME="Password-Phrase-Producer_${VERSION}_linux_${ARCH}.deb"
+dpkg-deb --build "$DEB_ROOT" "$OUTPUT_DIR/$DEB_NAME" >/dev/null
+
+rm -rf "$DEB_ROOT"


### PR DESCRIPTION
### Motivation
- Provide Linux distribution options (portable and Debian installer) so the MAUI app can be used on Linux hosts. 
- Automate Linux builds and artifact publishing alongside existing Android and Windows outputs in CI. 
- Ensure the project can be published for a Linux runtime via the existing MAUI/.NET build pipeline.

### Description
- Add `build/linux/package-linux.sh`, a packaging script that creates a portable tarball and a Debian package which installs into `/opt/Password-Phrase-Producer` and installs a `/usr/bin/password-phrase-producer` launcher. 
- Add a `linux` job to `.github/workflows/build.yml` that runs on `ubuntu-latest`, publishes a `net9.0` linux-x64 self-contained build, runs the packager, and uploads `Password-Phrase-Producer_<version>_linux_amd64_portable.tar.gz` and `Password-Phrase-Producer_<version>_linux_amd64.deb`. 
- Update `Password Phrase Producer/PasswordPhraseProducer.csproj` to include `net9.0` in `TargetFrameworks` when building on Linux. 
- Update `README.md` to document the Linux publish command and the new Linux artifacts produced by CI.

### Testing
- No automated tests were executed as part of this change; the CI workflow changes will be validated when the GitHub Actions pipeline runs on the next push or workflow dispatch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976319b3570832a99b38556e76e393b)