### PR TITLE
Add easy Windows installer ZIP for unsigned builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,22 +20,17 @@ jobs:
         shell: pwsh
         run: |
           $androidPath = [System.IO.Path]::Combine($env:RUNNER_TEMP, 'android_signing.keystore')
-          $windowsPath = [System.IO.Path]::Combine($env:RUNNER_TEMP, 'windows_signing_certificate.pfx')
 
           "ANDROID_KEYSTORE_PATH=$androidPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "WINDOWS_CERTIFICATE_PATH=$windowsPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Detect available signing assets
         shell: pwsh
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
-          WINDOWS_PFX_BASE64: ${{ secrets.WINDOWS_PFX_BASE64 }}
         run: |
           $hasAndroidKeystore = -not [string]::IsNullOrEmpty($env:ANDROID_KEYSTORE_BASE64)
-          $hasWindowsCertificate = -not [string]::IsNullOrEmpty($env:WINDOWS_PFX_BASE64)
 
           "HAS_ANDROID_KEYSTORE=$($hasAndroidKeystore.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "HAS_WINDOWS_CERTIFICATE=$($hasWindowsCertificate.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -134,14 +129,6 @@ jobs:
           name: android-apk
           path: '${{ env.RELEASE_DIRECTORY }}\\Password-Phrase-Producer_${{ env.APP_VERSION }}_android_signed.apk'
 
-      - name: Restore Windows signing certificate
-        if: ${{ env.HAS_WINDOWS_CERTIFICATE == 'true' }}
-        shell: pwsh
-        env:
-          WINDOWS_PFX_BASE64: ${{ secrets.WINDOWS_PFX_BASE64 }}
-        run: |
-          [IO.File]::WriteAllBytes($env:WINDOWS_CERTIFICATE_PATH, [Convert]::FromBase64String($env:WINDOWS_PFX_BASE64))
-
       - name: Publish Windows portable build
         shell: pwsh
         run: |
@@ -154,27 +141,6 @@ jobs:
             -p:PublishSingleFile=false `
             -p:ApplicationDisplayVersion=$env:APP_VERSION `
             -p:ApplicationVersion=$env:APP_BUILD
-
-      - name: Publish Windows installer (MSIX)
-        shell: pwsh
-        run: |
-          $signingArgs = ""
-          if (Test-Path $env:WINDOWS_CERTIFICATE_PATH) {
-            $signingArgs = "-p:PackageCertificateKeyFile=$env:WINDOWS_CERTIFICATE_PATH"
-          }
-          else {
-            Write-Host "::warning::Windows signing certificate not provided. MSIX will be unsigned and cannot be installed on Windows without a trusted certificate."
-            $signingArgs = "-p:AppxPackageSigningEnabled=false"
-          }
-
-          dotnet publish "./Password Phrase Producer/Password Phrase Producer.sln" `
-            -c Release `
-            -f net9.0-windows10.0.19041.0 `
-            -p:RuntimeIdentifier=win-x64 `
-            -p:WindowsPackageType=MSIX `
-            -p:ApplicationDisplayVersion=$env:APP_VERSION `
-            -p:ApplicationVersion=$env:APP_BUILD `
-            $signingArgs
 
       - name: Stage Windows artifact
         shell: pwsh
@@ -192,22 +158,26 @@ jobs:
 
           Compress-Archive -Path (Join-Path $publishDir '*') -DestinationPath $destination
 
-      - name: Stage Windows installer artifact
+      - name: Stage Windows easy installer
         shell: pwsh
         run: |
           $workspace = "${{ github.workspace }}"
-          $appPackagesDir = Join-Path $workspace "Password Phrase Producer\bin\Release\net9.0-windows10.0.19041.0\win-x64\AppPackages"
-          if (-not (Test-Path $appPackagesDir)) {
-            throw "Windows AppPackages directory not found."
-          }
+          $publishDir = Join-Path $workspace "Password Phrase Producer\bin\Release\net9.0-windows10.0.19041.0\win-x64\publish"
+          if (-not (Test-Path $publishDir)) { throw "Windows publish directory not found." }
 
-          $msix = Get-ChildItem -Path $appPackagesDir -Recurse -Filter "*.msix" | Select-Object -First 1
-          if (-not $msix) {
-            throw "MSIX package was not produced."
-          }
+          $installerRoot = Join-Path $env:RELEASE_DIRECTORY "windows-installer"
+          if (Test-Path $installerRoot) { Remove-Item -Path $installerRoot -Recurse -Force }
+          New-Item -ItemType Directory -Force -Path $installerRoot | Out-Null
+          New-Item -ItemType Directory -Force -Path (Join-Path $installerRoot "app") | Out-Null
 
-          $destination = Join-Path $env:RELEASE_DIRECTORY "Password-Phrase-Producer_$($env:APP_VERSION)_windows_x64_installer.msix"
-          Copy-Item -Path $msix.FullName -Destination $destination -Force
+          Copy-Item -Path (Join-Path $publishDir '*') -Destination (Join-Path $installerRoot "app") -Recurse -Force
+          Copy-Item -Path (Join-Path $workspace "Installer\Windows\Install.ps1") -Destination $installerRoot -Force
+          Copy-Item -Path (Join-Path $workspace "Installer\Windows\Uninstall.ps1") -Destination $installerRoot -Force
+          Copy-Item -Path (Join-Path $workspace "Installer\Windows\README.txt") -Destination $installerRoot -Force
+
+          $destination = Join-Path $env:RELEASE_DIRECTORY "Password-Phrase-Producer_$($env:APP_VERSION)_windows_x64_easy_installer.zip"
+          if (Test-Path $destination) { Remove-Item -Path $destination -Force }
+          Compress-Archive -Path (Join-Path $installerRoot '*') -DestinationPath $destination
 
       - name: Upload Windows artifact
         uses: actions/upload-artifact@v4
@@ -215,11 +185,11 @@ jobs:
           name: windows-portable
           path: '${{ env.RELEASE_DIRECTORY }}\\Password-Phrase-Producer_${{ env.APP_VERSION }}_windows_x64_portable.zip'
 
-      - name: Upload Windows installer artifact
+      - name: Upload Windows easy installer artifact
         uses: actions/upload-artifact@v4
         with:
-          name: windows-installer
-          path: '${{ env.RELEASE_DIRECTORY }}\\Password-Phrase-Producer_${{ env.APP_VERSION }}_windows_x64_installer.msix'
+          name: windows-easy-installer
+          path: '${{ env.RELEASE_DIRECTORY }}\\Password-Phrase-Producer_${{ env.APP_VERSION }}_windows_x64_easy_installer.zip'
 
   release:
     name: Release artifacts
@@ -248,7 +218,7 @@ jobs:
       - name: Download Windows installer artifact
         uses: actions/download-artifact@v4
         with:
-          name: windows-installer
+          name: windows-easy-installer
           path: release-assets
 
       - name: Generate SHA256 checksums
@@ -256,7 +226,7 @@ jobs:
         run: |
           sha256sum "Password-Phrase-Producer_${VERSION}_android_signed.apk" \
             "Password-Phrase-Producer_${VERSION}_windows_x64_portable.zip" \
-            "Password-Phrase-Producer_${VERSION}_windows_x64_installer.msix" \
+            "Password-Phrase-Producer_${VERSION}_windows_x64_easy_installer.zip" \
             > "Password-Phrase-Producer_${VERSION}_SHA256.txt"
 
       - name: Determine release metadata
@@ -283,5 +253,5 @@ jobs:
           files: |
             release-assets/Password-Phrase-Producer_${{ env.VERSION }}_android_signed.apk
             release-assets/Password-Phrase-Producer_${{ env.VERSION }}_windows_x64_portable.zip
-            release-assets/Password-Phrase-Producer_${{ env.VERSION }}_windows_x64_installer.msix
+            release-assets/Password-Phrase-Producer_${{ env.VERSION }}_windows_x64_easy_installer.zip
             release-assets/Password-Phrase-Producer_${{ env.VERSION }}_SHA256.txt

--- a/Installer/Windows/Install.ps1
+++ b/Installer/Windows/Install.ps1
@@ -1,0 +1,27 @@
+$ErrorActionPreference = 'Stop'
+
+$appName = 'Password Phrase Producer'
+$installDir = Join-Path $env:LOCALAPPDATA 'PasswordPhraseProducer'
+$startMenuDir = Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs'
+$shortcutPath = Join-Path $startMenuDir "$appName.lnk"
+$payloadDir = Join-Path $PSScriptRoot 'app'
+$exePath = Join-Path $installDir 'Password Phrase Producer.exe'
+
+if (-not (Test-Path $payloadDir)) {
+  throw "Install payload not found at $payloadDir. Please unzip the package before running the installer."
+}
+
+New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+Copy-Item -Path (Join-Path $payloadDir '*') -Destination $installDir -Recurse -Force
+
+$wshShell = New-Object -ComObject WScript.Shell
+$shortcut = $wshShell.CreateShortcut($shortcutPath)
+$shortcut.TargetPath = $exePath
+$shortcut.WorkingDirectory = $installDir
+$shortcut.IconLocation = $exePath
+$shortcut.Save()
+
+Write-Host "Installed $appName to $installDir"
+Write-Host "Start Menu shortcut created at $shortcutPath"
+Write-Host "Launching $appName..."
+Start-Process -FilePath $exePath

--- a/Installer/Windows/README.txt
+++ b/Installer/Windows/README.txt
@@ -1,0 +1,33 @@
+Password Phrase Producer - Windows Schnell-Installer
+=================================================
+
+Dieses Paket enthält eine portable Windows-Version plus einen einfachen Installations-Wrapper.
+Der Installer kopiert die App in dein Benutzerprofil und legt eine Startmenü-Verknüpfung an.
+
+Installation (empfohlen)
+------------------------
+1) ZIP entpacken.
+2) PowerShell öffnen.
+3) Im entpackten Ordner ausführen:
+
+   PowerShell -ExecutionPolicy Bypass -File .\Install.ps1
+
+Deinstallation
+--------------
+1) PowerShell öffnen.
+2) Im entpackten Ordner ausführen:
+
+   PowerShell -ExecutionPolicy Bypass -File .\Uninstall.ps1
+
+Hinweise
+--------
+- Die App wird unter %LOCALAPPDATA%\PasswordPhraseProducer installiert.
+- Für Updates zuerst deinstallieren oder den Installer erneut ausführen.
+
+English quick guide
+-------------------
+Install:
+  PowerShell -ExecutionPolicy Bypass -File .\Install.ps1
+
+Uninstall:
+  PowerShell -ExecutionPolicy Bypass -File .\Uninstall.ps1

--- a/Installer/Windows/Uninstall.ps1
+++ b/Installer/Windows/Uninstall.ps1
@@ -1,0 +1,18 @@
+$ErrorActionPreference = 'Stop'
+
+$appName = 'Password Phrase Producer'
+$installDir = Join-Path $env:LOCALAPPDATA 'PasswordPhraseProducer'
+$startMenuDir = Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs'
+$shortcutPath = Join-Path $startMenuDir "$appName.lnk"
+
+if (Test-Path $shortcutPath) {
+  Remove-Item -Path $shortcutPath -Force
+  Write-Host "Removed Start Menu shortcut."
+}
+
+if (Test-Path $installDir) {
+  Remove-Item -Path $installDir -Recurse -Force
+  Write-Host "Removed install directory at $installDir."
+} else {
+  Write-Host "Install directory not found at $installDir."
+}

--- a/README.md
+++ b/README.md
@@ -132,6 +132,22 @@ The workflow restores the keystore, signs the APK during `dotnet publish`, and i
 
 Windows builds are published as self-contained, portable bundles. The workflow zips the published output (`Password Phrase Producer.exe` plus all required dependencies) into a single archive named `Password-Phrase-Producer_<version>_windows_x64_portable.zip`. Users simply extract the ZIP and launch the executable—no installer or code-signing certificate is required.
 
+### Windows (easy installer ZIP)
+
+To avoid unsigned MSIX warnings, the workflow also publishes a simple installer ZIP: `Password-Phrase-Producer_<version>_windows_x64_easy_installer.zip`. The package includes the portable app plus PowerShell helper scripts that install the files into `%LOCALAPPDATA%\\PasswordPhraseProducer` and create a Start Menu shortcut.
+
+Installation:
+
+```powershell
+PowerShell -ExecutionPolicy Bypass -File .\Install.ps1
+```
+
+Uninstall:
+
+```powershell
+PowerShell -ExecutionPolicy Bypass -File .\Uninstall.ps1
+```
+
 ### Versioning
 
 Both Android and Windows builds derive their version numbers from the GitHub Actions run number (`1.0.<run_number>`), allowing each build to install as an update without removing the previous version.


### PR DESCRIPTION
### Motivation
- Windows MSIX installers produced by the workflow can be blocked by Windows when unsigned, so provide an alternative distribution that installs easily without code signing. 
- Provide a user-friendly, per-user installer that avoids requiring a signing certificate while still creating a Start Menu shortcut and supporting uninstall.

### Description
- Update the GitHub Actions workflow (`.github/workflows/build.yml`) to stop producing/expecting an MSIX and instead package a new `Password-Phrase-Producer_<version>_windows_x64_easy_installer.zip` built from the portable publish output. 
- Add a small installer package under `Installer/Windows` containing `Install.ps1`, `Uninstall.ps1`, and `README.txt` that copy the portable app into `%LOCALAPPDATA%\PasswordPhraseProducer`, create/remove a Start Menu shortcut, and include usage instructions. 
- Adjust artifact upload/download names, release checksum generation, and release file list to include the new easy installer ZIP and remove the unsigned MSIX artifact paths and related certificate environment handling. 
- Update `README.md` to document the new Windows easy installer ZIP and provide example `PowerShell -ExecutionPolicy Bypass -File .\Install.ps1`/`Uninstall.ps1` usage.

### Testing
- No automated tests were run because these are workflow-only and packaging/script additions; the changes will be validated when the GitHub Actions workflow runs and produces the new artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69810dacde10832aa75818c066816c78)