### PR TITLE
Skip MAUI workload install on Linux builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -234,9 +234,6 @@ jobs:
         with:
           dotnet-version: 9.0.x
 
-      - name: Install MAUI workload
-        run: dotnet workload install maui --ignore-failed-sources
-
       - name: Compute version numbers
         id: compute_versions
         run: |


### PR DESCRIPTION
### Motivation
- The Linux CI job fails with `Workload ID maui isn't supported on this platform` when running `dotnet workload install maui`, so the workflow should avoid installing MAUI on Ubuntu runners.

### Description
- Remove the `dotnet workload install maui --ignore-failed-sources` step from the Linux job in `.github/workflows/build.yml` so the Linux job no longer attempts to install the MAUI workload.

### Testing
- No automated tests were executed for this change because it is a workflow-only modification and CI has not been re-run yet.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976451e46a0832ab652a9010c1ef603)